### PR TITLE
bundle: Remove dependency on compose V1 library

### DIFF
--- a/requirements_debian.txt
+++ b/requirements_debian.txt
@@ -1,6 +1,6 @@
 docker==7.1.0
 requests==2.32.2
-docker-compose==1.29.2
+jsonschema>=3.2.0
 python-dateutil==2.8.2
 pyyaml==5.3.1
 requests-oauthlib==1.3.0

--- a/tcbuilder/backend/build.py
+++ b/tcbuilder/backend/build.py
@@ -246,7 +246,7 @@ def parse_config_file(config_path, schema_path=DEFAULT_SCHEMA_FILE, substs=None)
     # Load the YAML configuration file (user-supplied):
     with open(config_path) as file:
         try:
-            config = yaml.load(file, Loader=yaml.FullLoader)
+            config = yaml.safe_load(file)
 
         except yaml.YAMLError as ex:
             error_exc = ParseError(getattr(ex, "problem", "parsing error"))
@@ -263,7 +263,7 @@ def parse_config_file(config_path, schema_path=DEFAULT_SCHEMA_FILE, substs=None)
     # Load the YAML schema file (supplied with the tool):
     schemapath = os.path.join(os.path.dirname(__file__), schema_path)
     with open(schemapath) as file:
-        schema = yaml.load(file, Loader=yaml.FullLoader)
+        schema = yaml.safe_load(file)
 
     # Do the actual validation of configuration against the schema.
     validator = jsonschema.Draft7Validator(schema)

