### PR TITLE
tests/integration: Fix raw image test when running on a busybox host

### DIFF
--- a/tests/integration/testcases/wic/combine.bats
+++ b/tests/integration/testcases/wic/combine.bats
@@ -21,7 +21,7 @@ load '../lib/common.bash'
 
     local OUTPUT_IMAGE="$(echo $DEFAULT_WIC_IMAGE | sed 's/\.wic$//g')_bundled.wic"
 
-    truncate -s +1K invalid_image.wic
+    truncate -s 1K invalid_image.wic
 
     run torizoncore-builder combine invalid_image.wic $OUTPUT_IMAGE
     assert_failure


### PR DESCRIPTION
One raw image test for the combine command uses the 'truncate' command to create a temporary file. The current command syntax is only valid for the GNU coreutils version of truncate, and is invalid for the busybox one.

As our GitLab test pipeline runs in container 'docker:latest', which is an environment with busybox, this particular test started failing in it due to the invalid syntax.

This commit changes the syntax so that it works for both the GNU and the busybox version of truncate.

Signed-off-by: Lucas Akira Morishita <lucas.morishita@toradex.com>