### PR TITLE
tests/integration: Enable loading bar when using get_tezi_images locally

### DIFF
--- a/tests/integration/get_tezi_images.sh
+++ b/tests/integration/get_tezi_images.sh
@@ -59,7 +59,13 @@ download() {
                 sort -r | head -n1)
     torizon_tar_url="$torizon_tar_url/$filename"
 
-    wget --no-verbose -P workdir/images "$torizon_tar_url"
+    # The loading bar of wget is dynamically rendered using terminal control characters,
+    # this breaks the logs. So, disable the loading bar in CI
+    if [ "$TCB_UNDER_CI" = "1" ]; then
+        wget --no-verbose -P workdir/images "$torizon_tar_url"
+    else
+        wget -P workdir/images "$torizon_tar_url"
+    fi
 }
 
 main() {


### PR DESCRIPTION
This loading bar was disabled because it is dynamically rendered using terminal control characters, that break CI logs.
However, this loading bar is usefull when running this locally. This commit adds a condition that keep this verbosity when running locally and disable when running in CI.