### PR TITLE
gitlab-ci: Disable linter jobs on Jenkins pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,6 +72,10 @@ stages:
 
 lint-dockerfiles:
   stage: pre-build
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "trigger"
+      when: never
+    - when: on_success
   image: hadolint/hadolint:latest-debian
   script:
     # Some rules cannot be applied in our specific cases.
@@ -87,6 +91,10 @@ lint-dockerfiles:
 
 lint-python:
   stage: pre-build
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "trigger"
+      when: never
+    - when: on_success
   script:
     # Refresh a cached image with pylint and all employed libraries.
     - ${T} docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"


### PR DESCRIPTION
The pipelines triggered by Jenkins are purely for integration purposes, aiming to identify new bugs in the torizoncore-builder when new versions of Torizon are released. They do not contain any changes to the torizoncore-builder code. Therefore, since there are no code changes, it doesn't make sense to run the linter in these pipelines, as it would be just a waste of resources. This commit adds a rule that disable linter pipelines when the source is a trigger token.