### PR TITLE
Add initial support for Torizon OS 7 images

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -110,19 +110,19 @@ jobs:
         run: echo "TCB_IMAGE_TAG=$(echo "$GITHUB_REF_NAME" | sed 's/\//-/g')" >> ${GITHUB_OUTPUT}
 
       - id: tc5_32bit
-        run: echo "TEST_32BIT_MACHINE=$(echo ${TEST_IMAGE_TC5_32BIT} | sed -E 's/^torizon-core-docker-(evaluation-)?(.*)-Tezi.*$/\2/')" >> ${GITHUB_OUTPUT}
+        run: echo "TEST_32BIT_MACHINE=$(echo ${TEST_IMAGE_TC5_32BIT} | sed -E 's/^torizon(-core)?-docker-(evaluation-)?(.*)-Tezi.*$/\3/')" >> ${GITHUB_OUTPUT}
       - id: tc5_64bit
-        run: echo "TEST_64BIT_MACHINE=$(echo ${TEST_IMAGE_TC5_64BIT} | sed -E 's/^torizon-core-docker-(evaluation-)?(.*)-Tezi.*$/\2/')" >> ${GITHUB_OUTPUT}
+        run: echo "TEST_64BIT_MACHINE=$(echo ${TEST_IMAGE_TC5_64BIT} | sed -E 's/^torizon(-core)?-docker-(evaluation-)?(.*)-Tezi.*$/\3/')" >> ${GITHUB_OUTPUT}
 
       - id: tc6_32bit
-        run: echo "TEST_32BIT_MACHINE=$(echo ${TEST_IMAGE_TC6_32BIT} | sed -E 's/^torizon-core-docker-(evaluation-)?(.*)-Tezi.*$/\2/')" >> ${GITHUB_OUTPUT}
+        run: echo "TEST_32BIT_MACHINE=$(echo ${TEST_IMAGE_TC6_32BIT} | sed -E 's/^torizon(-core)?-docker-(evaluation-)?(.*)-Tezi.*$/\3/')" >> ${GITHUB_OUTPUT}
       - id: tc6_64bit
-        run: echo "TEST_64BIT_MACHINE=$(echo ${TEST_IMAGE_TC6_64BIT} | sed -E 's/^torizon-core-docker-(evaluation-)?(.*)-Tezi.*$/\2/')" >> ${GITHUB_OUTPUT}
+        run: echo "TEST_64BIT_MACHINE=$(echo ${TEST_IMAGE_TC6_64BIT} | sed -E 's/^torizon(-core)?-docker-(evaluation-)?(.*)-Tezi.*$/\3/')" >> ${GITHUB_OUTPUT}
 
       - id: tc6_common_intel_machine
-        run: echo "TEST_INTEL_MACHINE=$(echo ${TEST_IMAGE_TC_COMMON_INTEL} | sed -E 's/^torizon-core-common-docker-dev-(evaluation-)?(.*)-.*$/\2/')" >> ${GITHUB_OUTPUT}
+        run: echo "TEST_INTEL_MACHINE=$(echo ${TEST_IMAGE_TC_COMMON_INTEL} | sed -E 's/^torizon(-core)?-common-docker-dev-(evaluation-)?(.*)-.*$/\3/')" >> ${GITHUB_OUTPUT}
       - id: tc6_common_raspi4_machine
-        run: echo "TEST_RASPI4_MACHINE=$(echo ${TEST_IMAGE_TC_COMMON_RASPI4} | sed -E 's/^torizon-core-common-docker-dev-(evaluation-)?(v.*-)?(.*-..).*$/\3/')" >> ${GITHUB_OUTPUT}
+        run: echo "TEST_RASPI4_MACHINE=$(echo ${TEST_IMAGE_TC_COMMON_RASPI4} | sed -E 's/^torizon(-core)?-common-docker-dev-(evaluation-)?(v.*-)?(.*-..).*$/\4/')" >> ${GITHUB_OUTPUT}
 
   amd64-build-test-torizoncore5:
     needs: [test-setup]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,12 +25,12 @@ variables:
   GITLAB_DOCKERREGISTRY_SUFFIX: ${CI_COMMIT_REF_SLUG}-${CI_PIPELINE_ID}
   GITLAB_DOCKERREGISTRY_SUFFIX_LATEST: ${CI_COMMIT_REF_SLUG}-latest
   # TC image default versions:
