### PR TITLE
tests/integration: Add --ignore-different-secondaries-between-updates to AVAL

### DIFF
--- a/tests/integration/aval/aval-tests.yml
+++ b/tests/integration/aval/aval-tests.yml
@@ -42,7 +42,7 @@ build-aval-docker:
     - ${T} docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
     - ${T} docker pull "${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
     - echo -e "\e[0Ksection_end:$(date +%s):pull_eval_tcb_section\r\e[0K"
-    - cd tests/integration && python /aval/main.py --delegation-config $DELEGATION_CONFIG
+    - cd tests/integration && python /aval/main.py --delegation-config $DELEGATION_CONFIG --ignore-different-secondaries-between-updates
       --run-before-on-host "./run_all.sh --device --machine $TCB_MACHINE --report --tcb-tags requires-device
       --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
       # To circumvent the mismatch between Aktualizr's database and ostree when an external entity manages ostree without
@@ -58,7 +58,7 @@ build-aval-docker:
           echo "release"
         fi
       }
-    - TARGET_BUILD_TYPE=$(toggle_release_type "$TARGET_BUILD_TYPE") python /aval/main.py --delegation-config $DELEGATION_CONFIG
+    - TARGET_BUILD_TYPE=$(toggle_release_type "$TARGET_BUILD_TYPE") python /aval/main.py --delegation-config $DELEGATION_CONFIG --ignore-different-secondaries-between-updates
       "echo 'Updating to a different TOS version than the TCB tests version, to circumvent the mismatch between Aktualizr'\''s database and ostree when an external entity manages ostree without Aktualizr'"
     - (! grep "^not ok" workdir/reports/*)
 


### PR DESCRIPTION
A new secondary for fuse was added to Torizon. Because of this, when AVAL tries this update path:

(image with secondary) -> (image withouth secondary) -> (image with secondary)

Aktualizr/Uptane breaks due to an artificial limitation imposed by the platform to prevent security issues. Thus we must always make sure to remove secondaries that are not in the intersection between the images. In the current case, this is only the `fuses` secondary.
This flag allow AVAL to delete /var/sota/storage/fuse path, as a workaround for this.

Related-to: TCB-505
Related-to: TOR-3635