### PR TITLE
tests: Allow AVAL tests to be disabled

### DIFF
--- a/tests/integration/aval/aval-tests.yml
+++ b/tests/integration/aval/aval-tests.yml
@@ -3,6 +3,8 @@ build-aval-docker:
   image: docker:dind
   stage: build
   rules:
+    - if: '$AVAL_DISABLED =~ /^true$/i'
+      when: never
     - if: $CI_PIPELINE_SOURCE == "schedule"
   variables:
     IMAGE_NAME_AVAL: aval-docker
@@ -23,6 +25,8 @@ build-aval-docker:
     IMAGE_NAME: torizoncore-builder-amd64
     IMAGE_NAME_AVAL: aval-docker
   rules:
+    - if: '$AVAL_DISABLED =~ /^true$/i'
+      when: never
     - if: $CI_PIPELINE_SOURCE == "schedule"
   image: ${CI_REGISTRY_IMAGE}/${IMAGE_NAME_AVAL}:main
   script:


### PR DESCRIPTION
Introduce variable AVAL_DISABLED which when set to "true" disables the execution of the AVAL tests; useful if the infrastructure is not available.