### PR TITLE
backend/bundle: Bump DIND container image version to 25.0.3

### DIFF
--- a/tcbuilder/backend/bundle.py
+++ b/tcbuilder/backend/bundle.py
@@ -128,7 +128,7 @@ class DindManager(DockerManager):
     Installer tool.
     """
 
-    DIND_CONTAINER_IMAGE = "docker:19.03.8-dind"
+    DIND_CONTAINER_IMAGE = "docker:25.0.3-dind"
     DIND_VOLUME_NAME = "dind-volume"
     DIND_CONTAINER_NAME = "tcb-fetch-dind"
     TAR_CONTAINER_NAME = "tcb-build-tar"


### PR DESCRIPTION
Bump Docker-in-Docker container image used in the bundle command to match the Docker version included on Torizon OS 7 images.

Signed-off-by: Lucas Akira Morishita <lucas.morishita@toradex.com>

Related-to: TCB-486