### PR TITLE
Make device-required tests independent of tests that don't use a device

### DIFF
--- a/tests/integration/testcases/dt.bats
+++ b/tests/integration/testcases/dt.bats
@@ -147,6 +147,7 @@ load 'lib/common.bash'
 @test "dt: deploy device tree in the device" {
     requires-device
     torizoncore-builder-shell "rm -rf device-trees"
+    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
 
     run torizoncore-builder dt checkout --update
     if is-major-version-greater-than-5; then


### PR DESCRIPTION
Some tests that require a device use data created by previous tests that do not require one. This causes problems when only running device-required tests via the 'requires-device' BATS tag, as the necessary data wouldn't be created in this case.

This commit makes these two types of tests independent of one another.

The AVAL-related pipeline only run tests that require a device, so this PR fixes test errors caused by the problem described above.

Signed-off-by: Lucas Akira Morishita <lucas.morishita@toradex.com>