### PR TITLE
GitHub Actions: Fix lint-python exit code check

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -82,7 +82,7 @@ jobs:
                          --disable=missing-class-docstring
                          --disable=missing-function-docstring
                          --disable=fixme
-                         $(find tcbuilder/ -type f -name "*.py") *.py || exit_code=$?
+                         $(find tcbuilder/ -type f -name "*.py") *.py || echo "exit_code=$?" >> ${GITHUB_ENV}
       - name: Pylint result
         run: exit ${exit_code}
 

--- a/tcbuilder/backend/registryops.py
+++ b/tcbuilder/backend/registryops.py
@@ -339,7 +339,7 @@ class RegistryOperations:
                     self.login = (username, password)
             elif len(_login) == 3:
                 reg, username, password = _login
-                if (reg == self.registry) or (reg == DEFAULT_REGISTRY):
+                if reg in (self.registry, DEFAULT_REGISTRY):
                     self.login = (username, password)
             else:
                 assert False, "Unhandled condition in _setup_credentials()"


### PR DESCRIPTION
The pylint exit code wasn't being verified correctly, resulting in false positive outcomes.

Also, fix the 'consider-using-in' pylint warning in `backend/registryops.py`.

Related-to: TCB-478

Signed-off-by: Lucas Akira Morishita <lucas.morishita@toradex.com>