### PR TITLE
platform push: Avoid fetching image repo metadata when not needed

### DIFF
--- a/tcbuilder/backend/platform.py
+++ b/tcbuilder/backend/platform.py
@@ -1179,15 +1179,18 @@ def translate_compatible_packages(credentials, criteria):
     :return: Found packages' information and the 'compatibleWith' value.
     """
 
+    package_info = []
+    compatible_with = []
+
+    if not criteria:
+        return package_info, compatible_with
+
     server_creds = sotaops.ServerCredentials(credentials)
     token = sotaops.get_access_token(server_creds)
 
     with TemporaryDirectory() as tmpdir:
         fetch_imgrepo_metadata(server_creds.repo_url, tmpdir, token, verbose=False)
         targets_metadata = load_imgrepo_targets(tmpdir, verbose=False)
-
-    package_info = []
-    compatible_with = []
 
     for criterion in criteria:
         target_hash = criterion.get("sha256")


### PR DESCRIPTION
The platform push command was always fetching the image repo metadata even when that data was not used. Now we only fetch the data when the switch --compatible-with is passed; this makes the command run faster when the switch is not passed.

Here's an example of running the recently added command to push fuse packages before and after this improvement:

```
# Before:
$ time torizoncore-builder tcb485 platform push ./fuses-missing.yaml --hardwareid colibri-imx8x-fuses --credentials ./credentials-prod.zip
Error: Found 9 fuse values in provided yaml file, but expected to find 16 instead.
exit status 255

real    0m18,253s <=
user    0m0,011s
sys     0m0,008s

# After:
$ time torizoncore-builder platform push ./fuses-missing.yaml --hardwareid colibri-imx8x-fuses --credentials ./credentials-prod.zip
Error: Found 9 fuse values in provided yaml file, but expected to find 16 instead.
exit status 255

real    0m0,557s <=
user    0m0,013s
sys     0m0,024s
```
