### PR TITLE
tests/integration: Implementation of AVAL on TCB integration tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,6 @@
+include:
+  - "/tests/integration/aval/aval-tests.yml"
+
 # TODO: GitLab's documentation recommends specifying a version:
 #       See https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-docker-in-docker
 #       Also in the services attribute.

--- a/tests/integration/README
+++ b/tests/integration/README
@@ -117,30 +117,30 @@ The command below will execute all test cases, including those that
 requires device access (the image used in the tests will be
 automatically selected based on the device):
 
-$ TCB_DEVICE=192.168.1.210 ./run.sh
+$ TCB_DEVICE=192.168.1.210 TCB_MACHINE=apalis-imx6 DEVICE_PASSWORD=<password> ./run.sh
 
 The command below will execute the test cases defined in
 testcases/dto.bats, using an Apalis iMX6 image, and a test report
 will be available in workdir/reports/:
 
-$ TCB_REPORT=1 TCB_TESTCASE=dto ./run.sh
+$ TCB_REPORT=1 TCB_TESTCASE=dto TCB_MACHINE=apalis-imx6 ./run.sh
 
 The command below will execute the test cases defined in both
 testcases/dt.bats and testcases/dto.bats:
 
-$ TCB_TESTCASE="dt dto" ./run.sh
+$ TCB_TESTCASE="dt dto" TCB_MACHINE=apalis-imx6 ./run.sh
 
 The command below will execute all test cases, including those that
 require device access, using a local torizoncore-builder container
 tagged with 'v1':
 
-$ TCB_CUSTOM_IMAGE=torizoncore-builder:v1 TCB_DEVICE=192.168.1.210 ./run.sh
+$ TCB_CUSTOM_IMAGE=torizoncore-builder:v1 TCB_DEVICE=192.168.1.210 TCB_MACHINE=apalis-imx6 DEVICE_PASSWORD=<password> ./run.sh
 
 The command below will execute all the tests:
-$ TCB_TAGS="all" ./run.sh
+$ TCB_TAGS="all" TCB_MACHINE=apalis-imx6 ./run.sh
 
 The command below will execute untagged tests:
-$ TCB_TAGS="" ./run.sh
+$ TCB_TAGS="" TCB_MACHINE=apalis-imx6 ./run.sh
 
 The command below will execute tests tagged as 'requires-device':
-$ TCB_TAGS="requires-device" TCB_DEVICE=192.168.1.210 ./run.sh
+$ TCB_TAGS="requires-device" TCB_DEVICE=192.168.1.210 TCB_MACHINE=apalis-imx6 DEVICE_PASSWORD=<password> ./run.sh

--- a/tests/integration/aval/aval-docker.Dockerfile
+++ b/tests/integration/aval/aval-docker.Dockerfile
@@ -1,0 +1,33 @@
+# Uses the AVAL container as a base, which is built in its own repo. From there, it adds
+# the docker that is necessary to run the TCB container in the tests, in addition to the
+# "sshpass" and "bats" dependencies that are also used in the tests.
+FROM gitlab.int.toradex.com:4567/rd/torizon-core-containers/aval/aval:main
+
+RUN apt-get update && \
+    apt-get install -y \
+        ca-certificates \
+        curl && \
+    install -m 0755 -d /etc/apt/keyrings
+
+# Add Docker's official GPG key
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
+    chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add docker GPG keys to APT source
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+    https://download.docker.com/linux/debian $(. /etc/os-release && echo $VERSION_CODENAME) stable" | \
+    tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# Install docker using apt
+RUN apt-get update && \
+    apt-get install -y \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        docker-buildx-plugin \
+        docker-compose-plugin
+
+# Install dependencies to run TCB integration tests
+RUN apt-get update && apt-get install -y \
+        sshpass bats git zstd wget bash \
+        tar openssl zip bc avahi-utils

