### PR TITLE
gitlab-ci: Use customized GitLab SaaS runners for CI jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,7 @@ variables:
 
 default:
   tags:
-    - aws-toradex-large
+    - saas-linux-small-amd64
 
 services:
   - name: docker:dind
@@ -86,6 +86,8 @@ lint-dockerfiles:
            --info DL3003 --info DL3008 --info DL3029 --info DL4006
 
 lint-python:
+  tags:
+    - saas-linux-large-amd64
   stage: pre-build
   rules:
     - if: $CI_PIPELINE_SOURCE == "trigger"
@@ -148,6 +150,8 @@ lint-python:
     - ${B} docker push "${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
 
 build-amd64:
+  tags:
+    - saas-linux-large-amd64
   extends: .build-base
   variables:
     IMAGE_ARCH: linux/amd64

--- a/tests/integration/aval/aval-tests.yml
+++ b/tests/integration/aval/aval-tests.yml
@@ -12,7 +12,7 @@ variables:
 # Build the AVAL container with docker that will run the tests on the host PC
 build-aval-docker:
   tags:
-    - aws-toradex-large
+    - saas-linux-small-amd64
   stage: build
   rules:
     - if: '$AVAL_DISABLED =~ /^true$/i'


### PR DESCRIPTION
This change to the GitLab runners is a request from the Automation team, which is now adopting the GitLab runners as the default runners to be used by the project. A study was carried out to determine which GitLab runner is the best fit for TCB. In this study, a full AVAL pipeline was executed using each of GitLab’s SaaS-linux runners, from small up to 2xlarge.

The use of these customized SaaS runners aims to minimize the time of each stage, up to the point where the cost becomes higher than the performance gain. These changes are being made in this commit:

- default: use saas-linux-small-amd64, as it has the lowest cost factor.

- lint-python and build-amd64 jobs: use saas-linux-large-amd64, because the job time decreased significantly up to the large runner. Beyond the large runner, the costs increased significantly and did not justify the gain in performance.

Related-to: TCB-733