### PR TITLE
Make subprocess invocations more robust - do not break on spaces and special characters

### DIFF
--- a/tcbuilder/backend/common.py
+++ b/tcbuilder/backend/common.py
@@ -163,6 +163,17 @@ def get_unpack_command(filename):
     return cmd
 
 
+def get_tar_compress_program_options(filename):
+    """ Get array with options to pass to tar to decompress given file format. """
+    cmd = get_unpack_command(filename)
+    # Tar adds a -d option to the command passed, but cat does not
+    # accept this, so omit the --use-compress-program entirely in this
+    # case.
+    if cmd == "cat":
+        return []
+    return ["--use-compress-program", cmd]
+
+
 def get_all_local_ip_addresses():
     """
     Get all local IP addresses on this host except the ones assigned to the

--- a/tcbuilder/backend/deploy.py
+++ b/tcbuilder/backend/deploy.py
@@ -126,10 +126,10 @@ def pack_rootfs_for_tezi(dst_sysroot_dir, output_dir):
 
     if image_filename.endswith(".xz"):
         uncompressed_file = image_filename.replace(".xz", "")
-        compress_cmd = f"xz -z {uncompressed_file}"
+        compress_cmd = ["xz", "-z", uncompressed_file]
     elif image_filename.endswith(".zst"):
         uncompressed_file = image_filename.replace(".zst", "")
-        compress_cmd = f"zstd --rm {uncompressed_file}"
+        compress_cmd = ["zstd", "--rm", uncompressed_file]
 
     # pylint: disable=line-too-long
     # This is a OSTree bare repository. Care must been taken to preserve all
@@ -137,13 +137,18 @@ def pack_rootfs_for_tezi(dst_sysroot_dir, output_dir):
     # here.
     # See: https://dev.gentoo.org/~mgorny/articles/portability-of-tar-features.html#extended-file-metadata
     # pylint: enable=line-too-long
-    tar_cmd = "tar --xattrs --xattrs-include='*' -cf {0} -S -C {1} -p .".format(
-        uncompressed_file, dst_sysroot_dir)
-    log.debug(f"Running tar command: {tar_cmd}")
-    subprocess.check_output(tar_cmd, shell=True, stderr=subprocess.STDOUT)
+    tar_cmd = [
+        "tar",
+        "--xattrs", "--xattrs-include=*",
+        "-cf", uncompressed_file,
+        "-S", "-C", dst_sysroot_dir,
+        "-p", "."
+    ]
+    log.debug(f"Running tar command: {shlex.join(tar_cmd)}")
+    subprocess.check_output(tar_cmd, stderr=subprocess.STDOUT)
 
-    log.debug(f"Running compress command: {compress_cmd}")
-    subprocess.check_output(compress_cmd, shell=True, stderr=subprocess.STDOUT)
+    log.debug(f"Running compress command: {shlex.join(compress_cmd)}")
+    subprocess.check_output(compress_cmd, stderr=subprocess.STDOUT)
 
     update_uncompressed_image_size(image_filename)
 

--- a/tcbuilder/backend/dt.py
+++ b/tcbuilder/backend/dt.py
@@ -5,6 +5,7 @@ Backend for the DT (device-tree) related operations.
 import logging
 import json
 import os
+import shlex
 import subprocess
 import sys
 import io
@@ -135,13 +136,14 @@ def build_dts(source_dts_path, include_dirs, target_dtb_path):
     opt_includes = []
     for include_dir in include_dirs:
         opt_includes.append("-I")
-        opt_includes.append(include_dir)
+        opt_includes.append(shlex.quote(include_dir))
     opt_includes = " ".join(opt_includes)
     try:
         subprocess.check_output(
             ("set -o pipefail && "
-             f"cpp -nostdinc -undef -x assembler-with-cpp {opt_includes} {source_dts_path} "
-             f"| dtc -I dts -O dtb -@ -o {target_dtb_path}"),
+             f"cpp -nostdinc -undef -x assembler-with-cpp {opt_includes} "
+             f"{shlex.quote(source_dts_path)} "
+             f"| dtc -I dts -O dtb -@ -o {shlex.quote(target_dtb_path)}"),
             shell=True, text=True, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as exc:
         log.error(exc.output.strip())

--- a/tcbuilder/backend/dt.py
+++ b/tcbuilder/backend/dt.py
@@ -112,16 +112,18 @@ def get_current_dtb_path(storage_dir):
             return (answer, True)
         # This is a device tree from the base image.
         answer = subprocess.check_output(
-            f"find {storage_dir}/sysroot/ostree/deploy -type f -name {dtb_basename} -print -quit",
-            shell=True, text=True).strip()
+            ["find", f"{storage_dir}/sysroot/ostree/deploy", "-type", "f",
+             "-name", dtb_basename, "-print", "-quit"],
+            text=True).strip()
         assert os.path.exists(answer), f"panic: missing device tree blob file for {dtb_basename}!"
         return (answer, True)
 
     # Cannot identify the device tree by peeking the boot loader configuration.
     # Hint by returning the first device tree blob found in the base image.
     answer = subprocess.check_output(
-        f"find {storage_dir}/sysroot/ostree/deploy -type f -name '*.dtb' -print -quit",
-        shell=True, text=True).strip()
+        ["find", f"{storage_dir}/sysroot/ostree/deploy", "-type", "f",
+         "-name", "*.dtb", "-print", "-quit"],
+        text=True).strip()
     assert os.path.exists(answer), "panic: missing device tree blobs in base image!"
     return (answer, False)
 

--- a/tcbuilder/backend/dto.py
+++ b/tcbuilder/backend/dto.py
@@ -92,9 +92,7 @@ def modify_dtb_by_overlays(source_dtb_path, source_dtob_paths, target_dtb_path):
         log.error(f"error: cannot apply device tree overlays {source_dtob_paths} "
                   f"against device tree {source_dtb_path}.")
         return False
-    # Run without shell=True (FIXME).
-    dtb_check = subprocess.check_output(
-        f"file {target_dtb_path}", shell=True, text=True).strip()
+    dtb_check = subprocess.check_output(["file", target_dtb_path], text=True).strip()
     log.info(dtb_check)
     if not "Device Tree Blob" in dtb_check:
         log.error(

--- a/tcbuilder/backend/kernel.py
+++ b/tcbuilder/backend/kernel.py
@@ -11,7 +11,7 @@ import logging
 import urllib.request
 
 from tcbuilder.backend import ostree
-from tcbuilder.backend.common import (get_unpack_command, progress,
+from tcbuilder.backend.common import (get_tar_compress_program_options, progress,
                                       set_output_ownership)
 from tcbuilder.errors import TorizonCoreBuilderError
 
@@ -181,8 +181,11 @@ def download_toolchain(toolchain, toolchain_path, version_gcc):
 
     log.info("Unpacking downloaded toolchain into storage")
     os.makedirs(toolchain_path, exist_ok=True)
-    tarcmd = "cat '{0}' | {1} | tar -xf - -C {2}".format(
-        tarball, get_unpack_command(tarball), toolchain_path)
-    subprocess.check_output(tarcmd, shell=True, stderr=subprocess.STDOUT)
+    tarcmd = [
+        "tar",
+        "-xf", tarball,
+        "-C", toolchain_path,
+    ] + get_tar_compress_program_options(tarball)
+    subprocess.check_output(tarcmd, stderr=subprocess.STDOUT)
     os.remove(tarball)
     log.info("Toolchain successfully unpacked.\n")

--- a/tcbuilder/backend/splash.py
+++ b/tcbuilder/backend/splash.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shutil
 import subprocess
+import shlex
 
 from gi.repository import Gio
 
@@ -33,8 +34,8 @@ def create_splash_initramfs(work_dir, image, src_ostree_archive_dir):
 
     # create splash image only initramfs
     create_initramfs_cmd = "echo {0} | cpio -H newc -D {1} -o | gzip > {2}".format(
-        os.path.join(splash_initramfs_dir, "watermark.png"), work_dir,
-        os.path.join(work_dir, splash_initramfs))
+        shlex.quote(os.path.join(splash_initramfs_dir, "watermark.png")),
+        shlex.quote(work_dir), shlex.quote(os.path.join(work_dir, splash_initramfs)))
     subprocess.check_output(create_initramfs_cmd, shell=True, stderr=subprocess.STDOUT)
 
     # get path of initramfs of current deployment inside sysroot

--- a/tcbuilder/cli/dt.py
+++ b/tcbuilder/cli/dt.py
@@ -4,6 +4,7 @@ CLI for the DT (device-tree) command.
 
 import logging
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -106,8 +107,9 @@ def dt_apply(dts_path, storage_dir, include_dirs=None):
         file.write(f"fdtfile={dtb_target_basename}\n")
     subprocess.check_call(
         "set -o pipefail && "
-        f"ostree --repo={storage_dir}/ostree-archive "
-        f"cat base /usr/lib/ostree-boot/uEnv.txt | sed /^fdtfile=/d >>{uenv_target_path}",
+        f"ostree --repo={shlex.quote(storage_dir)}/ostree-archive "
+        f"cat base /usr/lib/ostree-boot/uEnv.txt | sed /^fdtfile=/d "
+        f">>{shlex.quote(uenv_target_path)}",
         shell=True)
 
     # Deploy an empty overlays config file, so any overlays from the base image are disabled.

--- a/tcbuilder/cli/dt.py
+++ b/tcbuilder/cli/dt.py
@@ -91,7 +91,7 @@ def dt_apply(dts_path, storage_dir, include_dirs=None):
     # Deploy the device tree blob.
     dt_changes_dir = dt.get_dt_changes_dir(storage_dir)
     # Erase device tree and overlays of the current session.
-    subprocess.check_call(f"rm -rf {dt_changes_dir}", shell=True)
+    shutil.rmtree(dt_changes_dir, ignore_errors=True)
     dtb_target_dir = os.path.join(dt_changes_dir, dt.get_dtb_kernel_subdir(storage_dir))
     os.makedirs(dtb_target_dir, exist_ok=True)
     dtb_target_basename = os.path.splitext(os.path.basename(dts_path))[0] + ".dtb"

--- a/tcbuilder/cli/dto.py
+++ b/tcbuilder/cli/dto.py
@@ -316,7 +316,7 @@ def dto_remove_all(storage_dir):
     # Wipe out all overlay blobs as external changes.
     dtob_target_dir = os.path.join(
         dt_changes_dir, dt.get_dtb_kernel_subdir(storage_dir), "overlays")
-    subprocess.check_call(f"rm -rf {dtob_target_dir}", shell=True, text=True)
+    shutil.rmtree(dtob_target_dir, ignore_errors=True)
 
     # Sanity check.
     assert not dto.get_applied_overlays_base_names(storage_dir), \

--- a/tcbuilder/cli/dto.py
+++ b/tcbuilder/cli/dto.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -209,10 +210,10 @@ def do_dto_list(args):
             subprocess.check_output(
                 "set -o pipefail && "
                 "sed -r -e '/^[[:blank:]]*compatible *=/,/;/!d' "
-                f"-e '/;/q' {dtb_path} | tr -d '\n' | "
+                f"-e '/;/q' {shlex.quote(dtb_path)} | tr -d '\n' | "
                 "sed -r -e 's/.*\\<compatible *= *//' "
                 "-e 's/[[:blank:]]*//g' -e 's/\";.*/\"\\n/' -e 's/\",\"/\"\\n\"/g'"
-                f">{compat_regexps_tmp_path}",
+                f">{shlex.quote(compat_regexps_tmp_path)}",
                 shell=True, text=True, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as exc:
             log.error(exc.output.strip())
@@ -225,8 +226,8 @@ def do_dto_list(args):
             # About the 'sed' programs below:
             #  -e 's/$/\"/' appends '"' to each line
             subprocess.check_output(
-                f"set -o pipefail && fdtget {dtb_path} / compatible | tr ' ' '\n' "
-                f"| sed -e 's/$/\"/' >{compat_regexps_tmp_path}",
+                f"set -o pipefail && fdtget {shlex.quote(dtb_path)} / compatible | tr ' ' '\n' "
+                f"| sed -e 's/$/\"/' >{shlex.quote(compat_regexps_tmp_path)}",
                 shell=True, text=True, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as exc:
             log.error(exc.output.strip())
@@ -242,7 +243,8 @@ def do_dto_list(args):
     # files under a given subdirectory.
     try:
         compat_list = subprocess.check_output(
-            f"set -o pipefail && grep -rlHEf {compat_regexps_tmp_path} {overlays_subdir} "
+            f"set -o pipefail && grep -rlHEf {shlex.quote(compat_regexps_tmp_path)} "
+            f"{shlex.quote(overlays_subdir)} "
             "| sort -u | sed -e 's/^/- /'", shell=True, text=True).strip()
         log.info(f"Overlays compatible with device tree {os.path.basename(dtb_path)}:")
         log.info(f"{compat_list}")

--- a/tcbuilder/cli/kernel.py
+++ b/tcbuilder/cli/kernel.py
@@ -11,7 +11,7 @@ import subprocess
 
 from tcbuilder.errors import PathNotExistError
 from tcbuilder.errors import FileContentMissing
-from tcbuilder.backend.common import (get_unpack_command,
+from tcbuilder.backend.common import (get_tar_compress_program_options,
                                       images_unpack_executed)
 from tcbuilder.backend import kernel, dt, dto
 from tcbuilder.cli import dto as dto_cli
@@ -73,9 +73,12 @@ def kernel_build_module(source_dir, storage_dir, autoload):
          "-type", "f", "-name", "linux.tar.bz2", "-print", "-quit"], text=True)
     assert linux_src, "panic: missing Linux kernel source!"
     linux_src = linux_src.rstrip()
-    tarcmd = "cat '{0}' | {1} | tar -xf - -C {2}".format(
-        linux_src, get_unpack_command(linux_src), storage_dir)
-    subprocess.check_output(tarcmd, shell=True, stderr=subprocess.STDOUT)
+    tarcmd = [
+        "tar",
+        "-xf", linux_src,
+        "-C", storage_dir,
+    ] + get_tar_compress_program_options(linux_src)
+    subprocess.check_output(tarcmd, stderr=subprocess.STDOUT)
     extracted_src = os.path.join(storage_dir, "linux")
 
     # Build and install Kernel module


### PR DESCRIPTION
In a lot of places, subprocesses were spawned using a shell, passing a single string to be parsed by the shell. This is fragile, since the shell can interpret all kinds of special characters, including spaces. In practice, spaces or shell special characters in a lot of filenames would break the build.

This:
 1. Removes subprocess calls entirely where possible (using `shutil.rmtree` instead).
 2. Stops using the shell in commands that are just a single command and do not need a shell at all.
 3. Uses the `tar --use-decompress-program` to prevent the need for piping when calling tar, removing the need for a shell.
 4. Uses `shlex.quote()` to properly quote arguments in the remaining calls that need a pipeline and thus need a shell (or [more complex Python code](https://docs.python.org/3/library/subprocess.html#replacing-shell-pipeline)).

It might have made sense to add some unit or integration tests for this, but I could not quickly figure out how to run these tests at all. It seems there's only a gitlab CI config that runs them, but that looks quite complex to run manually, so I did not try.

I ran pylint on the code, but there are already a ton of pylint warnings in the `bullseye` branch. I made a diff and tried to fix every newly introduced warning, but I might have missed one ore more.