### PR TITLE
Improve failure output

### DIFF
--- a/tcbuilder/backend/kernel.py
+++ b/tcbuilder/backend/kernel.py
@@ -7,7 +7,6 @@ import os
 import re
 import shutil
 import logging
-import traceback
 import urllib.request
 
 from tcbuilder.backend import ostree
@@ -90,9 +89,8 @@ def build_module(src_dir, linux_src, src_mod_dir,
             CROSS_COMPILE={c_c} ARCH={arch} make -C {src_dir}""",
                        shell=True, stderr=subprocess.STDOUT, check=True)
         print()
-    except:
-        logging.error(traceback.format_exc())
-        raise TorizonCoreBuilderError("Error building kernel module(s)!")
+    except subprocess.CalledProcessError as exc:
+        raise TorizonCoreBuilderError(f"Error building kernel module(s): {exc}") from exc
     finally:
         set_output_ownership(src_dir)
 

--- a/torizoncore-builder.py
+++ b/torizoncore-builder.py
@@ -21,6 +21,7 @@ if sys.version_info < MIN_PYTHON:
 import argparse
 import logging
 import os
+import subprocess
 import traceback
 
 from tcbuilder.cli import (bundle, build, combine, deploy, dt, dto, images, isolate,
@@ -227,6 +228,14 @@ if __name__ == "__main__":
             logging.info(ex.det)  # more elaborative message
         logging.debug(traceback.format_exc())  # full traceback to be shown for debugging only
         sys.exit(-1)
+    except subprocess.CalledProcessError as ex:
+        logging.error(f"{ex}")
+        if b"\n" in ex.output:
+            logging.error("Output:\n  %s", "\n  ".join(ex.output.decode().split("\n")))
+        elif ex.output:
+            logging.error("Output: %s", ex.output.decode())
+        logging.debug(traceback.format_exc())  # full traceback to be shown for debugging only
+        sys.exit(4)
     except Exception as ex:
         logging.fatal(
             "An unexpected Exception occurred. Please provide the following stack trace to\n"


### PR DESCRIPTION
This makes two changes:
 1. Show output of failing commands (such as tar). This allows diagnosing problems such as invalid or missing tarballs or any other command failure. This fixes #10.
 2. Stop printing a useless backtrace on failing module builds.

See the commit message for details.