### PR TITLE
gitlab-ci: Allow to select a runner for a schedule pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,10 @@ variables:
   RELEASE_TYPE:
     value: "official"
     description: "Type of pipeline to run. Allowed values: 'official', 'early-access' or 'internal'."
+  # Variables defined in schedule pipelines has more precedente than this defined in gitlab-ci.yml. So,
+  # RUNNER_TAG defined in schedule pipeline will overwrite this variable. This one is useful for commit
+  # pipelines.
+  RUNNER_TAG: ""
 
   DEBIAN_RELEASE: "bullseye-slim"
   # Pipeline Settings
@@ -52,6 +56,10 @@ variables:
   D: ""        # deployment actions
   T: ""        # test actions
   B: ""        # build actions
+
+default:
+  tags:
+    - $RUNNER_TAG
 
 services:
   - name: docker:dind

--- a/tests/integration/aval/aval-tests.yml
+++ b/tests/integration/aval/aval-tests.yml
@@ -1,3 +1,13 @@
+variables:
+  # Variables defined in schedule pipelines has more precedente than this defined in gitlab-ci.yml. So,
+  # RUNNER_TAG defined in schedule pipeline will overwrite this variable. This one is useful for commit
+  # pipelines.
+  RUNNER_TAG: ""
+
+default:
+  tags:
+    - $RUNNER_TAG
+
 # Build the AVAL container with docker that will run the tests on the host PC
 build-aval-docker:
   image: docker:dind


### PR DESCRIPTION
When RUNNER_TAG variable is defined in a schedule pipeline, the pipeline will execute the jobs on the runner that contains the tag defined. If not defined, will execute jobs on untagged runner.

Related-to: TCB-253