### PR TITLE
Use skopeo to generate Lockbox tarballs

### DIFF
--- a/tcbuilder/backend/bundle.py
+++ b/tcbuilder/backend/bundle.py
@@ -379,6 +379,14 @@ class DindManager(DockerManager):
         dind_client = docker.DockerClient(base_url=self.docker_host, tls=tls_config)
         return dind_client
 
+    def get_client_env(self):
+        env = {
+            "DOCKER_HOST": self.docker_host,
+            "DOCKER_TLS_VERIFY": "1",
+            "DOCKER_CERT_PATH": os.path.join(self.cert_dir, 'client')
+        }
+        return env
+
     def save_tar(self, output_file):
         """Create compressed tar archive of the Docker images"""
 

--- a/tcbuilder/backend/bundle.py
+++ b/tcbuilder/backend/bundle.py
@@ -137,7 +137,7 @@ class DindManager(DockerManager):
     # - "23.0.6-dind":   version supporting zstd compression of layers
     # - "25.0.3-dind":   version used by Torizon OS 7.x.y
     #
-    DIND_IMAGE_VERSION_DEFAULT = "19.03.8-dind"
+    DIND_IMAGE_VERSION_DEFAULT = "25.0.3-dind"
 
     DIND_VOLUME_NAME = "dind-volume"
     DIND_CONTAINER_NAME = "tcb-fetch-dind"

--- a/tcbuilder/backend/bundle.py
+++ b/tcbuilder/backend/bundle.py
@@ -128,7 +128,17 @@ class DindManager(DockerManager):
     Installer tool.
     """
 
-    DIND_CONTAINER_IMAGE = "docker:19.03.8-dind"
+    DIND_IMAGE_NAME_DEFAULT = "docker"
+
+    # Noteworthy versions:
+    #
+    # - "19.03.8-dind":  old version used before TCB 3.11
+    # - "20.10.24-dind": (closest to the) version used by Torizon OS 6.x.y
+    # - "23.0.6-dind":   version supporting zstd compression of layers
+    # - "25.0.3-dind":   version used by Torizon OS 7.x.y
+    #
+    DIND_IMAGE_VERSION_DEFAULT = "19.03.8-dind"
+
     DIND_VOLUME_NAME = "dind-volume"
     DIND_CONTAINER_NAME = "tcb-fetch-dind"
     TAR_CONTAINER_NAME = "tcb-build-tar"
@@ -203,6 +213,7 @@ class DindManager(DockerManager):
                 f"{self.cert_dir} is a shared location between this script and "
                 "the Docker host.")
 
+    # pylint: disable=too-many-locals
     def start(self, network_name="fetch-dind-network",
               default_platform=None, dind_params=None, dind_env=None):
         """Start manager
@@ -279,8 +290,11 @@ class DindManager(DockerManager):
 
         log.debug(f"Environment variables for DinD: {environ}")
         log.debug(f"Running DinD container: ports={ports}, network={network_name}")
