### PR TITLE
images: Support symlinks to Tezi tarballs

### DIFF
--- a/tcbuilder/backend/images.py
+++ b/tcbuilder/backend/images.py
@@ -268,8 +268,9 @@ def import_local_image(image_dir, tezi_dir, src_sysroot_dir, src_ostree_archive_
         log.info("Unpacking Toradex Easy Installer image.")
         if "Tezi" in image_dir:
             extract_dir = _make_tezi_extract_dir(tezi_dir)
+            real_image_dir = os.path.realpath(image_dir)
             final_dir = os.path.join(
-                extract_dir, os.path.splitext(os.path.basename(image_dir))[0])
+                extract_dir, os.path.splitext(os.path.basename(real_image_dir))[0])
         elif "teziimage" in image_dir:
             extract_dir = _make_tezi_extract_dir(tezi_dir)
             final_dir = extract_dir


### PR DESCRIPTION
The filename of the tarball is used to predict the name of the directory contained in the tarball. When a symlink is used with a different (simpler) name, the unpack would fail.

This resolves the symlink and looks at the filename of the actual tarball file.

This can be useful to allow pointing tcbuild.yaml to a symlink with a stable name, which points to a locally built tarball which changes name on every build. For example, see this patch that does this automatically for the yocto builds:

    https://community.toradex.com/t/patch-create-non-versioned-symlink-to-tezi-tarball/21265