--- a/tests/integration/aval/aval-tests.yml
+++ b/tests/integration/aval/aval-tests.yml
@@ -1,0 +1,125 @@
+# Build the AVAL container with docker that will run the tests on the host PC
+build-aval-docker:
+  image: docker:dind
+  stage: build
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+  variables:
+    IMAGE_NAME_AVAL: aval-docker
+    DOCKERFILE_NAME: tests/integration/aval/aval-docker.Dockerfile
+  before_script:
+    - docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
+    - docker login -u "${CI_DOCKER_HUB_PULL_USER}" -p "${CI_DOCKER_HUB_PULL_PASSWORD}"
+  script:
+    - ${B} docker build -f "${DOCKERFILE_NAME}" -t "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_AVAL}:main" .
+    - ${B} docker push "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_AVAL}:main"
+
+.aval-template:
+  stage: test
+  needs:
+    - build-aval-docker
+    - build-amd64
+  variables:
+    IMAGE_NAME: torizoncore-builder-amd64
+    IMAGE_NAME_AVAL: aval-docker
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+  image: ${CI_REGISTRY_IMAGE}/${IMAGE_NAME_AVAL}:main
+  script:
+    # pull latest build of TorizonCore Builder
+    - echo -e "\e[0Ksection_start:$(date +%s):pull_eval_tcb_section\r\e[0KPull TorizonCore Builder to be evaluated"
+    - ${T} docker login -u "${CI_DOCKER_HUB_PULL_USER}" -p "${CI_DOCKER_HUB_PULL_PASSWORD}"
+    - ${T} docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
+    - ${T} docker pull "${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
+    - echo -e "\e[0Ksection_end:$(date +%s):pull_eval_tcb_section\r\e[0K"
+    - cd tests/integration && python /aval/main.py --delegation-config $DELEGATION_CONFIG
+      --run-before-on-host "./run_all.sh --device --machine $TCB_MACHINE --report --tcb-tags requires-device
+      --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
+    - (! grep "^not ok" workdir/reports/*)
+
+# AVAL_TEST_ALL can be defined as "true" on a Gitlab schedule to run tests on all devices
+aval-apalis-imx6q-scarthgap-release:
+  extends: .aval-template
+  variables:
+    SOC_UDT: "apalis-imx6q"
+    TARGET_BUILD_TYPE: "release"
+    DELEGATION_CONFIG: "./aval/delegation_config_scarthgap.toml"
+    TCB_MACHINE: "apalis-imx6"
+
+aval-apalis-imx8qm-scarthgap-release:
+  extends: .aval-template
+  rules:
+    - if: '$AVAL_TEST_ALL =~ /^true$/i'
+  variables:
+    SOC_UDT: "apalis-imx8qm"
+    TARGET_BUILD_TYPE: "release"
+    DELEGATION_CONFIG: "./aval/delegation_config_scarthgap.toml"
+    TCB_MACHINE: "apalis-imx8"
+
+aval-colibri-imx6dl-scarthgap-release:
+  extends: .aval-template
+  rules:
+    - if: '$AVAL_TEST_ALL =~ /^true$/i'
+  variables:
+    SOC_UDT: "colibri-imx6dl"
+    TARGET_BUILD_TYPE: "release"
+    DELEGATION_CONFIG: "./aval/delegation_config_scarthgap.toml"
+    TCB_MACHINE: "colibri-imx6"
+
+aval-colibri-imx6ull-emmc-scarthgap-release:
+  extends: .aval-template
+  rules:
+    - if: '$AVAL_TEST_ALL =~ /^true$/i'
+  variables:
+    SOC_UDT: "colibri-imx6ull-emmc"
+    TARGET_BUILD_TYPE: "release"
+    DELEGATION_CONFIG: "./aval/delegation_config_scarthgap.toml"
+    TCB_MACHINE: "colibri-imx6ull-emmc"
+
+aval-colibri-imx7d-emmc-scarthgap-release:
+  extends: .aval-template
+  rules:
+    - if: '$AVAL_TEST_ALL =~ /^true$/i'
+  variables:
+    SOC_UDT: "colibri-imx7d-emmc"
+    TARGET_BUILD_TYPE: "release"
+    DELEGATION_CONFIG: "./aval/delegation_config_scarthgap.toml"
+    TCB_MACHINE: "colibri-imx7-emmc"
+
+aval-colibri-imx8dx-scarthgap-release:
+  extends: .aval-template
+  rules:
+    - if: '$AVAL_TEST_ALL =~ /^true$/i'
+  variables:
+    SOC_UDT: "colibri-imx8dx"
+    TARGET_BUILD_TYPE: "release"
+    DELEGATION_CONFIG: "./aval/delegation_config_scarthgap.toml"
+    TCB_MACHINE: "colibri-imx8x"
+
+aval-verdin-am62dual-scarthgap-release:
+  extends: .aval-template
+  rules:
+    - if: '$AVAL_TEST_ALL =~ /^true$/i'
+  variables:
+    SOC_UDT: "verdin-am62dual"
+    TARGET_BUILD_TYPE: "release"
+    DELEGATION_CONFIG: "./aval/delegation_config_scarthgap.toml"
+    TCB_MACHINE: "verdin-am62"
+
+aval-verdin-imx8mmq-scarthgap-release:
+  extends: .aval-template
+  rules:
+    - if: '$AVAL_TEST_ALL =~ /^true$/i'
+  variables:
+    SOC_UDT: "verdin-imx8mmq"
+    TARGET_BUILD_TYPE: "release"
+    DELEGATION_CONFIG: "./aval/delegation_config_scarthgap.toml"
+    TCB_MACHINE: "verdin-imx8mm"
+
+aval-verdin-imx8mpq-scarthgap-release:
+  extends: .aval-template
+  variables:
+    SOC_UDT: "verdin-imx8mpq"
+    TARGET_BUILD_TYPE: "release"
+    DELEGATION_CONFIG: "./aval/delegation_config_scarthgap.toml"
+    TCB_MACHINE: "verdin-imx8mp"

--- a/tests/integration/aval/aval-tests.yml
+++ b/tests/integration/aval/aval-tests.yml
@@ -35,6 +35,21 @@ build-aval-docker:
     - cd tests/integration && python /aval/main.py --delegation-config $DELEGATION_CONFIG
       --run-before-on-host "./run_all.sh --device --machine $TCB_MACHINE --report --tcb-tags requires-device
       --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
+      # To circumvent the mismatch between Aktualizr's database and ostree when an external entity manages ostree without
+      # Aktualizr, install a different version than the one Aktualizr thinks it's currently installed (the one before TCB
+      # deploy), which externally forces both Aktualizr and ostree to sync. In particular, if we're running a nightly, install
+      # a release build and vice-versa
+    - |
+      toggle_release_type() {
+        local current_release_type="$1"
+        if [ "$current_release_type" == "release" ]; then
+          echo "nightly"
+        elif [ "$current_release_type" == "nightly" ]; then
+          echo "release"
+        fi
+      }
+    - TARGET_BUILD_TYPE=$(toggle_release_type "$TARGET_BUILD_TYPE") python /aval/main.py --delegation-config $DELEGATION_CONFIG
+      "echo 'Updating to a different TOS version than the TCB tests version, to circumvent the mismatch between Aktualizr'\''s database and ostree when an external entity manages ostree without Aktualizr'"
     - (! grep "^not ok" workdir/reports/*)
 
 # AVAL_TEST_ALL can be defined as "true" on a Gitlab schedule to run tests on all devices

--- a/tests/integration/aval/delegation_config_kirkstone.toml
+++ b/tests/integration/aval/delegation_config_kirkstone.toml
@@ -1,0 +1,11 @@
+[[delegation_filter.filter]]
+hardware_id_pattern = "imx6|imx7"
+name_prefix = "kirkstone"
+namespace = "torizon-upstream"
+name_suffix = "torizon-core-docker"
+
+[[delegation_filter.filter]]
+hardware_id_pattern = ".*"
+name_prefix = "kirkstone"
+namespace = "torizon"
+name_suffix = "torizon-core-docker"

--- a/tests/integration/aval/delegation_config_scarthgap.toml
+++ b/tests/integration/aval/delegation_config_scarthgap.toml
@@ -1,0 +1,11 @@
+[[delegation_filter.filter]]
+hardware_id_pattern = "imx6|imx7"
+name_prefix = "scarthgap"
+namespace = "torizon-upstream"
+name_suffix = "torizon-docker"
+
+[[delegation_filter.filter]]
+hardware_id_pattern = ".*"
+name_prefix = "scarthgap"
+namespace = "torizon"
+name_suffix = "torizon-docker"

--- a/tests/integration/functions.sh
+++ b/tests/integration/functions.sh
@@ -64,14 +64,14 @@ export -f torizoncore-builder-clean-storage
 # $@ = command to be executed
 device-shell() {
     local OPTS="-o ConnectTimeout=5 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
-    sshpass -p $DEVICE_PASS ssh -p $DEVICE_PORT -n -q $OPTS $DEVICE_USER@$DEVICE_ADDR "$@"
+    sshpass -p $DEVICE_PASSWORD ssh -p $DEVICE_PORT -n -q $OPTS $DEVICE_USER@$DEVICE_ADDR "$@"
 }
 export -f device-shell
 
 # run command in the device via SSH using sudo
 # $@ = command to be executed with sudo
 device-shell-root() {
-    device-shell "echo $DEVICE_PASS | sudo -S $@"
+    device-shell "echo $DEVICE_PASSWORD | sudo -S $@"
 }
 export -f device-shell-root
 

--- a/tests/integration/get_raw_images.sh
+++ b/tests/integration/get_raw_images.sh
@@ -37,7 +37,7 @@ download_wic_image() {
         echo "Image file $IMAGE_FILE already downloaded. Skiping."
     else
         echo "Downloading $IMAGE_FILE..."
-        if ! wget --no-verbose --show-progress -P $TMPDIR $LINK; then
+        if ! wget --no-verbose -P $TMPDIR $LINK; then
             echo "Error: could not download $IMAGE_FILE."
             exit 1
         fi

--- a/tests/integration/get_tezi_images.sh
+++ b/tests/integration/get_tezi_images.sh
@@ -3,12 +3,14 @@
 # images to be downloaded
 # format is MACHINE:DISTRO:IMAGE
 IMAGES="\
-colibri-imx6:torizon-upstream:torizon-core-docker \
-colibri-imx7-emmc:torizon-upstream:torizon-core-docker \
-apalis-imx6:torizon-upstream:torizon-core-docker \
-colibri-imx8x:torizon:torizon-core-docker \
-apalis-imx8:torizon:torizon-core-docker \
-verdin-imx8mm:torizon:torizon-core-docker \
+colibri-imx6:torizon-upstream:torizon-docker \
+colibri-imx6ull-emmc:torizon-upstream:torizon-docker \
+colibri-imx7-emmc:torizon-upstream:torizon-docker \
+colibri-imx8x:torizon:torizon-docker \
+apalis-imx6:torizon-upstream:torizon-docker \
+verdin-imx8mm:torizon:torizon-docker \
+verdin-imx8mp:torizon:torizon-docker \
+verdin-am62:torizon:torizon-docker \
 "
 
 # location to save images
@@ -17,13 +19,13 @@ TMPDIR="$OUTDIR/tmp"
 STAMP="$OUTDIR/.images_downloaded"
 
 # branch
-BRANCH="dunfell-5.x.y"
+BRANCH="scarthgap-7.x.y"
 
 # CONFIGME: version
-TCVERSION="5.2.0"
+TCVERSION="7.0.0"
 
 # CONFIGME: build number
-BUILD_NUMBER="246"
+BUILD_NUMBER="1"
 BUILD_DATE="20210315"
 
 # CONFIGME: uncomment for nightly images
@@ -37,9 +39,9 @@ BUILD_DATE="20210315"
 #VERSION="${TCVERSION}-devel-${BUILD_DATE}+build.${BUILD_NUMBER}"
 
 # CONFIGME: uncomment for quarterly images
-#BUILD_RELEASE="prod"
-#BUILD_TYPE="release"
-#VERSION="${TCVERSION}+build.${BUILD_NUMBER}"
+BUILD_RELEASE="prod"
+BUILD_TYPE="release"
+VERSION="${TCVERSION}+build.${BUILD_NUMBER}"
 
 prepare() {
     mkdir -p $OUTDIR

--- a/tests/integration/get_tezi_images.sh
+++ b/tests/integration/get_tezi_images.sh
@@ -64,7 +64,7 @@ download_tezi_image() {
         echo "Image file $IMAGE_FILE already downloaded. Skiping."
     else
         echo "Downloading $IMAGE_FILE..."
-        if ! wget --no-verbose --show-progress -P $TMPDIR $LINK; then
+        if ! wget --no-verbose -P $TMPDIR $LINK; then
             echo "Error: could not download $IMAGE_FILE."
             exit 1
         fi

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -47,7 +47,6 @@ export SAMPLES_DIR=samples
 # device address and credentials
 export DEVICE_ADDR=$TCB_DEVICE
 export DEVICE_USER="torizon"
-export DEVICE_PASS=$DEVICE_PASSWORD
 
 export WIC_MACHINES="intel-corei7-64 qemux86-64 raspberrypi4-64"
 

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -47,7 +47,7 @@ export SAMPLES_DIR=samples
 # device address and credentials
 export DEVICE_ADDR=$TCB_DEVICE
 export DEVICE_USER="torizon"
-export DEVICE_PASS="1"
+export DEVICE_PASS=$DEVICE_PASSWORD
 
 export WIC_MACHINES="intel-corei7-64 qemux86-64 raspberrypi4-64"
 
@@ -62,7 +62,16 @@ fi
 if [ ! -z "$TCB_MACHINE" ]; then
     export MACHINE=$TCB_MACHINE
 else
-    export MACHINE="apalis-imx6"
+    echo "Error: machine was not set"
+    exit 1
+fi
+
+# check if device password if defined when using device
+if [[ -n "$TCB_DEVICE" ]]; then
+    if [[ -z "$DEVICE_PASSWORD" ]]; then
+        echo "Error: Device password not defined."
+        exit 1
+    fi
 fi
 
 if [[ "$WIC_MACHINES" == *"$MACHINE"* ]]; then

--- a/tests/integration/run_all.sh
+++ b/tests/integration/run_all.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+# run_all.sh - Wrapper script to run all integration tests
+
+# Run all tests without a device:
+# ./run_all.sh
+#
+# Run tests that require a device where the network information is provided by a custom_device_info.json:
+#
+# ./run_all.sh --device --device-info custom_device_info.json
+#
+# Run a specific test case:
+# ./run_all.sh --testcase dto
+#
+# Run all tests with a specific TCB tag:
+# ./run_all.sh --tcb-tags "requires-device" --device
+#
+# Use a custom TorizonCore Builder image:
+# ./run_all.sh --tcb-custom-image torizoncore-builder:v1
+
+usage() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  -h, --help                 Show this help message"
+    echo "  -d, --device               Use device connection if required by tests"
+    echo "  -i, --device-info FILE     Use specified device information JSON file (default: device_information.json)"
+    echo "  -m, --machine MACHINE      Specify machine type (e.g., apalis-imx6)"
+    echo "  -t, --testcase TESTCASE    Specify test case(s) to run"
+    echo "  -r, --report               Generate test report"
+    echo "  --tcb-tags TAGS            Specify TCB tags"
+    echo "  --tcb-custom-image IMAGE   Use custom TorizonCore Builder image"
+    echo "  --                         Pass the rest of the arguments to test scripts"
+    echo
+    echo "Examples:"
+    echo "  $0 -d                      Run tests, using device connection if required"
+    echo "  $0 -t dto                  Run the 'dto' test case"
+    echo "  $0 --tcb-tags requires-device -d  Run tests with 'requires-device' tag, using device connection"
+    exit 0
+}
+
+USE_DEVICE=0
+DEVICE_INFO_FILE="device_information.json"
+export TCB_TESTCASE=""
+export TCB_REPORT=0
+export TCB_TAGS="all"
+export TCB_CUSTOM_IMAGE=""
+export TCB_DEVICE=""
+export DEVICE_ADDR=""
+export DEVICE_USER="torizon"
+
+while [[ "$1" != "" ]]; do
+    case $1 in
+        -d | --device )
+            USE_DEVICE=1
+            ;;
+        -i | --device-info )
+            shift
+            DEVICE_INFO_FILE="$1"
+            ;;
+        -m | --machine )
+            shift
+            export TCB_MACHINE="$1"
+            ;;
+        -t | --testcase )
+            shift
+            export TCB_TESTCASE="$1"
+            ;;
+        -r | --report )
+            export TCB_REPORT=1
+            ;;
+        --tcb-tags )
+            shift
+            export TCB_TAGS="$1"
+            ;;
+        --tcb-custom-image )
+            shift
+            export TCB_CUSTOM_IMAGE="$1"
+            ;;
+        -h | --help )
+            usage
+            ;;
+        -- )
+            shift
+            TEST_ARGS="$@"
+            break
+            ;;
+        * )
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+    shift
+done
+
+check_device_connection() {
+    if [ -f "$DEVICE_INFO_FILE" ]; then
+        deviceUuid=$(jq -r '.deviceUuid' "$DEVICE_INFO_FILE")
+        localIpV4=$(jq -r '.localIpV4' "$DEVICE_INFO_FILE")
+        hostname=$(jq -r '.hostname' "$DEVICE_INFO_FILE")
+        macAddress=$(jq -r '.macAddress' "$DEVICE_INFO_FILE")
+
+        export DEVICE_ADDR="$localIpV4"
+        export DEVICE_UUID="$deviceUuid"
+        export DEVICE_HOSTNAME="$hostname"
+        export DEVICE_MAC="$macAddress"
+        export TCB_DEVICE="$localIpV4"
+
+        echo "Using device at IP address $DEVICE_ADDR"
+    else
+        echo "Error: device information file '$DEVICE_INFO_FILE' not found."
+        exit 1
+    fi
+}
+
+if [ $USE_DEVICE -eq 1 ]; then
+    check_device_connection
+else
+    echo "Device connection not used."
+fi
+
+echo "Running setup..."
+source ./setup.sh
+
+if [ $? -ne 0 ]; then
+    echo "Error running setup.sh"
+    exit 1
+fi
+
+if [ ! -e workdir/images/.images_downloaded ] || [ ! -e workdir/images/.raw_images_downloaded ]; then
+    echo "Images not found. Attempting to download images..."
+
+    if [ -f "./get_tezi_images.sh" ]; then
+        echo "Downloading TEZI images..."
+        ./get_tezi_images.sh
+    fi
+
+    if [ -f "./get_raw_images.sh" ]; then
+        echo "Downloading raw images..."
+        ./get_raw_images.sh
+    fi
+
+    if [ ! -e workdir/images/.images_downloaded ] || [ ! -e workdir/images/.raw_images_downloaded ]; then
+        echo "Error: Images not found and could not be downloaded automatically."
+        echo "Please download images manually and place them in workdir/images/."
+        exit 1
+    fi
+fi
+
+echo "Running integration tests..."
+
+RUN_CMD="./run.sh $TEST_ARGS"
+
+$RUN_CMD
+
+if [ $? -ne 0 ]; then
+    echo "Error: Integration tests failed."
+    exit 1
+fi
+
+echo "Integration tests completed successfully."
+

--- a/tests/integration/setup.sh
+++ b/tests/integration/setup.sh
@@ -63,7 +63,7 @@ tcb_tests_pull_container() {
         return 2
     fi
 
-    export TCBCMD=$(alias torizoncore-builder | cut -d "'" -f 2)
+    export TCBCMD=$(alias torizoncore-builder | sed -e 's/-it/-i/' | cut -d "'" -f 2)
 
     echo "Testing TorizonCore Builder installation..."
     if ! eval $TCBCMD --version >/dev/null; then

--- a/tests/integration/setup.sh
+++ b/tests/integration/setup.sh
@@ -58,7 +58,7 @@ tcb_tests_pull_container() {
     fi
 
     echo "Pulling TorizonCore Builder container..."
-    if ! . $SETUP_SCRIPT $SCRIPT_PARAMS >/dev/null 2>&-; then
+    if ! . $SETUP_SCRIPT $SCRIPT_PARAMS >/dev/null; then
         echo "Error: could not pull container and initialize environment!"
         return 2
     fi
@@ -66,7 +66,7 @@ tcb_tests_pull_container() {
     export TCBCMD=$(alias torizoncore-builder | cut -d "'" -f 2)
 
     echo "Testing TorizonCore Builder installation..."
-    if ! eval $TCBCMD --version >/dev/null 2>&-; then
+    if ! eval $TCBCMD --version >/dev/null; then
         echo "Error: could not execute TorizonCore Builder!"
         return 3
     fi

--- a/tests/integration/testcases/build.bats
+++ b/tests/integration/testcases/build.bats
@@ -171,7 +171,7 @@ teardown_file() {
     # Deploy custom image.
     run torizoncore-builder deploy --remote-host "$DEVICE_ADDR" \
                                    --remote-username "$DEVICE_USER" \
-                                   --remote-password "$DEVICE_PASS" \
+                                   --remote-password "$DEVICE_PASSWORD" \
                                    --remote-port "$DEVICE_PORT" \
                                    --reboot "$COMMIT"
     assert_success

--- a/tests/integration/testcases/deploy.bats
+++ b/tests/integration/testcases/deploy.bats
@@ -56,7 +56,7 @@ load 'lib/common.bash'
 
     run torizoncore-builder deploy --remote-host $DEVICE_ADDR \
                                    --remote-username $DEVICE_USER \
-                                   --remote-password $DEVICE_PASS \
+                                   --remote-password $DEVICE_PASSWORD \
                                    --remote-port $DEVICE_PORT \
                                    --reboot some_branch
     assert_failure
@@ -74,7 +74,7 @@ load 'lib/common.bash'
 
     run torizoncore-builder deploy --remote-host $DEVICE_ADDR \
                                    --remote-username $DEVICE_USER \
-                                   --remote-password $DEVICE_PASS \
+                                   --remote-password $DEVICE_PASSWORD \
                                    --remote-port $DEVICE_PORT \
                                    --reboot branch1
     assert_success

--- a/tests/integration/testcases/dt.bats
+++ b/tests/integration/testcases/dt.bats
@@ -187,7 +187,7 @@ load 'lib/common.bash'
     torizoncore-builder union branch1
     run torizoncore-builder deploy --remote-host "$DEVICE_ADDR" \
                                    --remote-username "$DEVICE_USER" \
-                                   --remote-password "$DEVICE_PASS" \
+                                   --remote-password "$DEVICE_PASSWORD" \
                                    --remote-port "$DEVICE_PORT" \
                                    --reboot branch1
     assert_success

--- a/tests/integration/testcases/dto.bats
+++ b/tests/integration/testcases/dto.bats
@@ -109,7 +109,7 @@ bats_load_library 'bats/bats-file/load.bash'
     torizoncore-builder union branch1
     run torizoncore-builder deploy \
         --remote-host $DEVICE_ADDR --remote-username $DEVICE_USER \
-        --remote-password $DEVICE_PASS --remote-port $DEVICE_PORT --reboot branch1
+        --remote-password $DEVICE_PASSWORD --remote-port $DEVICE_PORT --reboot branch1
     assert_success
     assert_output --partial "Deploying successfully finished"
 
@@ -137,7 +137,7 @@ bats_load_library 'bats/bats-file/load.bash'
     torizoncore-builder union branch2
     run torizoncore-builder deploy \
         --remote-host $DEVICE_ADDR --remote-username $DEVICE_USER \
-        --remote-password $DEVICE_PASS --remote-port $DEVICE_PORT --reboot branch2
+        --remote-password $DEVICE_PASSWORD --remote-port $DEVICE_PORT --reboot branch2
     assert_success
     assert_output --partial "Deploying successfully finished"
 

--- a/tests/integration/testcases/images-download.bats
+++ b/tests/integration/testcases/images-download.bats
@@ -26,7 +26,7 @@ load 'lib/common.bash'
 
     run torizoncore-builder images download --remote-host $DEVICE_ADDR \
                                             --remote-username $DEVICE_USER \
-                                            --remote-password $DEVICE_PASS \
+                                            --remote-password $DEVICE_PASSWORD \
                                             --remote-port $DEVICE_PORT
     assert_success
     assert_output --partial "Unpacked OSTree from Toradex Easy Installer image"

--- a/tests/integration/testcases/isolate.bats
+++ b/tests/integration/testcases/isolate.bats
@@ -31,7 +31,7 @@ load 'lib/isolate.bash'
     run torizoncore-builder isolate --changes-directory $ISOLATE_DIR \
                                     --remote-host $DEVICE_ADDR \
                                     --remote-username $DEVICE_USER \
-                                    --remote-password $DEVICE_PASS \
+                                    --remote-password $DEVICE_PASSWORD \
                                     --remote-port $DEVICE_PORT
     assert_success
     assert_output --partial "Changes in /etc successfully isolated."
@@ -61,7 +61,7 @@ load 'lib/isolate.bash'
                                     --force \
                                     --remote-host $DEVICE_ADDR \
                                     --remote-username $DEVICE_USER \
-                                    --remote-password $DEVICE_PASS \
+                                    --remote-password $DEVICE_PASSWORD \
                                     --remote-port $DEVICE_PORT
     assert_success
     assert_output --partial "Changes in /etc successfully isolated."
@@ -86,7 +86,7 @@ load 'lib/isolate.bash'
     run torizoncore-builder isolate --changes-directory $ISOLATE_DIR \
                                     --remote-host $DEVICE_ADDR \
                                     --remote-username $DEVICE_USER \
-                                    --remote-password $DEVICE_PASS \
+                                    --remote-password $DEVICE_PASSWORD \
                                     --remote-port $DEVICE_PORT
     assert_failure
     assert_output --partial "There is already a directory with isolated changes. If you want to replace it, please use --force."
@@ -112,7 +112,7 @@ load 'lib/isolate.bash'
 
     run torizoncore-builder isolate --remote-host $DEVICE_ADDR \
                                     --remote-username $DEVICE_USER \
-                                    --remote-password $DEVICE_PASS \
+                                    --remote-password $DEVICE_PASSWORD \
                                     --remote-port $DEVICE_PORT
     assert_failure
     assert_output --partial "There is already a directory with isolated changes. If you want to replace it, please use --force."
@@ -138,7 +138,7 @@ load 'lib/isolate.bash'
 
     run torizoncore-builder isolate --remote-host $DEVICE_ADDR \
                                     --remote-username $DEVICE_USER \
-                                    --remote-password $DEVICE_PASS \
+                                    --remote-password $DEVICE_PASSWORD \
                                     --remote-port $DEVICE_PORT \
                                     --force
     assert_success
@@ -173,7 +173,7 @@ load 'lib/isolate.bash'
                                     --force \
                                     --remote-host $DEVICE_ADDR \
                                     --remote-username $DEVICE_USER \
-                                    --remote-password $DEVICE_PASS \
+                                    --remote-password $DEVICE_PASSWORD \
                                     --remote-port $DEVICE_PORT
     assert_success
     assert_output --partial "Changes in /etc successfully isolated."
@@ -205,7 +205,7 @@ load 'lib/isolate.bash'
     torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
     run torizoncore-builder isolate --remote-host $DEVICE_ADDR \
                                     --remote-username $DEVICE_USER \
-                                    --remote-password $DEVICE_PASS \
+                                    --remote-password $DEVICE_PASSWORD \
                                     --remote-port $DEVICE_PORT
     assert_success
     assert_output --partial "Changes in /etc successfully isolated."
@@ -229,7 +229,7 @@ load 'lib/isolate.bash'
     torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
     run torizoncore-builder isolate --remote-host $DEVICE_ADDR \
                                     --remote-username $DEVICE_USER \
-                                    --remote-password $DEVICE_PASS \
+                                    --remote-password $DEVICE_PASSWORD \
                                     --remote-port $DEVICE_PORT
     assert_success
     assert_output --partial "Changes in /etc successfully isolated."
@@ -251,7 +251,7 @@ load 'lib/isolate.bash'
     run torizoncore-builder isolate --changes-directory $ISOLATE_DIR \
                                     --remote-host $DEVICE_ADDR \
                                     --remote-username $DEVICE_USER \
-                                    --remote-password $DEVICE_PASS \
+                                    --remote-password $DEVICE_PASSWORD \
                                     --remote-port $DEVICE_PORT
     assert_success
     assert_output --partial "Changes in /etc successfully isolated."
@@ -270,7 +270,7 @@ load 'lib/isolate.bash'
 
     run torizoncore-builder isolate --remote-host $DEVICE_ADDR \
                                     --remote-username $DEVICE_USER \
-                                    --remote-password $DEVICE_PASS \
+                                    --remote-password $DEVICE_PASSWORD \
                                     --remote-port $DEVICE_PORT \
                                     --force
     assert_success
@@ -287,7 +287,7 @@ load 'lib/isolate.bash'
     run torizoncore-builder isolate --changes-directory $ISOLATE_DIR \
                                     --remote-host $DEVICE_ADDR \
                                     --remote-username $DEVICE_USER \
-                                    --remote-password $DEVICE_PASS \
+                                    --remote-password $DEVICE_PASSWORD \
                                     --remote-port $DEVICE_PORT \
                                     --force
     assert_success

--- a/tests/integration/testcases/union.bats
+++ b/tests/integration/testcases/union.bats
@@ -93,7 +93,7 @@ load 'lib/union.bash'
 
     run torizoncore-builder isolate --remote-host $DEVICE_ADDR \
                                     --remote-username $DEVICE_USER \
-                                    --remote-password $DEVICE_PASS \
+                                    --remote-password $DEVICE_PASSWORD \
                                     --remote-port $DEVICE_PORT
 
     make-changes-to-validate-tcattr-acls "/storage/changes"
@@ -129,7 +129,7 @@ load 'lib/union.bash'
                                     --force \
                                     --remote-host $DEVICE_ADDR \
                                     --remote-username $DEVICE_USER \
-                                    --remote-password $DEVICE_PASS \
+                                    --remote-password $DEVICE_PASSWORD \
                                     --remote-port $DEVICE_PORT
 
     add-files-to-check-default-credentials "/workdir/$ISOLATE_DIR"

--- a/tests/integration/testcases/wic/build.bats
+++ b/tests/integration/testcases/wic/build.bats
@@ -218,7 +218,7 @@ teardown_file() {
     # Deploy custom image.
     run torizoncore-builder deploy --remote-host "$DEVICE_ADDR" \
                                    --remote-username "$DEVICE_USER" \
-                                   --remote-password "$DEVICE_PASS" \
+                                   --remote-password "$DEVICE_PASSWORD" \
                                    --remote-port "$DEVICE_PORT" \
                                    --reboot "$COMMIT"
     assert_success

--- a/tests/integration/testcases/wic/deploy.bats
+++ b/tests/integration/testcases/wic/deploy.bats
@@ -67,7 +67,7 @@ load '../lib/common.bash'
 
     run torizoncore-builder deploy --remote-host $DEVICE_ADDR \
                                    --remote-username $DEVICE_USER \
-                                   --remote-password $DEVICE_PASS \
+                                   --remote-password $DEVICE_PASSWORD \
                                    --remote-port $DEVICE_PORT \
                                    --reboot some_branch
     assert_failure
@@ -85,7 +85,7 @@ load '../lib/common.bash'
 
     run torizoncore-builder deploy --remote-host $DEVICE_ADDR \
                                    --remote-username $DEVICE_USER \
-                                   --remote-password $DEVICE_PASS \
+                                   --remote-password $DEVICE_PASSWORD \
                                    --remote-port $DEVICE_PORT \
                                    --reboot branch1
     assert_success

--- a/tests/integration/testcases/wic/union.bats
+++ b/tests/integration/testcases/wic/union.bats
@@ -93,7 +93,7 @@ load '../lib/union.bash'
 
     run torizoncore-builder isolate --remote-host $DEVICE_ADDR \
                                     --remote-username $DEVICE_USER \
-                                    --remote-password $DEVICE_PASS \
+                                    --remote-password $DEVICE_PASSWORD \
                                     --remote-port $DEVICE_PORT
 
     make-changes-to-validate-tcattr-acls "/storage/changes"
@@ -129,7 +129,7 @@ load '../lib/union.bash'
                                     --force \
                                     --remote-host $DEVICE_ADDR \
                                     --remote-username $DEVICE_USER \
-                                    --remote-password $DEVICE_PASS \
+                                    --remote-password $DEVICE_PASSWORD \
                                     --remote-port $DEVICE_PORT
 
     add-files-to-check-default-credentials "/workdir/$ISOLATE_DIR"


### PR DESCRIPTION
The goal of the implementation is to run all TCB tests (including those that access modules) daily or weekly, using Gitlab CI `schedule` and the AVAL infrastructure.

The variables of AVAL were set in my personal fork at `Settings -> CI/CD -> Variables`.

By default, a schedule run all the tests on one ARM32 and on one ARM64 devices, however it is possible to set `$AVAL_TEST_ALL`  variable as `True` to run the tests on all devices.

Related-to: TCCP-864