-  TEST_IMAGES_TC5_VERSION: "5.2.0"
-  TEST_IMAGE_TC5_32BIT: "torizon-core-docker-apalis-imx6-Tezi_5.2.0-devel-20210325+build.255.tar"
-  TEST_IMAGE_TC5_64BIT: "torizon-core-docker-verdin-imx8mm-Tezi_5.2.0-devel-20210325+build.255.tar"
   TEST_IMAGES_TC6_VERSION: "6.2.0"
   TEST_IMAGE_TC6_32BIT: "torizon-core-docker-colibri-imx7-emmc-Tezi_6.2.0-devel-20230324+build.220.tar"
   TEST_IMAGE_TC6_64BIT: "torizon-core-docker-apalis-imx8-Tezi_6.2.0-devel-20230324+build.220.tar"
+  TEST_IMAGES_TOS7_VERSION: "7.0.0"
+  TEST_IMAGE_TOS7_32BIT: "torizon-docker-apalis-imx6-Tezi_7.0.0-devel-20240830+build.40.tar"
+  TEST_IMAGE_TOS7_64BIT: "torizon-docker-apalis-imx8-Tezi_7.0.0-devel-20240830+build.40.tar"
   # Common Torizon .wic/.img images:
   TEST_IMAGES_TC_COMMON_VERSION: "6.6.0-common"
   TEST_IMAGE_TC_COMMON_INTEL: "torizon-core-common-docker-dev-intel-corei7-64-20240226043251.rootfs.wic"
