### PR TITLE
gitlab-ci: Add Slack report in pipelines triggered by GitLab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,6 +65,7 @@ stages:
   - deploy
   - deploy-multiarch
   - tag
+  - post
 
 lint-dockerfiles:
   stage: pre-build
@@ -842,24 +843,8 @@ tag-int:
     - export GIT_TAGS_CHECK=""
     - export GIT_TAGS="${MAJOR}.${MINOR}.${PATCH}-int-${DATE}"
 
-on-custom-test-error:
-  stage: .post
-  when: on_failure
-  rules:
-    # Following condition is needed to avoid the execution of merge-request pipelines.
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
-      when: never
-    - if: '$CI_COMMIT_REF_PROTECTED != "true"'
-      when: never
-    # Following condition for execution with custom TorizonCore images only (triggered by Jenkins).
-    - if: $BUILD_MACHINE
-  variables:
-    ERROR_TEXT: |
-      🔴🔴** TCB Pipeline ERROR **🔴🔴
-      The ${BUILD_PIPELINETYPE} CI Pipeline failed:
-      Link: ${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}
-      Distro Version: ${DISTRO_VERSION} (${BUILD_MANIFEST_BRANCH})
-      Machine: ${BUILD_MACHINE}
+.on-custom-test-error:
+  stage: post
   script:
     - apk update && apk add curl jq
     - >
@@ -880,3 +865,40 @@ on-custom-test-error:
            -H "Authorization: Bearer ${SLACK_TOKEN}" \
            -X POST https://slack.com/api/chat.postMessage \
            --data "${MESSAGE}"
+
+on-custom-test-error-gitlab:
+  extends: .on-custom-test-error
+  rules:
+    # Following condition is needed to avoid the execution of merge-request pipelines.
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    - if: '$CI_COMMIT_REF_PROTECTED != "true"'
+      when: never
+    - if: $BUILD_MACHINE
+      when: never
+    - when: on_failure
+  variables:
+    ERROR_TEXT: |
+      🔴🔴** TCB Pipeline ERROR **🔴🔴
+      The CI Pipeline failed (Triggered by GitLab):
+      Link: ${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}
+
+on-custom-test-error-jenkins:
+  extends: .on-custom-test-error
+  rules:
+    # Following condition is needed to avoid the execution of merge-request pipelines.
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    - if: '$CI_COMMIT_REF_PROTECTED != "true"'
+      when: never
+    # Following condition for execution with custom TorizonCore images only (triggered by Jenkins).
+    - if: $BUILD_MACHINE
+      when: on_failure
+    - when: never
+  variables:
+    ERROR_TEXT: |
+      🔴🔴** TCB Pipeline ERROR **🔴🔴
+      The ${BUILD_PIPELINETYPE} CI Pipeline failed (Triggered by Jenkins):
+      Link: ${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}
+      Distro Version: ${DISTRO_VERSION} (${BUILD_MANIFEST_BRANCH})
+      Machine: ${BUILD_MACHINE}


### PR DESCRIPTION
Previously, only pipelines triggered by Jenkins were being reported on Slack. This commit extends this reports to pipelines triggered by GitLab.