### PR TITLE
kernel: Install kernel modules into "updates" directory

### DIFF
--- a/tcbuilder/backend/kernel.py
+++ b/tcbuilder/backend/kernel.py
@@ -152,6 +152,7 @@ def build_module(src_dir, linux_src, src_mod_dir, image_major_version,
         f"CROSS_COMPILE={c_c}",
         f"M={src_dir}",
         f"INSTALL_MOD_PATH={install_path}",
+        "INSTALL_MOD_DIR=updates",
         "modules_install",
     ]
     subprocess.check_output(cmd, stderr=subprocess.STDOUT, env=env_path)


### PR DESCRIPTION
By default, the 5.15 kernel's Makefile.modinst installs into a directory called "extra" (/lib/modules/5.15-something/extra). However, this directory is not listed in the depmod default search path (/lib/depmod.d/search.conf), which means it has the same priority as the main "kernel" directory that contains the in-tree modules.

In practice, this means if "torizoncore-builder kernel build_module" is used to add a module with the same name as an existing module, it is arbitrary whether the original or added module will be used (determined by the order in which the directory listing is returned to depmod at build time, which seems to be favoring the "extra" directory on a local linux system, and the default "kernel" directory in a github workflow).

Upstream linux has realized this is not ideal, and (since v6.3) changed the default install directory to "updates":

    https://github.com/torvalds/linux/commit/b74d7bb7ca2412ab37bab782591573b5f265872b

This commit effectively backports this change to achieve the same behavior with older kernels (i.e. with torizoncore 6.x or older). This change is presumably not needed with torizoncore 7.x which uses a 6.6 kernel, but should be harmless in that case.