@@ -203,20 +203,9 @@ build-arm64:
     # check results
     - (! grep "^not ok" workdir/reports/*)
 
-test-platform-tc5:
-  extends: .test-base
-  stage: test-platform
-  variables:
-    TEST_IMAGES_VERSION: ${TEST_IMAGES_TC5_VERSION}
-    TEST_IMAGE_32BIT: ${TEST_IMAGE_TC5_32BIT}
-    TEST_IMAGE_64BIT: ${TEST_IMAGE_TC5_64BIT}
-    TCB_TESTCASES_32BIT: "platform"
-    TCB_TESTCASES_64BIT: "torizoncore-builder"
-
 test-platform-tc6:
   extends: .test-base
   stage: test-platform
-  needs: ["test-platform-tc5"]
   variables:
     TEST_IMAGES_VERSION: ${TEST_IMAGES_TC6_VERSION}
     TEST_IMAGE_32BIT: ${TEST_IMAGE_TC6_32BIT}
@@ -224,12 +213,16 @@ test-platform-tc6:
     TCB_TESTCASES_32BIT: "torizoncore-builder"
     TCB_TESTCASES_64BIT: "platform"
 
-test-torizoncore5:
+test-platform-tos7:
   extends: .test-base
+  stage: test-platform
+  needs: ["test-platform-tc6"]
   variables:
-    TEST_IMAGES_VERSION: ${TEST_IMAGES_TC5_VERSION}
-    TEST_IMAGE_32BIT: ${TEST_IMAGE_TC5_32BIT}
-    TEST_IMAGE_64BIT: ${TEST_IMAGE_TC5_64BIT}
+    TEST_IMAGES_VERSION: ${TEST_IMAGES_TOS7_VERSION}
+    TEST_IMAGE_32BIT: ${TEST_IMAGE_TOS7_32BIT}
+    TEST_IMAGE_64BIT: ${TEST_IMAGE_TOS7_64BIT}
+    TCB_TESTCASES_32BIT: "platform"
+    TCB_TESTCASES_64BIT: "torizoncore-builder"
 
 test-torizoncore6:
   extends: .test-base
@@ -237,6 +230,13 @@ test-torizoncore6:
     TEST_IMAGES_VERSION: ${TEST_IMAGES_TC6_VERSION}
     TEST_IMAGE_32BIT: ${TEST_IMAGE_TC6_32BIT}
     TEST_IMAGE_64BIT: ${TEST_IMAGE_TC6_64BIT}
+
+test-torizonos7:
+  extends: .test-base
+  variables:
+    TEST_IMAGES_VERSION: ${TEST_IMAGES_TOS7_VERSION}
+    TEST_IMAGE_32BIT: ${TEST_IMAGE_TOS7_32BIT}
+    TEST_IMAGE_64BIT: ${TEST_IMAGE_TOS7_64BIT}
 
 test-torizoncore-common:
   extends: .test-base

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -191,12 +191,12 @@ build-arm64:
     - touch workdir/images/.images_downloaded
     - echo -e "\e[0Ksection_end:$(date +%s):download_tzimgs_section\r\e[0K"
     # run tests (32-bit device)
-    - TCB_MACHINE=$(echo "${TEST_IMAGE_32BIT}" | sed -E 's/^torizon-core-docker-(evaluation-)?(.*)-Tezi.*$/\2/')
+    - TCB_MACHINE=$(echo "${TEST_IMAGE_32BIT}" | sed -E 's/^torizon(-core)?-docker-(evaluation-)?(.*)-Tezi.*$/\3/')
     - echo -e "\e[0Ksection_start:$(date +%s):test_32bit_section\r\e[0KRun ${TCB_MACHINE} tests"
     - TCB_REPORT=1 TCB_UNDER_CI=1 TCB_MACHINE=${TCB_MACHINE} TCB_TESTCASE=${TCB_TESTCASES_32BIT} ${T} ./run.sh
     - echo -e "\e[0Ksection_end:$(date +%s):test_32bit_section\r\e[0K"
     # run test (64-bit device)
-    - TCB_MACHINE=$(echo "${TEST_IMAGE_64BIT}" | sed -E 's/^torizon-core-docker-(evaluation-)?(.*)-Tezi.*$/\2/')
+    - TCB_MACHINE=$(echo "${TEST_IMAGE_64BIT}" | sed -E 's/^torizon(-core)?-docker-(evaluation-)?(.*)-Tezi.*$/\3/')
     - echo -e "\e[0Ksection_start:$(date +%s):test_64bit_section\r\e[0KRun ${TCB_MACHINE} tests"
     - TCB_REPORT=1 TCB_UNDER_CI=1 TCB_MACHINE=${TCB_MACHINE} TCB_TESTCASE=${TCB_TESTCASES_64BIT} ${T} ./run.sh
     - echo -e "\e[0Ksection_end:$(date +%s):test_64bit_section\r\e[0K"
@@ -249,12 +249,12 @@ test-torizoncore-common:
     - touch workdir/images/.raw_images_downloaded
     - echo -e "\e[0Ksection_end:$(date +%s):download_rawimgs_section\r\e[0K"
     # run tests (Intel)
-    - TCB_MACHINE=$(echo "${TEST_IMAGE_TC_COMMON_INTEL}" | sed -E 's/^torizon-core-common-docker-dev-(evaluation-)?(.*)-.*$/\2/')
+    - TCB_MACHINE=$(echo "${TEST_IMAGE_TC_COMMON_INTEL}" | sed -E 's/^torizon(-core)?-common-docker-dev-(evaluation-)?(.*)-.*$/\3/')
     - echo -e "\e[0Ksection_start:$(date +%s):test_intel64_section\r\e[0KRun ${TCB_MACHINE} tests"
     - TCB_REPORT=1 TCB_UNDER_CI=1 TCB_MACHINE=${TCB_MACHINE} ${T} ./run.sh
     - echo -e "\e[0Ksection_end:$(date +%s):test_intel64_section\r\e[0K"
     # run tests (Raspberry Pi 4)
-    - TCB_MACHINE=$(echo "${TEST_IMAGE_TC_COMMON_RASPI4}" | sed -E 's/^torizon-core-common-docker-dev-(evaluation-)?(v.*-)?(.*-..).*$/\3/')
+    - TCB_MACHINE=$(echo "${TEST_IMAGE_TC_COMMON_RASPI4}" | sed -E 's/^torizon(-core)?-common-docker-dev-(evaluation-)?(v.*-)?(.*-..).*$/\4/')
     - echo -e "\e[0Ksection_start:$(date +%s):test_rasp4_64_section\r\e[0KRun ${TCB_MACHINE} tests"
     - TCB_REPORT=1 TCB_UNDER_CI=1 TCB_MACHINE=${TCB_MACHINE} ${T} ./run.sh
     - echo -e "\e[0Ksection_end:$(date +%s):test_rasp4_64_section\r\e[0K"
@@ -287,7 +287,7 @@ test-torizoncore:
     - mkdir -p workdir/images
     - "TEST_IMAGE_TORIZONCORE_URL=${INTERNAL_ARTIFACTORY_URL}/${ARTIFACTORY_SRC_REPO}\
         /${BUILD_MANIFEST_BRANCH}/${BUILD_PIPELINETYPE}/${MATRIX_BUILD_NUMBER}\
-        /${BUILD_MACHINE}/${BUILD_DISTRO}/torizon-core-docker/oedeploy\
+        /${BUILD_MACHINE}/${BUILD_DISTRO}/${BUILD_RECIPE}/oedeploy\
         /${BUILD_RECIPE}-${BUILD_MACHINE}-Tezi_${DISTRO_VERSION}.tar"
     - 'wget --progress=dot:giga ${TEST_IMAGE_TORIZONCORE_URL} -P workdir/images/'
     - touch workdir/images/.images_downloaded

--- a/tcbuilder/backend/build.py
+++ b/tcbuilder/backend/build.py
@@ -41,7 +41,8 @@ RELEASE_TO_BUILD_TYPE_MAP = {
 }
 MAJOR_TO_YOCTO_MAP = {
     5: "dunfell-5.x.y",
-    6: "kirkstone-6.x.y"
+    6: "kirkstone-6.x.y",
+    7: "scarthgap-7.x.y"
 }
 DEFAULT_IMAGE_VARIANT = "torizon-core-docker"
 

--- a/tcbuilder/backend/common.py
+++ b/tcbuilder/backend/common.py
@@ -462,15 +462,13 @@ def checkout_dt_git_repo(storage_dir, git_repo=None, git_branch=None):
     if git_branch is None:
         git_branch, image_major_version = get_branch_and_major_from_metadata(storage_dir)
 
-        if image_major_version == 6:
+        if image_major_version >= 6:
             raise TorizonCoreBuilderError(
-                "The TorizonCore Builder team is re-evaluating the device tree and device "
-                "tree overlays workflow, and the dt checkout command is currently not "
-                "supported on TorizonCore 6. Learn how to clone the device trees and "
-                "overlays repositories on "
+                "The dt checkout command is not supported on TorizonCore 6 and newer. "
+                "Learn how to clone the device trees and overlays repositories on "
                 "https://developer.toradex.com/torizon/os-customization/use-cases/"
-                "device-tree-overlays-on-torizon/"
-                "#clone-the-toradex-repository-and-check-the-available-device-trees-and-overlays")
+                "device-tree-overlays-on-torizon/#"
+                "clone-the-toradex-repositories-and-check-the-available-device-trees-and-overlays")
 
     if git_repo is None:
         repo_obj = git.Repo.clone_from("https://github.com/toradex/device-trees",

--- a/tcbuilder/backend/kernel.py
+++ b/tcbuilder/backend/kernel.py
@@ -87,8 +87,8 @@ def build_module(src_dir, linux_src, src_mod_dir, image_major_version,
         raise TorizonCoreBuilderError(
             "Could not determine kernel version of unpacked image. Aborting.")
 
-    # Makefile Hotfix needed to build modules for kernel v6.1+:
-    if (kversion['major'] == 6 and kversion['minor'] >= 1) or (kversion['major'] > 6):
+    # Makefile Hotfix needed to build modules for kernel v6.1:
+    if (kversion['major'] == 6 and kversion['minor'] == 1):
         _pattern = r"s/\$(build)=\. prepare/$(build)=./g"
         subprocess.check_output(
             ["sed", "-i", _pattern, f"{linux_src}/Makefile"],

--- a/tcbuilder/backend/kernel.py
+++ b/tcbuilder/backend/kernel.py
@@ -19,7 +19,8 @@ log = logging.getLogger("torizon." + __name__)
 
 IMAGE_MAJOR_TO_GCC_MAP = {
     5: "gcc-arm-9.2-2019.12",
-    6: "arm-gnu-toolchain-11.3.rel1"
+    6: "arm-gnu-toolchain-11.3.rel1",
+    7: "arm-gnu-toolchain-13.3.rel1"
 }
 
 

--- a/tests/integration/functions.sh
+++ b/tests/integration/functions.sh
@@ -183,11 +183,11 @@ decrypt-credentials-file() {
 }
 export -f decrypt-credentials-file
 
-is-major-version-6() {
+is-major-version-greater-than-5() {
     local MAJOR_VERSION=$(echo "${DEFAULT_TEZI_IMAGE}" | sed 's/.*Tezi_\([0-9]\).*/\1/')
-    [ "${MAJOR_VERSION}" -eq "6" ]
+    [ "${MAJOR_VERSION}" -gt "5" ]
 }
