### PR TITLE
aval-tests: Change the workaround for mismatch between database and OSTree

### DIFF
--- a/tests/integration/aval/aval-tests.yml
+++ b/tests/integration/aval/aval-tests.yml
@@ -55,25 +55,11 @@ build-aval-docker:
     - ${T} docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
     - ${T} docker pull "${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
     - echo -e "\e[0Ksection_end:$(date +%s):pull_eval_tcb_section\r\e[0K"
+    # To circumvent the mismatch between Aktualizr's database and ostree when an external entity manages ostree without
+    # Aktualizr, delete the database files, which forces Aktualizr to create database again, this time synced with ostree
     - cd tests/integration && python /aval/main.py --delegation-config $DELEGATION_CONFIG --ignore-different-secondaries-between-updates
       --run-before-on-host "./run_all.sh --device --machine $TCB_MACHINE --report --tcb-tags requires-device
-      --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
-      # To circumvent the mismatch between Aktualizr's database and ostree when an external entity manages ostree without
-      # Aktualizr, install a different version than the one Aktualizr thinks it's currently installed (the one before TCB
-      # deploy), which externally forces both Aktualizr and ostree to sync. In particular, if we're running a nightly, install
-      # a release build and vice-versa
-    - |
-      toggle_release_type() {
-        local current_release_type="$1"
-        if [ "$current_release_type" == "release" ]; then
-          echo "nightly"
-        elif [ "$current_release_type" == "nightly" ]; then
-          echo "release"
-        fi
-      }
-    - TARGET_BUILD_TYPE=$(toggle_release_type "$TARGET_BUILD_TYPE") python /aval/main.py --delegation-config $DELEGATION_CONFIG --ignore-different-secondaries-between-updates
-      "echo 'Updating to a different TOS version than the TCB tests version, to circumvent the mismatch between Aktualizr'\''s database and ostree when an external entity manages ostree without Aktualizr'"
-    - (! grep "^not ok" workdir/reports/*)
+      --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}" "echo $DEVICE_PASSWORD | sudo -S rm -rf /var/sota/sql.db /var/sota/storage/*"
 
 aval-apalis-imx6q-kirkstone-release:
   extends: .aval-template


### PR DESCRIPTION
The previous workaround was generating a problematic edge case. Let’s suppose the existence of two parallel tests, A and B. With this previous workaround, test A runs the TCB tests, releases the device, and then takes it again to update it to a different version, aiming to sync the Aktualizr’s database with OSTree. However, if test B takes the device after A’s TCB tests but before A’s workaround update and attempts an update to the Torizon version before A’s TCB tests, the device will fall into the same mismatch bug.

Because of this, the workaround was changed to delete the Aktualizr’s database, which forces Aktualizr to recreate it, this time based on OSTree, bringing both into sync again. With this new workaround, the device is not released until the workaround is completed, there is no risk of encountering these edge cases, and it also speeds up testing by saving one update.

Related-to: TOR-3518
Related-to: AVAL-53
Related-to: TCB-490