### PR TITLE
Fix local tests using get_tezi_images script

### DIFF
--- a/tests/integration/get_tezi_images.sh
+++ b/tests/integration/get_tezi_images.sh
@@ -4,6 +4,11 @@
 OUTDIR="$PWD/workdir/images"
 STAMP="$OUTDIR/.images_downloaded"
 
+# CONFIGME: uncomment for nightly images
+#TARGET_BUILD_TYPE="nightly"
+#YOCTO_BRANCH="scarthgap-7.x.y"
+#TCB_MACHINE="colibri-imx6"
+
 prepare() {
     rm -rf workdir/images
     mkdir -p "$OUTDIR"

--- a/tests/integration/get_tezi_images.sh
+++ b/tests/integration/get_tezi_images.sh
@@ -12,6 +12,21 @@ STAMP="$OUTDIR/.images_downloaded"
 prepare() {
     rm -rf workdir/images
     mkdir -p "$OUTDIR"
+
+    if [ -z "$TARGET_BUILD_TYPE" ]; then
+        echo "TARGET_BUILD_TYPE is empty. Check the CONFIGME section in the script."
+        exit 1
+    fi
+
+    if [ -z "$YOCTO_BRANCH" ]; then
+        echo "YOCTO_BRANCH is empty. Check the CONFIGME section in the script."
+        exit 1
+    fi
+
+    if [ -z "$TCB_MACHINE" ]; then
+        echo "TCB_MACHINE is empty. Check the CONFIGME section in the script."
+        exit 1
+    fi
 }
 
 download() {


### PR DESCRIPTION
Last change broke the local tests. Also the CONFIGME section is mentioned in the current documentation, but was remove in the same commit.

This change add the CONFIGME section again and also a check with verbose messages regarding the required environment variables to run the script get_tezi_images.sh.