### PR TITLE
Use all cores to store container bundle

### DIFF
--- a/tcbuilder/backend/bundle.py
+++ b/tcbuilder/backend/bundle.py
@@ -39,7 +39,7 @@ def get_compression_command(output_file):
     output_file_tar = output_file
     if output_file.endswith(".xz"):
         output_file_tar = output_file[:-3]
-        command = ["xz", "-3", "-z", output_file_tar]
+        command = ["xz", "-T0", "-3", "-z", output_file_tar]
     elif output_file.endswith(".gz"):
         output_file_tar = output_file[:-3]
         command = ["gzip", output_file_tar]


### PR DESCRIPTION
By adding the -T0 option to the xz compression command I was able to get my build time of the whole image down from 8 minutes to 4 minutes. 

Signed-off-by: Lovro Oreskovic <lovro@oreskovic.me>