### PR TITLE
Allow Docker images to be specified by tag+digest inside compose files

### DIFF
--- a/tcbuilder/backend/platform.py
+++ b/tcbuilder/backend/platform.py
@@ -389,7 +389,8 @@ def get_referenced_images(compose):
         parsed_name = parse_image_name(image)
         assert parsed_name.tag.startswith(SHA256_PREFIX), \
             f"Image '{image}' not specified by digest"
-        image_per_service[svc_name] = (image, image_platform)
+        image_per_service[svc_name] = \
+            (parsed_name.get_name_with_tag(), image_platform)
 
     log.debug(f"Images being used in docker-compose: {image_per_service}")
 
@@ -1395,6 +1396,8 @@ def set_images_hash(compose_file_data):
         image_parsed = parse_image_name(image_name)
         log.debug(f"Parsed {image_name} into {image_parsed}.")
         if image_parsed.uses_digest():
+            # Normalize the name (handle the case where tag+digest is passed)
+            svc_spec['image'] = image_parsed.get_name_with_tag()
             continue
         registry = RegistryOperations(image_parsed.registry)
         response, image_digest = registry.get_manifest(

--- a/tcbuilder/backend/registryops.py
+++ b/tcbuilder/backend/registryops.py
@@ -195,14 +195,24 @@ def parse_image_name(image_name):
     ImageName(registry='', name='ubuntu', tag='latest')
     >>> parse_image_name('linux/ubuntu:latest')
     ImageName(registry='', name='linux/ubuntu', tag='latest')
+    >>> parse_image_name('localhost/ubuntu@sha256:123456')
+    ImageName(registry='', name='localhost/ubuntu', tag='sha256:123456')
     >>> parse_image_name('localhost/ubuntu:latest@sha256:123456')
-    ImageName(registry='', name='localhost/ubuntu:latest', tag='sha256:123456')
+    ImageName(registry='', name='localhost/ubuntu', tag='sha256:123456')
 
     # With a registry:
     >>> parse_image_name('localhost:8000/ubuntu:latest')
     ImageName(registry='localhost:8000', name='ubuntu', tag='latest')
     >>> parse_image_name('gcr.io/ubuntu:latest')
     ImageName(registry='gcr.io', name='ubuntu', tag='latest')
+    >>> parse_image_name('gcr.io/ubuntu@sha256:123456')
+    ImageName(registry='gcr.io', name='ubuntu', tag='sha256:123456')
+    >>> parse_image_name('gcr.io/ubuntu:latest@sha256:123456')
+    ImageName(registry='gcr.io', name='ubuntu', tag='sha256:123456')
+    >>> parse_image_name('gcr.io:443/ubuntu:latest@sha256:123456')
+    ImageName(registry='gcr.io:443', name='ubuntu', tag='sha256:123456')
+    >>> parse_image_name('gcr.io:443/linux/ubuntu:latest@sha256:123456')
+    ImageName(registry='gcr.io:443', name='linux/ubuntu', tag='sha256:123456')
     """
 
     mres = re.match(r"^([a-zA-Z][-+.a-zA-Z0-9]+)://", image_name)
@@ -221,7 +231,12 @@ def parse_image_name(image_name):
 
     if "@" in name_with_tag:
         # E.g. ubuntu@sha256:1234...
+        # or   ubuntu:latest@sha256:1234: this can be deemed as a bad notation
+        #      but is accepted by Docker so we handle it here for compatibility
         name, tag = name_with_tag.split("@")
+        if ":" in name:
+            log.info(f"Ignoring tag of image specified by tag+digest ({image_name})")
+            name = name.split(":")[0]
     elif ":" in name_with_tag:
         # E.g. ubuntu:latest
         name, tag = name_with_tag.split(":")

--- a/tests/integration/samples/push/canonicalize/docker-compose-dh.yml
+++ b/tests/integration/samples/push/canonicalize/docker-compose-dh.yml
@@ -12,6 +12,9 @@ services:
   svc3:
     # Global namespace / with digest.
     image: hello-world@sha256:6e8b6f026e0b9c419ea0fd02d3905dd0952ad1feea67543f525c73a0a790fefb
+  svc3b:
+    # Global namespace / with tag+digest.
+    image: hello-world:dummytag@sha256:6e8b6f026e0b9c419ea0fd02d3905dd0952ad1feea67543f525c73a0a790fefb
   svc4:
     # Inside namespace / no tag.
     image: torizon/torizoncore-builder
@@ -21,6 +24,9 @@ services:
   svc6:
     # Inside namespace / with digest.
     image: torizon/weston@sha256:6fab6152b860c93cbfc0abfecd3f892adb9154ce284dc4c4442afdab3a005047
+  svc6b:
+    # Inside namespace / with tag+digest.
+    image: torizon/weston:dummytag@sha256:6fab6152b860c93cbfc0abfecd3f892adb9154ce284dc4c4442afdab3a005047
 
   # ---
   # TODO: Images only accessible after authentication.

--- a/tests/integration/samples/push/canonicalize/docker-compose-gcr.yml
+++ b/tests/integration/samples/push/canonicalize/docker-compose-gcr.yml
@@ -14,6 +14,8 @@ services:
     image: gcr.io/google-containers/alpine-with-bash@sha256:0955672451201896cf9e2e5ce30bec0c7f10757af33bf78b7a6afa5672c596f5
   svc4:
     image: gcr.io:443/google-containers/alpine-with-bash@sha256:0955672451201896cf9e2e5ce30bec0c7f10757af33bf78b7a6afa5672c596f5
+  svc5:
+    image: gcr.io:443/google-containers/alpine-with-bash:dummytag@sha256:0955672451201896cf9e2e5ce30bec0c7f10757af33bf78b7a6afa5672c596f5
 
   # ---
   # TODO: Images only accessible after authentication.

--- a/tests/integration/testcases/platform.bats
+++ b/tests/integration/testcases/platform.bats
@@ -33,13 +33,18 @@ test_canonicalize_only_success() {
     local LCK_FNAME="${ORG_FNAME%%.yml}.lock.yml"
     shift # Extra arguments will be forwarded to torizoncore-builder.
 
-    local ORG_IMG_COUNT=$(cat "$CANON_DIR/${ORG_FNAME}" | grep -Ee "^\\s+image *:" | wc -l)
+    local ORG_IMG_COUNT=$(cat "$CANON_DIR/${ORG_FNAME}" |
+                              grep -Ee "^[[:space:]]+image *:" |
+                              wc -l)
 
     run torizoncore-builder platform push "$CANON_DIR/${ORG_FNAME}" --canonicalize-only "$@"
     assert_success
     assert_output --partial "'$CANON_DIR/${LCK_FNAME}' has been generated"
 
-    local RES_IMG_COUNT=$(cat "$CANON_DIR/${LCK_FNAME}" | grep -Ee "^\\s+image *:.*@sha256:" | wc -l)
+    local RES_IMG_COUNT=$(cat "$CANON_DIR/${LCK_FNAME}" |
+                              grep -Ee "^[[:space:]]+image *:.*@sha256:" |
+                              grep -Ee ':[-.a-z0-9]+@sha256:' -v |
+                              wc -l)
     if [ "$ORG_IMG_COUNT" -ne "$RES_IMG_COUNT" ]; then
         fail "Canonicalization failed ($ORG_IMG_COUNT != $RES_IMG_COUNT)"
     fi
@@ -155,6 +160,9 @@ test_canonicalize_only_success() {
        skip "avoid hitting DH pull limits in CI"
     fi
     test_canonicalize_only_success "docker-compose-dh.yml" --force
+    # Confirm tags have been ignored:
+    assert_output --partial "Ignoring tag of image specified by tag+digest (hello-world:dummytag"
+    assert_output --partial "Ignoring tag of image specified by tag+digest (torizon/weston:dummytag"
 }
 
 @test "platform push: docker-compose canonicalization (DockerHub with authentication)" {
@@ -170,6 +178,8 @@ test_canonicalize_only_success() {
 
 @test "platform push: docker-compose canonicalization (GCR without authentication)" {
     test_canonicalize_only_success "docker-compose-gcr.yml" --force
+    # Confirm tags have been ignored:
+    assert_output --partial "Ignoring tag of image specified by tag+digest (gcr.io:443/google-containers/alpine-with-bash:dummytag"
 }
 
 @test "platform push: docker-compose canonicalization (DockerHub with required authentication)" {
@@ -576,7 +586,7 @@ test_canonicalize_only_success() {
 
     run torizoncore-builder platform lockbox \
         --credentials "${CREDS_PROD_ZIP}" --platform linux/arm64 \
-        --force  LockBox-With-OCI-64bit-Images \
+        --force LockBox-With-OCI-64bit-Images \
         ${CI_DOCKER_HUB_PULL_USER:+"--login" "${CI_DOCKER_HUB_PULL_USER}"
                                              "${CI_DOCKER_HUB_PULL_PASSWORD}"}
     assert_success


### PR DESCRIPTION
In theory, specifying a Docker image by a tag plus a digest (such as in `image:tag@sha256:<hex-digest`) doesn't make much sense, but Docker does accept it by basically ignoring the tag. However, the implementation in TorizonCore Builder did not work in such cases. With the present commit we try to mimic Docker's behavior by also ignoring the tag. This has an effect both when canonicalizing a compose file (via `platform push`) and when generating Lockboxes (via `platform lockbox`).

Related-to: TCB-689

Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>