### PR TITLE
tests/integration: Fail job if any test fails

### DIFF
--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -234,18 +234,22 @@ if [ "$TCB_REPORT" = "1" ]; then
         BATS_CMD="$BATS_CMD --report-formatter junit --output $REPORT_DIR"
         echo "Running in CI with JUnit formatter..."
         $BATS_CMD
+        EXIT_CODE_TESTS=$?
         mv "$REPORT_DIR/report.xml" "$REPORT_DIR/report-${CI_JOB_NAME}.xml"
         echo "Test report available in $REPORT_DIR/report-${CI_JOB_NAME}.xml"
     else
         echo "Running locally with tee to save report..."
         $BATS_CMD 2>&1 | tee "$REPORT_FILE"
+        EXIT_CODE_TESTS=$?
         echo "Test report available in $REPORT_FILE"
     fi
 else
     echo "Running without report..."
     $BATS_CMD
+    EXIT_CODE_TESTS=$?
 fi
 
 # end tests
 echo "Integration tests finished!"
 cd $BASE_DIR
+exit $EXIT_CODE_TESTS


### PR DESCRIPTION
After JUnit integration in TCB, the test behavior changed: if the tests reach the end, the job is considered successful.
As a result, even if some TCB tests fail, the pipeline may still pass.

This can be confusing for maintainers and makes it unclear when a test has actually failed. This commit changes the behavior so that the job fails if any TCB test fails.