### PR TITLE
aval-tests: Don't run AVAL tests when the source is a trigger token

### DIFF
--- a/tests/integration/aval/aval-tests.yml
+++ b/tests/integration/aval/aval-tests.yml
@@ -25,6 +25,8 @@ build-aval-docker:
       allow_failure: true
     - if: '$AVAL_DISABLED =~ /^true$/i'
       when: never
+    - if: $CI_PIPELINE_SOURCE == "trigger"
+      when: never
     - when: on_success
   variables:
     IMAGE_NAME_AVAL: aval-docker
@@ -45,6 +47,8 @@ build-aval-docker:
     - if: '$AVAL_ALLOW_FAILURE =~ /^true$/i'
       allow_failure: true
     - if: '$AVAL_DISABLED =~ /^true$/i'
+      when: never
+    - if: $CI_PIPELINE_SOURCE == "trigger"
       when: never
     - when: on_success
   image: ${CI_REGISTRY_IMAGE}/${IMAGE_NAME_AVAL}:main


### PR DESCRIPTION
A side effect of commit c27a999c48e6b8625b18cc069eb608799f36b309, which removes the rule $CI_PIPELINE_SOURCE == "schedule", is that AVAL tests started running by default in all created pipelines, including the pipeline triggered by Jenkins.

However, it does not make sense to test AVAL with this pipeline created by Jenkins in the Torizon nightlies, since it runs TCB tests using the nightly created by Jenkins as the base image for the tests. On the other hand, AVAL runs tests using the release or the nightly available in the Cloud, which is not necessarily the same as the one created by Jenkins, making these tests unnecessary and redundant with those already performed when a commit is created or with the Early-Access pipeline.

To solve this, a rule was added to prevent AVAL tests from running when the job source is a trigger token.