### PR TITLE
tests/integration: Fix zeroconf test failing in test-torizoncore job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -315,7 +315,7 @@ test-torizoncore-common-intel:
     IS_WIC: true
   extends: .test-base
   script:
-    - TCB_SKIP_PULL=1 ./setup.sh
+    - TCB_SKIP_PULL=1 source ./setup.sh
     # TODO: Switch to Bash and use tcb-env-setup.sh script later
     - export TCBCMD="docker run --rm -v /deploy -v $(pwd)/workdir:/workdir -v storage:/storage --net=host -v /var/run/docker.sock:/var/run/docker.sock ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
     # prepare image
@@ -336,7 +336,7 @@ test-torizoncore-common-rasp4:
   extends: .test-base
   script:
     # TODO: Since this creates a sub-shell, the environment variables created in setup.sh aren't persisting, because of this 'export TCBCMD' is required
-    - TCB_SKIP_PULL=1 ./setup.sh
+    - TCB_SKIP_PULL=1 source ./setup.sh
     # TODO: Switch to Bash and use tcb-env-setup.sh script later
     - export TCBCMD="docker run --rm -v /deploy -v $(pwd)/workdir:/workdir -v storage:/storage --net=host -v /var/run/docker.sock:/var/run/docker.sock ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
     # prepare image
@@ -362,7 +362,7 @@ test-torizoncore:
       when: never
     - if: $BUILD_MACHINE
   script:
-    - TCB_SKIP_PULL=1 ./setup.sh
+    - TCB_SKIP_PULL=1 source ./setup.sh
     # TODO: Switch to Bash and use tcb-env-setup.sh script later
     - export TCBCMD="docker run --rm -v /deploy -v $(pwd)/workdir:/workdir -v storage:/storage --net=host -v /var/run/docker.sock:/var/run/docker.sock ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
     - if [ -z ${INTERNAL_ARTIFACTORY_URL} ]; then echo "Missing variable INTERNAL_ARTIFACTORY_URL." && exit 1; fi


### PR DESCRIPTION
The 'images serve: check zeroconf tezi service response.' test was failing because the docker command running 'images serve' contained the '--net=' parameter, instead of the expected '--net=tcb_network'. This happened because the environment variable TCB_BG_ALT_NETWORK, which should have been interpreted and included in '--net', was not defined in this zeroconf test of 'test-torizoncore' job.

The root cause was that this variable is exported in 'setup.sh', and in the CI it was being run as './setup.sh'. Running it this way, the value of TCB_BG_ALT_NETWORK did not persist to the later test steps.

To fix this, this commit changes the setup step to use 'source ./setup.sh', ensuring that the environment variables defined in the setup persist for subsequent steps. Additionally, to avoid similar issues in the future, this change is applied not only to the 'test-torizoncore' job that was failing, but also to 'test-torizoncore-common-intel' and 'test-torizoncore-common-rasp4' jobs, aiming to standardize the tests and prevent future issues.