### PR TITLE
registryops: Fix --login-to arg behavior when using default registry

### DIFF
--- a/tcbuilder/backend/registryops.py
+++ b/tcbuilder/backend/registryops.py
@@ -339,7 +339,7 @@ class RegistryOperations:
                     self.login = (username, password)
             elif len(_login) == 3:
                 reg, username, password = _login
-                if reg == self.registry:
+                if (reg == self.registry) or (reg == DEFAULT_REGISTRY):
                     self.login = (username, password)
             else:
                 assert False, "Unhandled condition in _setup_credentials()"


### PR DESCRIPTION
Until now when using the --login-to arg to login to a private container registry, if the specified registry is equal to the default one (in this case registry-1.docker.io), then the login credentials end up not being applied, resulting in a 'not authorized' error message.

Related-to: TCB-477

Signed-off-by: Lucas Akira Morishita <lucas.morishita@toradex.com>