+        dind_image = "{}:{}".format(
+            os.environ.get("DIND_IMAGE_NAME", self.DIND_IMAGE_NAME_DEFAULT),
+            os.environ.get("DIND_IMAGE_VERSION", self.DIND_IMAGE_VERSION_DEFAULT))
         self.dind_container = self.host_client.containers.run(
-            self.DIND_CONTAINER_IMAGE,
+            dind_image,
             privileged=True,
             environment=environ,
             mounts=mounts,
@@ -297,6 +311,7 @@ class DindManager(DockerManager):
             dind_ip = self.dind_container.attrs \
                 ["NetworkSettings"]["Networks"][network_name]["IPAddress"]
             self.docker_host = "tcp://{}:22376".format(dind_ip)
+    # pylint: enable=too-many-locals
 
     def _stop_container(self):
         log.info("Stopping DIND container")

--- a/tcbuilder/backend/platform.py
+++ b/tcbuilder/backend/platform.py
@@ -720,7 +720,8 @@ def fetch_compose_target(target, repo_url, images_dir, metadata_dir,
     # Fetch the manifests of all images.
     manifests_dir = os.path.join(metadata_dir, sha256 + ".manifests")
     os.mkdir(manifests_dir)
-    manifests_per_image = fetch_manifests(images, manifests_dir)
+    manifests_per_image = fetch_manifests(
+        images, manifests_dir, req_platforms=req_platforms)
 
     # Determine (image, platform) pairs referenced in the compose file.
     image_platform_pairs = set(image_per_service.values())

--- a/tcbuilder/backend/platform.py
+++ b/tcbuilder/backend/platform.py
@@ -897,6 +897,11 @@ def build_docker_tarballs(unique_images, target_dir, host_workdir,
             log.info(f"Saving {image_spec}\n"
                      f"  into {image_fname}")
 
+            if os.path.exists(image_fname):
+                # Sanity check: images in a Lockbox should be unique.
+                raise TorizonCoreBuilderError(
+                    "Container image file '{image_fname}' already exists")
+
             tar_generator = os.environ.get("LOCKBOX_TARBALL_GENERATOR", "skopeo")
             if tar_generator == "docker":
                 save_image_tarball_docker(dind_client, image_spec_new, image_fname)
@@ -973,6 +978,19 @@ def fetch_compose_target(target, repo_url, images_dir, metadata_dir,
     # Determine which images will be needed at `docker-compose up` time.
     images_selection = select_unique_images(
         image_platform_pairs, manifests_per_image, req_platforms=req_platforms)
+
+    # At this point the pairs are (image, digest) are unique but let us make
+    # sure the digests alone are also unique. If not, it means the same image is
+    # being referenced in two different ways which the code in Aktualizr would
+    # not handle correctly. Users can easily work around this corner case by
+    # always referencing an image in the same way in their compose file.
+    digests_unique = set()
+    for _spec, sel_digest in images_selection:
+        if sel_digest in digests_unique:
+            raise TorizonCoreBuilderError(
+                f"Image with digest {sel_digest} has been selected more than once"
+                " through different names which is not supported.")
+        digests_unique.add(sel_digest)
 
     # Build tarball with the images.
     docker_dir = os.path.join(images_dir, sha256 + ".images")

--- a/tcbuilder/backend/platform.py
+++ b/tcbuilder/backend/platform.py
@@ -588,7 +588,239 @@ def select_unique_images(image_platform_pairs, manifests_per_image,
     return images_selection_unique
 
 
-# pylint:disable=too-many-locals
+def _apply_skopeo_canon_wkaround(tbdir, image_spec):
+    """Apply workarounds for the Skopeo image name canonicalization
+
+    Unlike "docker save", the "skopeo copy" command canonicalizes the names of
+    the images that go inside the generated tarball. This is incompatible with
+    the validation code that runs inside Aktualizr. To deal with it we undo the
+    operation by replacing the canonical names back with the original names as
+    referenced by the compose file.
+    """
+
+    # ---
+    # Fix manifest file:
+    # ---
+    manifest_path = os.path.join(tbdir, "manifest.json")
+    if os.path.exists(manifest_path):
+        with open(manifest_path, "r") as fhandle:
+            manifest_data = json.load(fhandle)
+
+        log.debug(f"Original manifest data: {manifest_data}")
+
+        try:
+            # Manifest metadata would look like this:
+            #
+            # [{'Config': '9cad51f33b0fxxxxxxxxxxxx.json',
+            #   'RepoTags': ['docker.io/library/debian:digest_sha256_5c7562ee9fcfxxxxxxxx'],
+            #   'Layers': ['58f07f898f87xxxxxxxxxxxx.tar']}]
+            #
+            # and we want it to become:
+            #
+            # [{'Config': '9cad51f33b0fxxxxxxxxxxxx.json',
+            #   'RepoTags': [<image_spec>],
+            #   'Layers': ['58f07f898f87xxxxxxxxxxxx.tar']}]
+            #
+            assert len(manifest_data) == 1
+            assert len(manifest_data[0]["RepoTags"]) == 1
+            _tag = manifest_data[0]["RepoTags"][0]
+            assert _tag[_tag.index(":digest_"):] == image_spec[image_spec.index(":digest_"):]
+            manifest_data[0]["RepoTags"] = [image_spec]
+
+        except (KeyError, IndexError, ValueError, AssertionError) as _error:
+            raise TorizonCoreBuilderError(
+                f"Couldn't parse manifest metadata from '{tbdir}'")
+
+        log.debug(f"Transformed manifest data: {manifest_data}")
+
+        with open(manifest_path, "w") as fhandle:
+            json.dump(manifest_data, fhandle, separators=(",", ":"))
+
+    # ---
+    # Fix repositories file:
+    # ---
+    repos_path = os.path.join(tbdir, "repositories")
+    if os.path.exists(repos_path):
+        with open(repos_path, "r") as fhandle:
+            repos_data = json.load(fhandle)
+
+        log.debug(f"Original repositories data: {repos_data}")
+        try:
+            # Repositories metadata would look like this:
+            #
+            # {'docker.io/library/debian':
+            #    {'digest_sha256_5c7562ee9fcfxxxxxxxxxxxx':'a56935c728c6xxxxxxxxxxxx'}}
+            #
+            # and we want it to become:
+            #
+            # {'<image_spec (without the tag)>':
+            #    {'digest_sha256_5c7562ee9fcfxxxxxxxxxxxx':'a56935c728c6xxxxxxxxxxxx'}}
+            #
+            assert len(repos_data) == 1
+            assert len(repos_data.keys()) == 1
+            _repo, _digdict = next(iter(repos_data.items()))
+            assert len(_digdict) == 1
+            _tag, _value = next(iter(_digdict.items()))
+            assert _tag == image_spec[image_spec.index(":digest_")+1:]
+            _newrepo = image_spec[:image_spec.index(":digest")]
+            repos_data[_newrepo] = _digdict
+            del repos_data[_repo]
+
+        except (KeyError, IndexError, ValueError, AssertionError) as _error:
+            raise TorizonCoreBuilderError(
+                f"Couldn't parse repositories metadata from '{tbdir}'")
+
+        log.debug("Transformed repositories data: {repos_data}")
+
+        with open(repos_path, "w") as fhandle:
+            json.dump(repos_data, fhandle, separators=(",", ":"))
+
+
+def _apply_aktualizr_blkread_wkaround(tbdir):
+    """Workaround for bug found in image loading in Aktualizr.
+
+    Aktualizr loads Lockbox image tarballs in blocks of 256K and it performs
+    two passes over each tarball. Since the method for loading a tarball is
+    different in each pass, it has been found that sometimes there is a
+    mismatch in the apparent size of the tarball file causing the Lockbox
+    loading to fail. In particular, this happens when the tarball has a size
+    slightly above a multiple of 256K. This seems to happen because the first
+    pass uses libarchive which stops the reading preemptively without reading
+    the end of the file (which is expected to have padding bytes only) while
+    the second pass does not go through libarchive and always reads the whole
+    file.
+
+    To prevent this bug on Aktualizr from ever being hit, here we increase the
+    size of a tarball when its size is slightly above a multiple of 256K.
+    """
+
+    # Estimate tarball size:
+    tbs = 512
+    totsize = 0
+    for fname in os.listdir(tbdir):
+        path = os.path.join(tbdir, fname)
+        if os.path.isdir(path):
+            fsize = tbs
+            psize = tbs
+        else:
+            fsize = os.stat(path).st_size
+            psize = tbs + ((fsize + tbs - 1) // tbs) * tbs
+        totsize += psize
+
+    # As per Wikipedia: The end of an archive is marked by *at least* two consecutive
+    # zero-filled records. The final block of an archive is padded out to full length
+    # with zeros.
+    totsize += 2048 + 1024
+
+    log.debug(f"Estimated image tarball size for '{tbdir}': {totsize}")
+
+    # Aktualizr processes the file in blocks of 256K and we want to avoid a small block
+    # at the end to prevent a bug from showing up. For that, we add a dummy file to the
+    # tarball when the estimated size is close to a multiple of 256K.
+    procbs = 256 * 1024
+    if (totsize % procbs < 8192) or (procbs - (totsize % procbs) < 8192):
+        log.debug(f"Adding dummy file to '{tbdir}'.")
+        dummy_content = "\n" * (4 * 8192)
+        with open(os.path.join(tbdir, "xdummy_"), "w") as dummy_file:
+            dummy_file.write(dummy_content)
+    else:
+        log.debug(f"No need to add dummy file to '{tbdir}'.")
+
+
+def amend_image_tarball(image_fname, image_spec, skopeo_generated=True):
+    # Apply the workaround for Skopeo canonicalizing the image names which
+    # prevents the loading by Aktualizr since the names are validated against
+    # the docker-compose file.
+    canon_wkaround = (skopeo_generated and
+                      os.environ.get("APPLY_SKOPEO_CANON_WKAROUND", "1") == "1")
+
+    # Apply the workaround for a bug in the Docker image validation which happens if the image is
+    # slightly bigger than a multiple of the block reading size (256KB).
+    blkread_wkaround = (os.environ.get("APPLY_AKTUALIZR_BLKREAD_WKAROUND", "1") == "1")
+
+    if not (canon_wkaround or blkread_wkaround):
+        log.debug("No fixes required to the generated Lockbox tarball")
+
+    image_fname_new = image_fname + "_"
+    tbdir = os.path.splitext(image_fname)[0] + "_"
+    try:
+        # Unpack the tarball:
+        log.debug(f"Unpacking '{image_fname}' into '{tbdir}'")
+        shutil.rmtree(tbdir, ignore_errors=True)
+        os.mkdir(tbdir)
+        subprocess.check_output([
+            "tar", "--numeric-owner", "--preserve-permissions",
+            "-xvf", os.path.abspath(image_fname), "-C", tbdir
+        ])
+
+        if canon_wkaround:
+            _apply_skopeo_canon_wkaround(tbdir, image_spec)
+        if blkread_wkaround:
+            _apply_aktualizr_blkread_wkaround(tbdir)
+
+        # Repack files into a tarball:
+        log.debug(f"Repacking '{tbdir}' into '{image_fname_new}'")
+        subprocess.check_output([
+            "tar", "--numeric-owner", "--preserve-permissions",
+            "-cvf", os.path.abspath(image_fname_new), "-C", tbdir,
+            *sorted(os.listdir(tbdir))
+        ])
+
+        log.debug(f"Replacing '{image_fname_new}' -> '{image_fname}'")
+        os.replace(image_fname_new, image_fname)
+
+    finally:
+        shutil.rmtree(tbdir, ignore_errors=True)
+
+
+def save_image_tarball_docker(dind_client, image_spec, image_fname):
+    """Build tarball via `docker image save image:tag > output.tar`
+
+    :param dind_client: Docker API client object.
+    :param image_spec: Image specification such as "hello-world:latest".
+    :param image_fname: Tarball file to generate such as "/a/b/output.tar".
+    """
+    image_obj = dind_client.images.get(image_spec)
+    with open(image_fname, "wb") as outf:
+        for image_data in image_obj.save(named=True):
+            outf.write(image_data)
+
+
+def save_image_tarball_skopeo(dind_env, image_spec, image_fname):
+    """Build tarball via `skopeo copy <image> docker-archive:<file>:...`
+
+    :param dind_env: Dictionary with environment variables specifying how to
+                     access the desired Docker host.
+    :param image_spec: Image specification such as "hello-world:latest".
+    :param image_fname: Tarball file to generate such as "/a/b/output.tar".
+    """
+    cmd = ["skopeo", "copy"]
+
+    # Ensure Docker v2 Schema 2 is always used.
+    cmd += ["--format", "v2s2"]
+
+    # skopeo does not handle the usual host specification environment variables
+    # used by the Docker client CLI; here we translate them into parameters
+    # suitable for the program:
+    if dind_env.get("DOCKER_HOST"):
+        cmd += ["--src-daemon-host", dind_env["DOCKER_HOST"]]
+    if dind_env.get("DOCKER_CERT_PATH"):
+        cmd += ["--src-cert-dir", dind_env["DOCKER_CERT_PATH"]]
+    if dind_env.get("DOCKER_TLS_VERIFY"):
+        # Any non-empty string enables TLS (following Docker's behavior).
+        cmd += ["--src-tls-verify"]
+
+    cmd += [f"docker-daemon:{image_spec}",
+            f"docker-archive:{image_fname}:{image_spec}"]
+
+    res = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    if res.returncode != 0:
+        log.error(res.stderr)
+        raise TorizonCoreBuilderError(
+            f"Error: failed to generate image tarball via skopeo for '{image_fname}'.")
+
+
+# pylint: disable=too-many-locals,too-many-statements
 def build_docker_tarballs(unique_images, target_dir, host_workdir,
                           verbose=True, dind_params=None, dind_env=None):
     """Build the docker tarballs of a lockbox image
@@ -624,6 +856,7 @@ def build_docker_tarballs(unique_images, target_dir, host_workdir,
         manager.add_cacerts(cacerts)
         # Get DinD client to be used on the pulling operations.
         dind_client = manager.get_client()
+        dind_client_env = manager.get_client_env()
         if dind_client is None:
             return None
         # Login to all registries before trying to fetch anything.
@@ -657,14 +890,24 @@ def build_docker_tarballs(unique_images, target_dir, host_workdir,
             image_spec_new = f"{image_spec_parts[0]}:{image_spec_tag}"
             image_obj = dind_client.images.get(image_spec_new)
 
-            # Build tarball via `docker image save image:tag > output.tar`:
+            # Name tarball after the image digest:
             image_fname = image_digest[len(SHA256_PREFIX):] + ".tar"
             image_fname = os.path.join(target_dir, image_fname)
+
             log.info(f"Saving {image_spec}\n"
                      f"  into {image_fname}")
-            with open(image_fname, "wb") as outf:
-                for image_data in image_obj.save(named=True):
-                    outf.write(image_data)
+
+            tar_generator = os.environ.get("LOCKBOX_TARBALL_GENERATOR", "skopeo")
+            if tar_generator == "docker":
+                save_image_tarball_docker(dind_client, image_spec_new, image_fname)
+                amend_image_tarball(image_fname, image_spec_new, skopeo_generated=False)
+            elif tar_generator == "skopeo":
+                save_image_tarball_skopeo(dind_client_env, image_spec_new, image_fname)
+                amend_image_tarball(image_fname, image_spec_new, skopeo_generated=True)
+            else:
+                raise TorizonCoreBuilderError(
+                    "Unknown generator set through variable LOCKBOX_TARBALL_GENERATOR "
+                    f"({tar_generator})")
 
             tarballs.append({
                 "image_spec": image_spec,
@@ -690,7 +933,7 @@ def build_docker_tarballs(unique_images, target_dir, host_workdir,
             log.info(f" * image:  {tarball['image_spec']}")
 
     return tarballs
-# pylint:enable=too-many-locals
+# pylint: enable=too-many-locals,too-many-statements
 
 
 # pylint: disable=too-many-arguments,too-many-locals

--- a/tests/integration/samples/push/lockbox/README.md
+++ b/tests/integration/samples/push/lockbox/README.md
@@ -1,0 +1,27 @@
+# Overview
+
+This directory contains compose files used for testing Lockbox generation with
+TorizonCore Builder.
+
+Currently, the tests assume that these files have been previously pushed and the
+corresponding Lockboxes have been created on the platform.
+
+The names of the Lockboxes follow the pattern:
+
+`lockbox-with-<compose-name-without-extension>`
+
+where the `<compose-name-without-extension>` is the name of a canonical package
+on the platform. For example, the file `docker-compose-lkbx-32bit.yml` would be
+pushed to the plaform in canonical form with the name
+`docker-compose-lkbx-32bit.lock.yml` and that file should be included in the
+Lockbox named `lockbox-with-docker-compose-lkbx-32bit`.
+
+To push all compose files in the current folder one can run:
+
+```
+$ . <path-to-tcb-env-setup-script>
+$ . push-lockbox-compose-files.sh <credentials-file-for-account>
+```
+
+After that, one can create the corresponding Lockboxes, which currently must be
+done manually through the platform web UI.

--- a/tests/integration/samples/push/lockbox/docker-compose-lkbx-32bit.yml
+++ b/tests/integration/samples/push/lockbox/docker-compose-lkbx-32bit.yml
@@ -1,0 +1,11 @@
+# All images referenced are single platform 32-bit.
+services:
+  svc1-docker:
+    # Docker, single-platform (linux/arm/v7), no manifest list.
+    image: torizon/manifest-test-armv7-vnddck
+  svc1-oci:
+    # OCI, single-platform (linux/arm/v7), no OCI image index.
+    image: torizon/manifest-test-armv7-vndoci
+  svc1-oci-prov:
+    # OCI, single-platform (linux/arm/v7), provenance enabled.
+    image: torizon/manifest-test-armv7-vndoci-prov

--- a/tests/integration/samples/push/lockbox/docker-compose-lkbx-64bit.yml
+++ b/tests/integration/samples/push/lockbox/docker-compose-lkbx-64bit.yml
@@ -1,0 +1,12 @@
+# All images referenced are single platform 64-bit.
+services:
+  svc2-docker:
+    # Docker, single-platform (linux/arm64/v8), no manifest list.
+    image: torizon/manifest-test-arm64v8-vnddck
+  svc2-oci:
+    # OCI, single-platform (linux/arm64/v8), no OCI image index.
+    image: torizon/manifest-test-arm64v8-vndoci
+    platform: linux/arm
+  svc2-oci-prov:
+    # OCI, single-platform (linux/arm64/v8), provenance enabled.
+    image: torizon/manifest-test-arm64v8-vndoci-prov

--- a/tests/integration/samples/push/lockbox/docker-compose-lkbx-badmix.yml
+++ b/tests/integration/samples/push/lockbox/docker-compose-lkbx-badmix.yml
@@ -1,0 +1,8 @@
+# Refer to the same image directly and indirectly which is not currently supported.
+services:
+  svc2-docker:
+    # Docker, single-platform (linux/arm64/v8), no manifest list.
+    image: torizon/manifest-test-arm64v8-vnddck
+  svc3-docker:
+    # Docker, multi-platform, with a manifest list.
+    image: torizon/manifest-test-multi-vnddck-manlst

--- a/tests/integration/samples/push/lockbox/docker-compose-lkbx-big-64bit.yml
+++ b/tests/integration/samples/push/lockbox/docker-compose-lkbx-big-64bit.yml
@@ -1,0 +1,32 @@
+services:
+  svc1:
+    # Global namespace / no tag.
+    image: alpine
+  svc2:
+    # Global namespace / with tag.
+    image: debian:bullseye-slim
+  svc3:
+    # Global namespace / with digest.
+    image: hello-world@sha256:6e8b6f026e0b9c419ea0fd02d3905dd0952ad1feea67543f525c73a0a790fefb
+  svc4:
+    # Global namespace / with tag+digest.
+    image: hello-world:dummytag@sha256:6e8b6f026e0b9c419ea0fd02d3905dd0952ad1feea67543f525c73a0a790fefb
+  svc5:
+    # Inside namespace / with tag.
+    image: torizon/debian:2-bullseye
+  svc6:
+    # Inside namespace / with digest.
+    image: torizon/weston@sha256:bb9ac09f69a1480a981a3862ec9efcfd8eb2c157777ad7d41dfd51e7bb367b4b
+  svc7:
+    # Inside namespace / with tag+digest.
+    image: torizon/weston:4@sha256:bb9ac09f69a1480a981a3862ec9efcfd8eb2c157777ad7d41dfd51e7bb367b4b
+  svc8:
+    # Docker, multi-platform, with a manifest list.
+    image: torizon/manifest-test-multi-vnddck-manlst
+  svc9:
+    # OCI, multi-platform, with an OCI image index.
+    image: torizon/manifest-test-multi-vndoci-imgidx
+    platform: linux/arm64
+  svc10:
+    # OCI, multi-platform, provenance enabled.
+    image: torizon/manifest-test-multi-vndoci-imgidx-prov

--- a/tests/integration/samples/push/lockbox/docker-compose-lkbx-mixed-mp32bit.yml
+++ b/tests/integration/samples/push/lockbox/docker-compose-lkbx-mixed-mp32bit.yml
@@ -1,0 +1,11 @@
+# Mix multiplatform and single-platform images targeting a 32-bit device.
+services:
+  svc1-docker:
+    # Docker, single-platform (linux/arm/v7), no manifest list.
+    image: torizon/manifest-test-armv7-vnddck
+  svc3-oci:
+    # OCI, multi-platform, with an OCI image index.
+    image: torizon/manifest-test-multi-vndoci-imgidx
+  svc1-oci-prov:
+    # OCI, single-platform (linux/arm/v7), provenance enabled.
+    image: torizon/manifest-test-armv7-vndoci-prov

--- a/tests/integration/samples/push/lockbox/docker-compose-lkbx-mutiplat.yml
+++ b/tests/integration/samples/push/lockbox/docker-compose-lkbx-mutiplat.yml
@@ -1,0 +1,12 @@
+# All images referenced are multi-platform.
+services:
+  svc3-docker:
+    # Docker, multi-platform, with a manifest list.
+    image: torizon/manifest-test-multi-vnddck-manlst
+  svc3-oci:
+    # OCI, multi-platform, with an OCI image index.
+    image: torizon/manifest-test-multi-vndoci-imgidx
+    platform: linux/arm64
+  svc3-oci-prov:
+    # OCI, multi-platform, provenance enabled.
+    image: torizon/manifest-test-multi-vndoci-imgidx-prov

--- a/tests/integration/samples/push/lockbox/docker-compose-lkbx-regaccess-auth.yml.in
+++ b/tests/integration/samples/push/lockbox/docker-compose-lkbx-regaccess-auth.yml.in
@@ -1,0 +1,3 @@
+services:
+  test2:
+    image: @SR_WITH_AUTH_IP@/test1@sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4

--- a/tests/integration/samples/push/lockbox/docker-compose-lkbx-regaccess-dh.yml.in
+++ b/tests/integration/samples/push/lockbox/docker-compose-lkbx-regaccess-dh.yml.in
@@ -1,0 +1,3 @@
+services:
+  hello-world:
+    image: hello-world@sha256:e18f0a777aefabe047a671ab3ec3eed05414477c951ab1a6f352a06974245fe7

--- a/tests/integration/samples/push/lockbox/docker-compose-lkbx-regaccess-err.yml.in
+++ b/tests/integration/samples/push/lockbox/docker-compose-lkbx-regaccess-err.yml.in
@@ -1,0 +1,11 @@
+services:
+  hello-world:
+    image: hello-world@sha256:e18f0a777aefabe047a671ab3ec3eed05414477c951ab1a6f352a06974245fe7
+  test1:
+    image: @SR_NO_AUTH_IP@/test1@sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4
+  test2:
+    image: @SR_WITH_AUTH_IP@/test1@sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4
+  test3:
+    image: @SR_NO_AUTH_IP@/test2@sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4
+  test4:
+    image: @SR_WITH_AUTH_IP@/test2@sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4

--- a/tests/integration/samples/push/lockbox/docker-compose-lkbx-regaccess-noauth.yml.in
+++ b/tests/integration/samples/push/lockbox/docker-compose-lkbx-regaccess-noauth.yml.in
@@ -1,0 +1,3 @@
+services:
+  test1:
+    image: @SR_NO_AUTH_IP@/test1@sha256:f54a58bc1aac5ea1a25d796ae155dc228b3f0e11d046ae276b39c4bf2f13d8c4

--- a/tests/integration/samples/push/lockbox/push-lockbox-compose-files.sh
+++ b/tests/integration/samples/push/lockbox/push-lockbox-compose-files.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+if [ "$#" != 1 ]; then
+    echo "Usage: push-lockbox-compose-files.sh <credentials.zip>"
+    echo "Note: The present script must be sourced."
+    return 1
+fi
+
+if ! [[ "$(type -t torizoncore-builder)" == @("alias"|"function") ]]; then
+    echo "Please source the torizoncore-builder environment setup script first." >&2
+    return 1
+fi
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+. "${SCRIPT_DIR}/../../../testcases/lib/registries.sh"
+
+_tcb() {
+    local cmd=$(alias torizoncore-builder |
+                    sed -ne "s/^.*torizoncore-builder='\(.*\)'$/\1/p")
+    echo ">> torizoncore-builder $*"
+    eval ${cmd} "$@"
+}
+
+_TCB_CREDENTIALS="${1?credentials file name must be passed}"
+_TCB_COMPOSE_FILES="
+    docker-compose-lkbx-32bit.yml
+    docker-compose-lkbx-64bit.yml 
+    docker-compose-lkbx-badmix.yml
+    docker-compose-lkbx-mixed-mp32bit.yml
+    docker-compose-lkbx-mutiplat.yml
+    docker-compose-lkbx-regaccess.yml.in
+    docker-compose-lkbx-regaccess-dh.yml.in
+    docker-compose-lkbx-regaccess-noauth.yml.in
+    docker-compose-lkbx-regaccess-auth.yml.in
+    docker-compose-lkbx-regaccess-err.yml.in
+"
+
+for _tcb_cf in ${_TCB_COMPOSE_FILES}; do
+    if [ "${_tcb_cf##*.}" == "in" ]; then
+        # File needs pre-processing before pushing:
+        cp "${_tcb_cf}" "${_tcb_cf%.*}"
+        _tcb_cf="${_tcb_cf%.*}"
+
+        sed -e "s/@SR_NO_AUTH_IP@/${SR_NO_AUTH_IP}/" -i "${_tcb_cf}"
+        sed -e "s/@SR_WITH_AUTH_IP@/${SR_WITH_AUTH_IP}/" -i "${_tcb_cf}"
+
+        #cat "${_tcb_cf}"
+        _tcb platform push "${_tcb_cf}" --canonicalize --credentials "${_TCB_CREDENTIALS}"
+
+        rm "${_tcb_cf}"
+    else
+        _tcb platform push "${_tcb_cf}" --canonicalize --credentials "${_TCB_CREDENTIALS}"
+    fi
+done

--- a/tests/integration/testcases/platform.bats
+++ b/tests/integration/testcases/platform.bats
@@ -554,47 +554,132 @@ test_canonicalize_only_success() {
 @test "platform lockbox: test advanced registry access" {
     skip-no-ota-credentials
     local ci_dockerhub_login="$(ci-dockerhub-login-flag)"
-
     local CREDS_PROD_ZIP=$(decrypt-credentials-file "$SAMPLES_DIR/credentials/credentials-prod.zip.enc")
 
     run check-registries
     assert_success
 
+    # Consider populating the registry with images with different hashes and
+    # making a compose file + Lockbox referencing them. For now we have various
+    # compose files each one testing a different use case of registry access,
+    # but not all of them at the same time.
+    # run torizoncore-builder platform lockbox \
+    #     --credentials "${CREDS_PROD_ZIP}"  \
+    #     --cacert-to "${SR_NO_AUTH_IP}" "${SR_NO_AUTH_CERTS}/cacert.crt" \
+    #     --login-to "${SR_WITH_AUTH_IP}" toradex test \
+    #     --cacert-to "${SR_WITH_AUTH_IP}" "${SR_WITH_AUTH_CERTS}/cacert.crt" \
+    #     --force lockbox-with-docker-compose-lkbx-regaccess \
+    #     ${ci_dockerhub_login:+"--login" "${CI_DOCKER_HUB_PULL_USER}"
+    #                                     "${CI_DOCKER_HUB_PULL_PASSWORD}"}
+    # assert_success
+
+    run torizoncore-builder platform lockbox \
+        --credentials "${CREDS_PROD_ZIP}"  \
+        --force lockbox-with-docker-compose-lkbx-regaccess-dh \
+        ${ci_dockerhub_login:+"--login" "${CI_DOCKER_HUB_PULL_USER}"
+                                        "${CI_DOCKER_HUB_PULL_PASSWORD}"}
+    assert_success
+
     run torizoncore-builder platform lockbox \
         --credentials "${CREDS_PROD_ZIP}"  \
         --cacert-to "${SR_NO_AUTH_IP}" "${SR_NO_AUTH_CERTS}/cacert.crt" \
+        --force lockbox-with-docker-compose-lkbx-regaccess-noauth \
+        ${ci_dockerhub_login:+"--login" "${CI_DOCKER_HUB_PULL_USER}"
+                                        "${CI_DOCKER_HUB_PULL_PASSWORD}"}
+    assert_success
+
+    run torizoncore-builder platform lockbox \
+        --credentials "${CREDS_PROD_ZIP}"  \
         --login-to "${SR_WITH_AUTH_IP}" toradex test \
         --cacert-to "${SR_WITH_AUTH_IP}" "${SR_WITH_AUTH_CERTS}/cacert.crt" \
-        --force LockBox-Test \
+        --force lockbox-with-docker-compose-lkbx-regaccess-auth \
         ${ci_dockerhub_login:+"--login" "${CI_DOCKER_HUB_PULL_USER}"
-                           "${CI_DOCKER_HUB_PULL_PASSWORD}"}
+                                        "${CI_DOCKER_HUB_PULL_PASSWORD}"}
     assert_success
+
+    run torizoncore-builder platform lockbox \
+        --credentials "${CREDS_PROD_ZIP}"  \
+        --login-to "${SR_WITH_AUTH_IP}" toradex test \
+        --cacert-to "${SR_WITH_AUTH_IP}" "${SR_WITH_AUTH_CERTS}/cacert.crt" \
+        --cacert-to "${SR_NO_AUTH_IP}" "${SR_NO_AUTH_CERTS}/cacert.crt" \
+        --force lockbox-with-docker-compose-lkbx-regaccess-err \
+        ${ci_dockerhub_login:+"--login" "${CI_DOCKER_HUB_PULL_USER}"
+                                        "${CI_DOCKER_HUB_PULL_PASSWORD}"}
+    assert_failure
+    assert_output --regexp "${SR_NO_AUTH_IP}/test1@sha256"
+    assert_output --regexp "${SR_NO_AUTH_IP}/test2@sha256"
+    assert_output --regexp "${SR_WITH_AUTH_IP}/test1@sha256"
+    assert_output --regexp "${SR_WITH_AUTH_IP}/test2@sha256"
 }
 
-@test "platform lockbox: generate lockbox with OCI and non-OCI images" {
+@test "platform lockbox: generate lockbox from 32-bit Docker+OCI images" {
     skip-no-ota-credentials
-
     local CREDS_PROD_ZIP=$(decrypt-credentials-file "$SAMPLES_DIR/credentials/credentials-prod.zip.enc")
 
     # TODO: Consider generating the Lockbox as part of the test with the new platform API.
     run torizoncore-builder platform lockbox \
         --credentials "${CREDS_PROD_ZIP}" --platform linux/arm/v7 \
-        --force LockBox-With-OCI-32bit-Images \
-        ${CI_DOCKER_HUB_PULL_USER:+"--login" "${CI_DOCKER_HUB_PULL_USER}"
-                                             "${CI_DOCKER_HUB_PULL_PASSWORD}"}
-    assert_success
-
-    run torizoncore-builder platform lockbox \
-        --credentials "${CREDS_PROD_ZIP}" --platform linux/arm64 \
-        --force LockBox-With-OCI-64bit-Images \
+        --force lockbox-with-docker-compose-lkbx-32bit \
         ${CI_DOCKER_HUB_PULL_USER:+"--login" "${CI_DOCKER_HUB_PULL_USER}"
                                              "${CI_DOCKER_HUB_PULL_PASSWORD}"}
     assert_success
 }
 
+@test "platform lockbox: generate lockbox from 64-bit Docker+OCI images" {
+    skip-no-ota-credentials
+    local CREDS_PROD_ZIP=$(decrypt-credentials-file "$SAMPLES_DIR/credentials/credentials-prod.zip.enc")
+
+    # TODO: Consider generating the Lockbox as part of the test with the new platform API.
+    run torizoncore-builder platform lockbox \
+        --credentials "${CREDS_PROD_ZIP}" --platform linux/arm64 \
+        --force lockbox-with-docker-compose-lkbx-64bit \
+        ${CI_DOCKER_HUB_PULL_USER:+"--login" "${CI_DOCKER_HUB_PULL_USER}"
+                                             "${CI_DOCKER_HUB_PULL_PASSWORD}"}
+    assert_success
+}
+
+@test "platform lockbox: generate lockbox from mixed single/multi-platform Docker+OCI images" {
+    skip-no-ota-credentials
+    local CREDS_PROD_ZIP=$(decrypt-credentials-file "$SAMPLES_DIR/credentials/credentials-prod.zip.enc")
+
+    # TODO: Consider generating the Lockbox as part of the test with the new platform API.
+    run torizoncore-builder platform lockbox \
+        --credentials "${CREDS_PROD_ZIP}" --platform linux/arm/v7 \
+        --force lockbox-with-docker-compose-lkbx-mixed-mp32bit \
+        ${CI_DOCKER_HUB_PULL_USER:+"--login" "${CI_DOCKER_HUB_PULL_USER}"
+                                             "${CI_DOCKER_HUB_PULL_PASSWORD}"}
+    assert_success
+}
+
+@test "platform lockbox: generate lockbox from multi-platform Docker+OCI images" {
+    skip-no-ota-credentials
+    local CREDS_PROD_ZIP=$(decrypt-credentials-file "$SAMPLES_DIR/credentials/credentials-prod.zip.enc")
+
+    # TODO: Consider generating the Lockbox as part of the test with the new platform API.
+    run torizoncore-builder platform lockbox \
+        --credentials "${CREDS_PROD_ZIP}" --platform linux/arm64 \
+        --force lockbox-with-docker-compose-lkbx-mutiplat \
+        ${CI_DOCKER_HUB_PULL_USER:+"--login" "${CI_DOCKER_HUB_PULL_USER}"
+                                             "${CI_DOCKER_HUB_PULL_PASSWORD}"}
+    assert_success
+}
+
+@test "platform lockbox: fail when referencing same image by different names" {
+    skip-no-ota-credentials
+    local CREDS_PROD_ZIP=$(decrypt-credentials-file "$SAMPLES_DIR/credentials/credentials-prod.zip.enc")
+
+    # TODO: Consider generating the Lockbox as part of the test with the new platform API.
+    run torizoncore-builder platform lockbox \
+        --credentials "${CREDS_PROD_ZIP}" \
+        --force lockbox-with-docker-compose-lkbx-badmix \
+        ${CI_DOCKER_HUB_PULL_USER:+"--login" "${CI_DOCKER_HUB_PULL_USER}"
+                                             "${CI_DOCKER_HUB_PULL_PASSWORD}"}
+    assert_failure
+    assert_output --regexp "has been selected more than once through different names"
+}
+
 @test "platform lockbox: check --dind-param parameter" {
     skip-no-ota-credentials
-
     local CREDS_PROD_ZIP=$(decrypt-credentials-file "$SAMPLES_DIR/credentials/credentials-prod.zip.enc")
 
     # TODO: Consider generating the Lockbox as part of the test with the new platform API.
@@ -603,7 +688,7 @@ test_canonicalize_only_success() {
         --\
         platform lockbox \
         --credentials "${CREDS_PROD_ZIP}" --platform linux/arm/v7 \
-        --force LockBox-With-OCI-32bit-Images \
+        --force lockbox-with-docker-compose-lkbx-32bit \
         --dind-param="--invalid-param" \
         ${CI_DOCKER_HUB_PULL_USER:+"--login" "${CI_DOCKER_HUB_PULL_USER}"
                                              "${CI_DOCKER_HUB_PULL_PASSWORD}"}
@@ -613,7 +698,6 @@ test_canonicalize_only_success() {
 
 @test "platform lockbox: check --dind-env parameter" {
     skip-no-ota-credentials
-
     local CREDS_PROD_ZIP=$(decrypt-credentials-file "$SAMPLES_DIR/credentials/credentials-prod.zip.enc")
 
     # TODO: Consider generating the Lockbox as part of the test with the new platform API.
@@ -622,7 +706,7 @@ test_canonicalize_only_success() {
         --\
         platform lockbox \
         --credentials "${CREDS_PROD_ZIP}" --platform linux/arm/v7 \
-        --force LockBox-With-OCI-32bit-Images \
+        --force lockbox-with-docker-compose-lkbx-32bit \
         --dind-env "HTTP_PROXY=http://localhost:33456" \
         --dind-env "HTTPS_PROXY=http://localhost:33456" \
         ${CI_DOCKER_HUB_PULL_USER:+"--login" "${CI_DOCKER_HUB_PULL_USER}"

--- a/torizoncore-builder.Dockerfile
+++ b/torizoncore-builder.Dockerfile
@@ -75,13 +75,50 @@ RUN cd aktualizr && \
     tar cjvf aktualizr.tar.bz2 \
         --show-transformed-names --transform="s,^install-dir,," install-dir/
 
+# Build skopeo
+FROM common-base AS skopeo-builder
+
+RUN apt-get -q -y update && \
+    apt-get -q -y --no-install-recommends install git ca-certificates wget && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /root
+
+RUN echo "Installing Go..." && \
+    wget https://go.dev/dl/go1.24.3.linux-amd64.tar.gz && \
+    rm -rf /usr/local/go && \
+    tar -C /usr/local -xzf go1.24.3.linux-amd64.tar.gz && \
+    rm go1.24.3.linux-amd64.tar.gz
+
+ENV PATH=/usr/local/go/bin:$PATH
+ENV GOPATH=/root/go
+
+RUN echo "Installing skopeo build dependencies..." && \
+    apt-get -q -y update && \
+    apt-get -q -y --no-install-recommends install \
+            libgpgme-dev libassuan-dev libbtrfs-dev pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN echo "Fetching skopeo source code..." && \
+    git clone --depth 1 --branch v1.19.0 \
+        https://github.com/containers/skopeo ${GOPATH}/src/github.com/containers/skopeo
+
+# hadolint ignore=SC2046
+RUN echo "Building skopeo..." && \
+    cd ${GOPATH}/src/github.com/containers/skopeo && \
+    B="$(pwd)" && D="${B}/install-dir" && \
+    make clean && \
+    make EXTRA_LDFLAGS="-w -s" bin/skopeo && \
+    make EXTRA_LDFLAGS="-w -s" DESTDIR="${D}" DISABLE_DOCS="1" install && \
+    tar cjvf /root/skopeo.tar.bz2 -C "${D}" $(cd "${D}" && echo *)
+
 FROM common-base AS tcbuilder-base
 
 RUN apt-get -q -y update && \
     apt-get -q -y --no-install-recommends install \
             python3 python3-pip python3-setuptools python3-wheel python3-gi \
             file curl gzip xz-utils lz4 lzop zstd cpio jq acl libmpc-dev \
-            device-tree-compiler cpp  bzip2 flex bison kmod libgmp3-dev bc && \
+            device-tree-compiler cpp bzip2 flex bison kmod libgmp3-dev bc && \
     apt-get -q -y --no-install-recommends install \
             python3-paramiko python3-dnspython python3-ifaddr \
             python3-git avahi-daemon && \
@@ -112,11 +149,19 @@ RUN apt-get -q -y update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install aktualizr from our sota-builder generated tarball
-RUN --mount=type=bind,from=sota-builder,source=/root/aktualizr/build,target=/build \
-    tar xvf /build/aktualizr.tar.bz2 -C / && ldconfig -v && \
+RUN --mount=type=bind,from=sota-builder,source=/root/aktualizr/build,target=/build/aktualizr \
+    tar xvf /build/aktualizr/aktualizr.tar.bz2 -C / && ldconfig -v && \
     apt-get -q -y update && \
     apt-get -q -y --no-install-recommends install \
             libboost-log1.74.0 libboost-program-options1.74.0 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install the skopeo tool from our skopeo-builder generated tarball
+RUN --mount=type=bind,from=skopeo-builder,source=/root,target=/build/skopeo \
+    tar xvf /build/skopeo/skopeo.tar.bz2 -C / && ldconfig -v && \
+    apt-get -q -y update && \
+    apt-get -q -y --no-install-recommends install \
+            libgpgme11 libassuan0 libbtrfs0 pkg-config && \
     rm -rf /var/lib/apt/lists/*
 
 # Debian has old version of docker and docker-compose, which does not support some of


### PR DESCRIPTION
Switch to `skopeo` to generate the Docker tarballs that go into a Lockbox. Also, introduce a couple of related improvements and upgrade the DinD version used by TorizonCore Builder.

For more detail, please refer to the individual commit messages.

The following tests have been done manually since they are not covered by our current CI tests:

- Build Lockboxes with different versions of DinD (19.03.8, 20.10.24, 23.0.6, 25.0.3) and install then into a device running Torizon OS 6.8.2 and 7.2.0. All combinations have been tested to make sure we can suggest users to use a different version in case they ever bump into compatibility issues.
- Build Torizon OS with bundled containers and install on a device, with all combinations above.

Related-to: TCB-692
