### PR TITLE
Add bc to the torizoncore-builder image

### DIFF
--- a/torizoncore-builder.Dockerfile
+++ b/torizoncore-builder.Dockerfile
@@ -60,7 +60,7 @@ FROM common-base AS tcbuilder-base
 RUN apt-get -q -y update && apt-get -q -y --no-install-recommends install \
     python3 python3-pip python3-setuptools python3-wheel python3-gi \
     file curl gzip xz-utils lz4 lzop zstd cpio jq acl libmpc-dev \
-    device-tree-compiler cpp  bzip2 flex bison kmod libgmp3-dev \
+    device-tree-compiler cpp  bzip2 flex bison kmod libgmp3-dev bc \
     && apt-get -q -y --no-install-recommends install python3-paramiko \
     python3-dnspython python3-ifaddr python3-git avahi-daemon && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add the bc tool (https://packages.debian.org/bullseye/bc) to the torizoncore-builder image to support the `prepare` target of the linux kernel source.