--- a/tcbuilder/backend/bundle.py
+++ b/tcbuilder/backend/bundle.py
@@ -532,7 +532,7 @@ def download_containers_by_compose_file(
             show_progress = False
 
     with open(compose_path, encoding='utf-8') as file:
-        compose_file_data = yaml.load(file, Loader=yaml.FullLoader)
+        compose_file_data = yaml.safe_load(file)
 
     # Basic compose file validation e.g. if it has 'services' section, images are specified, etc.
     validate_compose_file(compose_file_data)
@@ -580,7 +580,7 @@ def download_containers_by_compose_file(
 
         log.info("Saving Docker Compose file")
         with open(os.path.join(manager.output_dir, "docker-compose.yml"), "w") as file:
-            file.write(yaml.dump(compose_file_data, Dumper=yaml.Dumper))
+            file.write(yaml.safe_dump(compose_file_data))
 
         log.info("Exporting storage")
         manager.save_tar(output_filename)

--- a/tcbuilder/backend/common.py
+++ b/tcbuilder/backend/common.py
@@ -785,3 +785,20 @@ def check_licence_acceptance(image_dir, tezi_props):
         raise LicenceAcceptanceError(
             f"Error: To enable the auto-installation feature you must accept the licence "
             f"\"{licence_file}\".")
+
+
+def validate_compose_file(compose_file_data):
+    """
+    Validate the Docker compose file and throw an exception if the file is invalid.
+
+    :param compose_file_data: The Docker compose file data as a dictionary
+    """
+
+    if not (isinstance(compose_file_data, dict) and
+            isinstance(compose_file_data.get('services'), dict)):
+        raise InvalidDataError("Error: No 'services' section in compose file.")
+
+    for svc_name, svc_spec in compose_file_data['services'].items():
+        image_name = svc_spec.get('image')
+        if not image_name:
+            raise InvalidDataError(f"Error: No image specified for service '{svc_name}'.")

--- a/tcbuilder/backend/images.py
+++ b/tcbuilder/backend/images.py
@@ -39,7 +39,8 @@ PROV_DATA_FILENAME = "provisioning-data.tar.gz"
 
 VERSION_TO_YOCTO_MAP = {
     "dunfell": "dunfell-5.x.y",
-    "kirkstone": "kirkstone-6.x.y"
+    "kirkstone": "kirkstone-6.x.y",
+    "scarthgap": "scarthgap-7.x.y"
 }
 
 LAST_DEPRECATED_IMAGE_MAJOR = 5
@@ -179,6 +180,11 @@ def download_tezi(r_host, r_username, r_password, r_port,
 
     for key in VERSION_TO_YOCTO_MAP:
         if key in version:
+            if key in ("dunfell", "kirkstone"):
+                yocto_img_name = "torizon-core"
+            else:
+                yocto_img_name = "torizon"
+
             yocto = VERSION_TO_YOCTO_MAP[key]
             break
     else:
@@ -212,10 +218,10 @@ def download_tezi(r_host, r_username, r_password, r_port,
     module_name = hostname[:-10]
 
     url = "https://artifacts.toradex.com/artifactory/{0}/{1}/{2}/{3}/{4}/" \
-          "torizon{5}{6}/torizon-core-{7}/oedeploy/" \
-          "torizon-core-{7}{6}-{4}-Tezi_{8}{9}{10}+build.{3}.tar".format(
+          "torizon{5}{6}/{7}-{8}/oedeploy/" \
+          "{7}-{8}{6}-{4}-Tezi_{9}{10}{11}+build.{3}.tar".format(
               prod, yocto, build_type, build_number, module_name, kernel_type,
-              rt_flag, container, sem_ver, devel, date)
+              rt_flag, yocto_img_name, container, sem_ver, devel, date)
 
     # Download and unpack tezi image
     log.info(f"Downloading image from: {url}\n")

--- a/tcbuilder/backend/platform.py
+++ b/tcbuilder/backend/platform.py
@@ -1450,7 +1450,7 @@ def canonicalize_compose_file(compose_file, force=False):
             "Please use the '--force' parameter if you want it to be overwritten.")
 
     set_images_hash(compose_file_data)
-    canonical_data = yaml.dump(compose_file_data, Dumper=yaml.Dumper)
+    canonical_data = yaml.safe_dump(compose_file_data)
 
     with open(canonical_compose_file_lock, 'w', encoding='utf-8') as compose_lock_fd:
         compose_lock_fd.write(canonical_data)
@@ -1480,7 +1480,7 @@ def is_canonicalized(compose_file, ret_parsed=False):
         return all(_uses_digest)
 
     with open(compose_file, encoding='utf-8') as file:
-        compose_file_data = yaml.load(file, Loader=yaml.FullLoader)
+        compose_file_data = yaml.safe_load(file)
         file.seek(0)
         original_yaml_string = file.read()
 
@@ -1488,8 +1488,7 @@ def is_canonicalized(compose_file, ret_parsed=False):
     # Checking for correct file structure and adherence to image references with digests
     validate_compose_file(compose_file_data)
     if images_with_digest(compose_file_data):
-        is_canonical = original_yaml_string == yaml.dump(
-            compose_file_data, Dumper=yaml.Dumper)
+        is_canonical = original_yaml_string == yaml.safe_dump(compose_file_data)
 
     return (is_canonical, compose_file_data) if ret_parsed else is_canonical
 

--- a/tcbuilder/backend/platform.py
+++ b/tcbuilder/backend/platform.py
@@ -29,7 +29,8 @@ from tcbuilder.backend import ostree, sotaops
 from tcbuilder.backend.bundle import \
     (DindManager, login_to_registries, show_pull_progress_xterm)
 from tcbuilder.backend.common import \
-    (get_host_workdir, get_own_network, set_output_ownership, run_with_loading_animation)
+    (get_host_workdir, get_own_network, set_output_ownership, run_with_loading_animation,
+     validate_compose_file)
 from tcbuilder.backend.registryops import \
     (RegistryOperations, SHA256_PREFIX, parse_image_name, platform_matches)
 
@@ -1392,23 +1393,6 @@ def upload_static_delta_superblock(delta_dir, ostree_url, delta_id, headers):
         else:
             log.error(post.text)
             raise TorizonCoreBuilderError("Error uploading static delta superblock")
-
-
-def validate_compose_file(compose_file_data):
-    """
-    Validate the Docker compose file and throw an exception if the file is invalid.
-
-    :param compose_file_data: The Docker compose file data.
-    """
-
-    if not (isinstance(compose_file_data, dict) and
-            isinstance(compose_file_data.get('services'), dict)):
-        raise InvalidDataError("Error: No 'services' section in compose file.")
-
-    for svc_name, svc_spec in compose_file_data['services'].items():
-        image_name = svc_spec.get('image')
-        if not image_name:
-            raise InvalidDataError(f"Error: No image specified for service '{svc_name}'.")
 
 
 def set_images_hash(compose_file_data):

--- a/tcbuilder/backend/tcbuild.schema.yaml
+++ b/tcbuilder/backend/tcbuild.schema.yaml
@@ -365,6 +365,9 @@ properties:
                         type: string
                         description: "CA certificate path of alternative container registry"
                         tdxMeta: "file;cer,crt"
+                      keep-double-dollar-sign:
+                        type: boolean
+                        description: "Keep double dollar sign instead of replacing it with a single one when parsing string values of the compose file"
                     required: [compose-file]
                     additionalProperties: false
                   - properties:

--- a/tcbuilder/cli/build.py
+++ b/tcbuilder/cli/build.py
@@ -437,6 +437,7 @@ def handle_bundle_output(image_dir, storage_dir, bundle_props, tezi_props):
                 "host_workdir": common.get_host_workdir()[0],
                 "use_host_docker": False,
                 "output_filename": common.DOCKER_BUNDLE_FILENAME,
+                "keep_double_dollar_sign": bundle_props.get("keep-double-dollar-sign", False),
                 "platform": platform
             }
             download_containers_by_compose_file(**download_params)

--- a/tcbuilder/cli/bundle.py
+++ b/tcbuilder/cli/bundle.py
@@ -18,8 +18,8 @@ log = logging.getLogger("torizon." + __name__)
 
 
 # pylint: disable=too-many-arguments
-def bundle(bundle_dir, compose_file, force=False, platform=None,
-           dind_params=None):
+def bundle(bundle_dir, compose_file, force=False, keep_double_dollar_sign=False,
+           platform=None, dind_params=None):
     """Main handler of the bundle command (CLI layer)
 
     :param bundle_dir: Name of bundle directory (that will be created in the
@@ -27,6 +27,9 @@ def bundle(bundle_dir, compose_file, force=False, platform=None,
     :param compose_file: Relative path to the input compose file.
     :param force: Whether or not to overwrite the (output) bundle directory
                   if it already exists.
+    :param keep_double_dollar_sign: Keep '$$' instead of replacing it with '$'
+                                    when parsing string values (not keys) of
+                                    input compose file.
     :param platform: Default platform to use when fetching multi-platform
                      container images.
     :param dind_params: Extra parameters to pass to Docker-in-Docker (list).
@@ -49,6 +52,7 @@ def bundle(bundle_dir, compose_file, force=False, platform=None,
     bundle_be.download_containers_by_compose_file(
         bundle_dir, compose_file, host_workdir,
         output_filename=common.DOCKER_BUNDLE_FILENAME,
+        keep_double_dollar_sign=keep_double_dollar_sign,
         platform=platform,
         dind_params=dind_params)
 
@@ -97,6 +101,7 @@ def do_bundle(args):
     bundle(bundle_dir=args.bundle_directory,
            compose_file=args.compose_file,
            force=args.force,
+           keep_double_dollar_sign=args.keep_double_dollar_sign,
            platform=args.platform,
            dind_params=args.dind_params)
 
@@ -150,6 +155,10 @@ def init_parser(subparsers):
         help=("Default platform for fetching container images when multi-"
               "platform images are specified in the compose file (e.g. "
               "linux/arm/v7 or linux/arm64)."))
+    subparser.add_argument(
+        "--keep-double-dollar-sign", dest="keep_double_dollar_sign",
+        default=False, action="store_true",
+        help="Don't replace '$$' with '$' when parsing string values of the input compose file.")
     common.add_common_registry_arguments(subparser)
     add_dind_param_arguments(subparser)
 

--- a/tcbuilder/cli/tcbuild.template.yaml
+++ b/tcbuilder/cli/tcbuild.template.yaml
@@ -107,13 +107,17 @@ output:
     # bundle:
       # >> Choose one of the options:
       # >> (1) Specify a docker-compose file whose referenced images will be downloaded.
-      # >>     Properties platform, username, password, registry and ca-certificate are optional.
+      # >>     Properties platform, username, password, registry, ca-certificate and
+      # >>     keep-double-dollar-sign are optional.
+      # >>     When using a docker-compose file all config values with '$$' will be replaced
+      # >>     by '$', unless keep-double-dollar-sign is set to true.
       # compose-file: files/docker-compose.yml
       # platform: linux/arm/v7
       # username: "${USERNAME}"
       # password: "${PASSWORD}"
       # registry: hub.docker.com
       # ca-certificate: cacert.pem
+      # keep-double-dollar-sign: false
       # >> (2) Specify a local directory containing the bundled images (previously
       # >>     obtained by 'torizoncore-builder bundle' command).
       # dir: bundle/

--- a/tests/integration/samples/compose/hello/docker-compose-env-double-dollar-test.yml
+++ b/tests/integration/samples/compose/hello/docker-compose-env-double-dollar-test.yml
@@ -1,0 +1,15 @@
+services:
+  hello-world:
+    image: hello-world:latest
+    environment:
+      $$var: $$HOME
+      HOME1: $$HOME
+      HOME2: "$$HOME"
+      HOME3: '$$HOME'
+      HOME4:
+        >-
+          $$HOME
+      HOME5: |
+          $$HOME
+      HOME6: |
+          \$$HOME

--- a/tests/integration/testcases/bundle.bats
+++ b/tests/integration/testcases/bundle.bats
@@ -89,7 +89,7 @@ load 'lib/common.bash'
     rm -f "$COMPOSE"
     run torizoncore-builder bundle "$COMPOSE"
     assert_failure
-    assert_output --partial "Could not load the Docker compose file '$COMPOSE'"
+    assert_output --partial "File does not exist: $COMPOSE"
 }
 
 @test "bundle: check --platform parameter" {


### PR DESCRIPTION
I did some tests by running 'bundle' with compose files with V2 specific features like `cgroup` and `create_host_path`, and things are working as expected.

Related-to: TCB-458

Signed-off-by: Lucas Akira Morishita <lucas.morishita@toradex.com>