-export -f is-major-version-6
+export -f is-major-version-greater-than-5
 
 get-unique-version() {
     echo "${MACHINE}-${EPOCHSECONDS}"

--- a/tests/integration/testcases/dt.bats
+++ b/tests/integration/testcases/dt.bats
@@ -30,9 +30,9 @@ load 'lib/common.bash'
     torizoncore-builder-shell "rm -rf device-trees"
 
     run torizoncore-builder dt checkout
-    if is-major-version-6; then
+    if is-major-version-greater-than-5; then
         assert_failure
-        assert_output --partial "the dt checkout command is currently not supported on TorizonCore 6"
+        assert_output --partial "dt checkout command is not supported"
         return 0
     fi
     assert_success
@@ -54,9 +54,9 @@ load 'lib/common.bash'
     torizoncore-builder-shell "rm -rf device-trees"
 
     run torizoncore-builder dt checkout --update
-    if is-major-version-6; then
+    if is-major-version-greater-than-5; then
         assert_failure
-        assert_output --partial "the dt checkout command is currently not supported on TorizonCore 6"
+        assert_output --partial "dt checkout command is not supported"
         return 0
     fi
     assert_success
@@ -118,9 +118,9 @@ load 'lib/common.bash'
     torizoncore-builder-shell "rm -rf device-trees"
 
     run torizoncore-builder dt checkout --update
-    if is-major-version-6; then
+    if is-major-version-greater-than-5; then
         assert_failure
-        assert_output --partial "the dt checkout command is currently not supported on TorizonCore 6"
+        assert_output --partial "dt checkout command is not supported"
         return 0
     fi
     assert_success
@@ -149,9 +149,9 @@ load 'lib/common.bash'
     torizoncore-builder-shell "rm -rf device-trees"
 
     run torizoncore-builder dt checkout --update
-    if is-major-version-6; then
+    if is-major-version-greater-than-5; then
         assert_failure
-        assert_output --partial "the dt checkout command is currently not supported on TorizonCore 6"
+        assert_output --partial "dt checkout command is not supported"
         return 0
     fi
     assert_success

--- a/tests/integration/testcases/dto.bats
+++ b/tests/integration/testcases/dto.bats
@@ -19,9 +19,9 @@ bats_load_library 'bats/bats-file/load.bash'
     rm -rf device-trees
 
     run torizoncore-builder dt checkout --update
-    if is-major-version-6; then
+    if is-major-version-greater-than-5; then
         assert_failure
-        skip "device-trees not available on TC6"
+        skip "dt checkout not available on TC6+"
     fi
     assert_success
 
@@ -38,9 +38,9 @@ bats_load_library 'bats/bats-file/load.bash'
     rm -rf device-trees
 
     run torizoncore-builder dt checkout --update
-    if is-major-version-6; then
+    if is-major-version-greater-than-5; then
         assert_failure
-        skip "device-trees not available on TC6"
+        skip "dt checkout not available on TC6+"
     fi
     assert_success
 


### PR DESCRIPTION
This includes:

- TCB recognizing major version 7 images;
- When building kernel modules for Torizon OS 7 images: Using an updated ARM GNU Toolchain version aligned to the GCC version used in Yocto scarthgap;
- Restricting 'dt checkout' to be incompatible with major version 6 images and newer;
- Adapting GitLab CI tests to support Torizon OS 7 images;
- Removing TorizonCore 5 tests from the GitLab pipeline.

As of writing this there are only nightly Torizon OS 7 images available on our Artifactory server, which are deleted after a few days. Our GitHub Actions pipeline currently downloads fixed image versions from Artifactory for the tests, so right now we can't use Torizon OS 7 images there.

Related-to: TCB-462, TCB-464

Signed-off-by: Lucas Akira Morishita <lucas.morishita@toradex.com>