### PR TITLE
aval-tests: Add variable to allow tests to fail plus improvements

### DIFF
--- a/tests/integration/aval/aval-tests.yml
+++ b/tests/integration/aval/aval-tests.yml
@@ -6,6 +6,12 @@ variables:
   AVAL_TEST_ALL:
     value: false
     description: "Whether to test all machines using AVAL"
+  AVAL_DISABLED:
+    value: false
+    description: "Whether to disable the AVAL jobs in the pipeline."
+  AVAL_ALLOW_FAILURE:
+    value: false
+    description: "Whether to allow the pipeline to continue upon failures in AVAL jobs."
 
 default:
   tags:
@@ -15,9 +21,11 @@ default:
 build-aval-docker:
   stage: build
   rules:
+    - if: '$AVAL_ALLOW_FAILURE =~ /^true$/i'
+      allow_failure: true
     - if: '$AVAL_DISABLED =~ /^true$/i'
       when: never
-    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - when: on_success
   variables:
     IMAGE_NAME_AVAL: aval-docker
     DOCKERFILE_NAME: tests/integration/aval/aval-docker.Dockerfile
@@ -34,9 +42,11 @@ build-aval-docker:
     IMAGE_NAME: torizoncore-builder-amd64
     IMAGE_NAME_AVAL: aval-docker
   rules:
+    - if: '$AVAL_ALLOW_FAILURE =~ /^true$/i'
+      allow_failure: true
     - if: '$AVAL_DISABLED =~ /^true$/i'
       when: never
-    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - when: on_success
   image: ${CI_REGISTRY_IMAGE}/${IMAGE_NAME_AVAL}:main
   script:
     # pull latest build of TorizonCore Builder


### PR DESCRIPTION
Add pipeline variable AVAL_ALLOW_FAILURE (default value: false) which one can set to true to allow the pipeline to continue running when AVAL tests fail. This can be useful to deal with instabilities of the infrastructure.

Also, do not rely on the pipeline source being set to "schedule" to enable the AVAL-related jobs. Relying on the source makes it harder for testing the pipeline. If someone does not want the AVAL-related jobs to be present on the pipeline they can always set AVAL_DISABLED=true.

--

My idea is to make AVAL_ALLOW_FAILURE=true in our production and early-access pipelines so that we can take the decision of going ahead with the publishing even upon failures.

Due to the second change of removing the dependency on the pipeline source for the AVAL jobs, one point of discussion could be regarding the desirable default value of AVAL_DISABLED...
