### PR TITLE
aval-tests: Use --remove-databases argument as a workaround for TOR-3518

### DIFF
--- a/tests/integration/aval/aval-tests.yml
+++ b/tests/integration/aval/aval-tests.yml
@@ -52,9 +52,8 @@ build-aval-docker:
     # To circumvent the mismatch between Aktualizr's database and ostree when an external entity manages ostree without
     # Aktualizr, delete the database files, which forces Aktualizr to create database again, this time synced with ostree
     - cd tests/integration && python /aval/main.py --delegation-config $DELEGATION_CONFIG --ignore-different-secondaries-between-updates
-      --run-before-on-host "./run_all.sh --device --machine $TCB_MACHINE --report --tcb-tags requires-device
-      --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}" "echo $DEVICE_PASSWORD |
-      sudo -S sh -c 'systemctl stop aktualizr-torizon && rm -rf /var/sota/sql.db /var/sota/storage/* && systemctl start aktualizr-torizon'"
+      --remove-databases --run-before-on-host "./run_all.sh --device --machine $TCB_MACHINE --report --tcb-tags requires-device
+      --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
   artifacts:
     when: always
     reports:


### PR DESCRIPTION
Related-to: AVAL-70