### PR TITLE
Refactor 'secboot' commands and add sign feature to 'build' command

### DIFF
--- a/tcbuilder/backend/common.py
+++ b/tcbuilder/backend/common.py
@@ -10,8 +10,6 @@ import time
 import threading
 import binascii
 import glob
-import tempfile
-import shlex
 
 from typing import Optional
 
@@ -66,6 +64,8 @@ RAW_PROP_DEFAULTS = {
 }
 
 REMOTE_CMD_TIMEOUT = 30
+
+SECBOOT_ARTIFACTS_DIR = "/storage/secboot_tracked_artifacts"
 
 # Based on this solution: https://stackoverflow.com/a/50690347
 # Usage of Event object to stop thread was based on:
@@ -836,43 +836,33 @@ def check_if_file_exists(filename, directory):
     return file_list[0]
 
 
-def get_tezi_uenv_txt_vars(tezi_dir, var_list):
+def get_unpacked_uenv_txt_vars(storage_dir, var_list):
     """
     Get the values of specific U-Boot variables declared in uEnv.txt in a
-    Torizon OS image in Toradex Easy Installer format
+    Torizon OS image unpacked in storage_dir
 
-    :param tezi_dir: Path of Torizon OS Toradex Easy Installer image in directory format
+    :param storage_dir: Path of the unpacked image. The rootfs dir is assumed to be named 'sysroot'
     :param var_list: List of variables to get the values
     :returns: Dictionary with the values for each variable in var_list. If an entry is not in
               uEnv.txt, its value will be None
     """
 
     result = {}
-    with tempfile.TemporaryDirectory(dir=tezi_dir) as tempdir:
-        rootfs_tar = get_rootfs_tarball(tezi_dir)
-        tar_compress_options = get_tar_compress_program_options(rootfs_tar)
-        tarcmd = [
-            "tar",
-            "-xf", rootfs_tar,
-            "-C", tempdir,
-        ] + tar_compress_options + ["--wildcards", "./boot/loader*/uEnv.txt"]
-        log.debug(f"Running tar command: {shlex.join(tarcmd)}")
-        subprocess.check_output(tarcmd, stderr=subprocess.STDOUT)
+    rootfs_dir = os.path.join(storage_dir, "sysroot")
+    uenv_txt_path = glob.glob(os.path.join(rootfs_dir, "boot/loader*/uEnv.txt"))[0]
 
-        uenv_txt_path = glob.glob(os.path.join(tempdir, "boot/loader*/uEnv.txt"))[0]
+    if not os.path.isfile(uenv_txt_path):
+        raise FileContentMissing("Couldn't find uEnv.txt in unpacked image rootfs! Aborting.")
 
-        if not os.path.isfile(uenv_txt_path):
-            raise FileContentMissing("Couldn't find uEnv.txt in TEZI image rootfs! Aborting.")
+    with open(uenv_txt_path, 'r') as uenv_txt_file:
+        uenv_txt_str = uenv_txt_file.read()
 
-        with open(uenv_txt_path, 'r') as uenv_txt_file:
-            uenv_txt_str = uenv_txt_file.read()
-
-        for var in var_list:
-            match = re.search(r"^" + var + r"=(.*)", uenv_txt_str, re.MULTILINE)
-            if match:
-                result[var] = str(match.group(1))
-            else:
-                log.warning(f'"{var}=" variable not found in uEnv.txt.')
-                result[var] = None
+    for var in var_list:
+        match = re.search(r"^" + var + r"=(.*)", uenv_txt_str, re.MULTILINE)
+        if match:
+            result[var] = str(match.group(1))
+        else:
+            log.warning(f'"{var}=" variable not found in uEnv.txt.')
+            result[var] = None
 
     return result

--- a/tcbuilder/backend/deploy.py
+++ b/tcbuilder/backend/deploy.py
@@ -20,8 +20,10 @@ from gi.repository import Gio, OSTree
 
 from tcbuilder.backend import ostree
 from tcbuilder.backend.common import (get_rootfs_tarball, resolve_remote_host,
-                                      run_with_loading_animation, REMOTE_CMD_TIMEOUT)
+                                      run_with_loading_animation, REMOTE_CMD_TIMEOUT,
+                                      SECBOOT_ARTIFACTS_DIR)
 from tcbuilder.backend.rforward import reverse_forward_tunnel, request_port_forward
+from tcbuilder.backend.secboot import FUSE_CMD_TXT_NAME
 from tcbuilder.errors import TorizonCoreBuilderError, InvalidDataError
 from tezi.utils import find_rootfs_content
 # pylint: enable=wrong-import-position
@@ -279,6 +281,8 @@ def deploy_ostree_local(src_sysroot_dir, src_ostree_archive_dir,
     log.info("Copy files not under OSTree control from original deployment.")
     src_sysroot = ostree.load_sysroot(src_sysroot_dir)
     copy_files_from_old_sysroot(src_sysroot, sysroot)
+
+    return csumdeploy
 # pylint: enable=too-many-locals
 
 
@@ -289,12 +293,18 @@ def deploy_tezi_image(tezi_dir, src_sysroot_dir, src_ostree_archive_dir,
     Creates a new Toradex Easy Installer image with a OSTree deployment of the
     given OSTree reference.
     """
-    deploy_ostree_local(src_sysroot_dir, src_ostree_archive_dir, dst_sysroot_dir, ref)
+    commit = deploy_ostree_local(src_sysroot_dir, src_ostree_archive_dir, dst_sysroot_dir, ref)
 
     log.info("Packing rootfs...")
     copy_tezi_image(tezi_dir, output_dir)
     pack_rootfs_for_tezi(dst_sysroot_dir, output_dir)
     log.info("Packing rootfs done.")
+
+    # Check if there is a signed bootloader to be copied for this ref
+    commit_dir = os.path.join(SECBOOT_ARTIFACTS_DIR, commit)
+    if os.path.isdir(commit_dir):
+        log.info(f"Copying signed artifacts linked with {commit} to output image.")
+        copy_signed_artifacts(commit_dir, output_dir)
 
 
 def write_rootfs_to_raw_image(base_raw_img, output_raw_img, base_rootfs_partition, rootfs_label,
@@ -584,3 +594,28 @@ def deploy_ostree_remote(remote_host, remote_username, remote_password, remote_p
 
     ostree.serve_ostree_stop(http_server_thread)
 # pylint: enable=too-many-locals
+
+
+def copy_signed_artifacts(src_commit_dir, tezi_dir):
+    """
+    Copy artifacts signed by TCB to the Torizon OS image in tezi_dir, overwriting
+    existing content. These include the bootloader container, the text file with
+    fusing instructions, and the tarball with the signing files.
+
+    :param src_commit_dir: Commit directory where the artifacts are located
+    :param tezi_dir: Path of Torizon OS image in Toradex Easy Installer format (directory)
+    """
+
+    # Add the signed artifacts to the tezi image, overwriting existing files
+    shutil.copytree(src_commit_dir, tezi_dir, dirs_exist_ok=True)
+
+    fuse_cmd_txt = os.path.join(tezi_dir, FUSE_CMD_TXT_NAME)
+    if os.path.isfile(fuse_cmd_txt):
+        with open(fuse_cmd_txt, 'r') as fuse_file:
+            print()
+            print("# Fusing instructions to be executed in U-Boot:")
+            print()
+            print(fuse_file.read())
+            print(f"# You can recheck the instructions given above in {FUSE_CMD_TXT_NAME} "
+                  f"created in directory '{os.path.basename(tezi_dir)}'.")
+            print()

--- a/tcbuilder/backend/images.py
+++ b/tcbuilder/backend/images.py
@@ -25,8 +25,9 @@ import fabric
 from tcbuilder.backend.common import (get_rootfs_tarball, get_tar_compress_program_options,
                                       set_output_ownership, run_with_loading_animation,
                                       get_tezi_image_version, DEFAULT_RAW_ROOTFS_LABEL,
-                                      RAW_PROP_TO_ARGNAME)
+                                      RAW_PROP_TO_ARGNAME, SECBOOT_ARTIFACTS_DIR)
 from tcbuilder.backend import ostree
+from tcbuilder.backend.secboot import DEFAULT_TCB_SIGNING_FILES_TARNAME, BOOTLOADER_CONTAINER_NAME
 from tcbuilder.errors import (TorizonCoreBuilderError, InvalidArgumentError, InvalidStateError)
 from tezi.image import ImageConfig, DEFAULT_IMAGE_JSON_FILENAME
 from tezi.errors import TeziError
@@ -386,6 +387,7 @@ def import_local_image(image_dir_or_file, tezi_dir, src_sysroot_dir, src_ostree_
     metadata, _, _ = ostree.get_metadata_from_checksum(src_sysroot.repo(), csum)
 
     if os.path.exists(tezi_dir):
+        track_tezi_signed_files(tezi_dir, csum, metadata.get("oe.machine"))
         log.info("Unpacked OSTree from Toradex Easy Installer image:")
     else:
         log.info("Unpacked OSTree from WIC/raw image:")
@@ -564,4 +566,38 @@ def provision(input_dir, output_dir, shared_data, online_data, hibernated=False,
         raise
 
 
+def track_tezi_signed_files(tezi_dir, commit_hash, machine):
+    """
+    Check if input TEZI image has a tarfile with signing files and if so,
+    associate it and the bootloader container with the current OSTree commit of the image.
+    Otherwise, do nothing.
+
+    :param tezi_dir: Path of directory containing input TEZI image.
+    :param commit_hash: Current OSTree commit hash of the TEZI image.
+    :machine: Machine name compatible with the TEZI image
+    """
+
+    if not machine:
+        log.warning("Warning: Could not determine compatible machine for the image.")
+        log.warning("Secboot commands will not be usable with this image.")
+        log.warning("Proceeding anyway.")
+        return
+
+    tcb_signing_files_tar = os.path.join(tezi_dir, DEFAULT_TCB_SIGNING_FILES_TARNAME)
+    if os.path.isfile(tcb_signing_files_tar):
+
+        # Assume the signing feature for the machine is not supported if TCB doesn't have its
+        # entry in BOOTLOADER_CONTAINER_NAME
+        if machine not in BOOTLOADER_CONTAINER_NAME:
+            log.warning("Warning: secboot commands are not supported for this machine.")
+            return
+
+        log.info(f"Found {DEFAULT_TCB_SIGNING_FILES_TARNAME}. Linking it to {commit_hash}.")
+        commit_dir = os.path.join(SECBOOT_ARTIFACTS_DIR, commit_hash)
+        os.makedirs(commit_dir, exist_ok=True)
+        shutil.copy2(tcb_signing_files_tar, commit_dir)
+
+        log.info(f"Linking bootloader container to {commit_hash}.")
+        shutil.copy2(os.path.join(tezi_dir, BOOTLOADER_CONTAINER_NAME[machine]),
+                     commit_dir)
 # EOF

--- a/tcbuilder/backend/secboot.py
+++ b/tcbuilder/backend/secboot.py
@@ -703,6 +703,17 @@ def sign_bootloader_hab(storage_dir, kernel_key_dir,
     # Using absolute path as the signing script will be executed relative from its own directory
     cst_dir = os.path.abspath(cst_dir)
 
+    log.info("Attempting to sign the bootloader container with the following options:")
+    log.info(f"- Key type: {cst_args['crypto']}")
+    log.info(f"- Key length: {cst_args['key_size']}")
+    if cst_args['crypto'] == "rsa":
+        log.info(f"- Key exponent: {cst_args['key_exp']}")
+    log.info(f"- Digest algorithm: {cst_args['dig_algo']}")
+    log.info(f"- SRK index: {cst_args['srk_index']}")
+    log.info(f"- SRK table filename: {os.path.basename(cst_args['srk_table'])}")
+    log.info(f"- SRK fuse filename: {os.path.basename(cst_args['srk_fuse'])}")
+    log.info(f"- SRK CA flag disabled: {'YES' if cst_args['srk_no_ca'] else 'NO'}")
+
     check_cst_dir(cst_dir, cst_args)
 
     tezi_dir = os.path.join(storage_dir, "tezi")

--- a/tcbuilder/backend/secboot.py
+++ b/tcbuilder/backend/secboot.py
@@ -8,16 +8,16 @@ import re
 import shutil
 import shlex
 import subprocess
-import tempfile
 
 from tcbuilder.backend.common import \
-    (set_output_ownership, get_tar_compress_program_options, check_valid_tezi_image,
-     get_rootfs_tarball, is_tcb_container_64bit, check_if_file_exists,
-     get_tezi_uenv_txt_vars, get_tezi_image_version)
+    (set_output_ownership, get_tar_compress_program_options, is_tcb_container_64bit,
+     check_if_file_exists, get_unpacked_uenv_txt_vars, get_tezi_image_version)
 from tcbuilder.backend.ubootenv import \
     (get_env_filename, find_board)
 from tcbuilder.backend.platform import \
     (FUSE_HARDWAREIDS)
+from tcbuilder.backend import ostree
+
 from tcbuilder.errors import \
     (TorizonCoreBuilderError, InvalidArgumentError,
      FileContentMissing, InvalidStateError, InvalidDataError)
@@ -29,12 +29,14 @@ DEFAULT_TCB_SIGNING_FILES_TARNAME = "tcb_signing_files.tar.gz"
 UBOOT_TOOLS_DIR = "/u-boot/tools"
 SECURE_BOOT_WORKDIR = "/storage/secure_boot_workdir"
 UBOOT_DTB = "u-boot.dtb"
-KERNEL_FITIMAGE = "fitImage-initramfs-ostree-torizon-*.bin"
+KERNEL_FIT_FILENAME = "vmlinuz"
+KERNEL_DEPLOY_PATH_WILDCARD = "ostree/deploy/torizon/deploy/*/usr/lib/modules/*/"
 UBOOT_CONFIG_FILE = "uboot_config"
 UBOOT_DTBS_DIR = "u-boot-dtbs"
 
 BINMAN_OUTPUT_DIR = f"{SECURE_BOOT_WORKDIR}/binman_output"
-FLASH_BIN_SIGNING_DIR = f"{SECURE_BOOT_WORKDIR}/flash_bin_signing"
+FLASH_BIN_SIGNING_DIR = "/storage/flash_bin_signing"
+SIGNED_BOOTLOADER_ARTIFACTS_DIR = "/storage/signed_bootloader_artifacts"
 
 MKIMAGE_DTC_OPT = "-I dts -O dtb -p 2000"
 
@@ -493,24 +495,23 @@ def run_hab_signing_script(signing_dir, uboot_config_path, binman_output_dir,
     os.chdir("/workdir")
 
 
-def check_basic_signing_prerequisites(tezi_dir):
+def check_basic_signing_prerequisites(storage_dir):
     """
-    Check if the given Torizon OS image in Toradex Easy Installer format has the minimum
+    Check if the unpacked Torizon OS image in Toradex Easy Installer format has the minimum
     requirements necessary for the signing feature
 
-    :param tezi_dir: Path of Toradex Easy Installer image in directory format
+    :param storage_dir: Path to storage directory, where the image was unpacked
     """
 
-    img_major, _, _ = get_tezi_image_version(tezi_dir)
+    img_major, _, _ = get_tezi_image_version(os.path.join(storage_dir, "tezi"))
     if img_major is None:
-        raise InvalidArgumentError("Unable to determine image version in input directory. "
-                                   "Aborting.")
+        raise InvalidArgumentError("Unable to determine unpacked image version. Aborting.")
 
     if img_major < 7:
         raise InvalidArgumentError("Feature only supported on Torizon OS 7 images. Aborting.")
 
-    log.info("Checking if the input image has the kernel in fitImage format...")
-    uenv_var = get_tezi_uenv_txt_vars(tezi_dir, ["kernel_image_type"])
+    log.info("Checking if the unpacked image has the kernel in fitImage format...")
+    uenv_var = get_unpacked_uenv_txt_vars(storage_dir, ["kernel_image_type"])
 
     if uenv_var["kernel_image_type"]:
         log.info(f"Detected kernel image format: {uenv_var['kernel_image_type']}")
@@ -519,15 +520,16 @@ def check_basic_signing_prerequisites(tezi_dir):
 
     if uenv_var["kernel_image_type"] != "fitImage":
         raise InvalidArgumentError(
-            "Provided input image does not have the kernel in fitImage format. Aborting.")
+            "Unpacked image does not have the kernel in fitImage format. Aborting.")
 
 
-def check_kernel_signing_support(tezi_dir):
-    """Check if TorizonCore Builder can sign the kernel of the given Toradex Easy Installer image
+def check_unpacked_tezi_kernel_signing_support(storage_dir):
+    """Check if TorizonCore Builder can sign the kernel of the unpacked TEZI image
 
-    :param tezi_dir: Path of Toradex Easy Installer image in directory format
-    :returns: The name of the machine compatible with the image
+    :param storage_dir: Path to storage directory, where the image was unpacked
     """
+
+    tezi_dir = os.path.join(storage_dir, "tezi")
 
     initial_env_filename = get_env_filename(tezi_dir)
     initial_env = os.path.join(tezi_dir, initial_env_filename)
@@ -544,19 +546,18 @@ def check_kernel_signing_support(tezi_dir):
             "Aborting.\n"
             f"Currently supported machines: {', '.join(KERNEL_SIGNING_SUPPORTED_MACHINES)}")
 
-    check_basic_signing_prerequisites(tezi_dir)
-
-    return board
+    check_basic_signing_prerequisites(storage_dir)
 
 
-def check_hab_signing_support(tezi_dir):
+def check_unpacked_tezi_hab_signing_support(storage_dir):
     """
     Check if TorizonCore Builder can sign the HAB-compatible bootloader of the given
     Toradex Easy Installer image
 
-    :param tezi_dir: Path of Toradex Easy Installer image in directory format
+    :param storage_dir: Path to storage directory, where the image was unpacked
     :returns: The name of the machine compatible with the image
     """
+    tezi_dir = os.path.join(storage_dir, "tezi")
 
     initial_env_filename = get_env_filename(tezi_dir)
     initial_env = os.path.join(tezi_dir, initial_env_filename)
@@ -579,7 +580,7 @@ def check_hab_signing_support(tezi_dir):
             f"\"{board}\". Aborting.\n"
             f"Currently supported machines: {', '.join(HAB_SIGNING_SUPPORTED_MACHINES)}")
 
-    check_basic_signing_prerequisites(tezi_dir)
+    check_basic_signing_prerequisites(storage_dir)
 
     return board
 
@@ -618,24 +619,19 @@ def check_cst_dir(abs_cst_dir, cst_args):
     cst_args["srk_fuse"] = check_if_file_exists(cst_args["srk_fuse"], cst_crts_dir)
 
 
-def sign_kernel(input_dir, key_dir, key_algo, key_name, output_dir, force):
-    """Sign kernel fitImage of image in input_dir
+def sign_kernel(storage_dir, kernel_changes_dir, key_dir, key_algo, key_name):
+    """Sign kernel fitImage of unpacked Easy Installer image in storage_dir
 
-    :param input_dir: Path to input Tezi image
+    :param storage_dir: Path to storage directory, where the image was unpacked
+    :param kernel_changes_dir: Path to directory with all kernel changes to be commited
     :param key_dir: Path to directory with the key to sign the kernel fitImage
     :param key_algo: Pair of hashing and crypto algorithms used to sign the kernel
     :param key_name: Name of the provided key
-    :param output_dir: Path to output Tezi image
-    :param force: Whether to overwrite existing output
     """
 
     check_if_file_exists(f"{key_name}.key", key_dir)
 
-    check_valid_tezi_image(input_dir)
-
-    board = check_kernel_signing_support(input_dir)
-
-    signing_binaries_file = check_if_file_exists(DEFAULT_TCB_SIGNING_FILES_TARNAME, input_dir)
+    check_unpacked_tezi_kernel_signing_support(storage_dir)
 
     # Check if secure boot work directory exists, and if so, remove it
     # so we have a clean work directory
@@ -644,35 +640,53 @@ def sign_kernel(input_dir, key_dir, key_algo, key_name, output_dir, force):
 
     os.mkdir(SECURE_BOOT_WORKDIR)
 
-    tar_compress_options = get_tar_compress_program_options(signing_binaries_file)
-    if signing_binaries_file.endswith(".tar") or tar_compress_options:
-        tarcmd = [
-            "tar",
-            "-xf", signing_binaries_file,
-            "-C", SECURE_BOOT_WORKDIR,
-        ] + tar_compress_options
-        log.debug(f"Running tar command: {shlex.join(tarcmd)}")
-        subprocess.check_output(tarcmd, stderr=subprocess.STDOUT)
-
-    kernel_fitimage_path = check_if_file_exists(KERNEL_FITIMAGE, SECURE_BOOT_WORKDIR)
+    # Copy kernel FIT in current image deployment to the work directory
+    kernel_deploy_path = check_if_file_exists(KERNEL_FIT_FILENAME,
+                                              os.path.join(storage_dir, "sysroot",
+                                                           KERNEL_DEPLOY_PATH_WILDCARD))
+    kernel_fitimage_path = os.path.join(SECURE_BOOT_WORKDIR, KERNEL_FIT_FILENAME)
+    shutil.copy2(kernel_deploy_path, kernel_fitimage_path)
 
     # Before signing, update the expected key name of the fitImage.
     update_fit_configs_keyname(kernel_fitimage_path, key_name)
 
     sign_with_mkimage(kernel_fitimage_path, key_dir, key_algo)
 
-    create_output_image(input_dir, output_dir, board, force, "kernel")
-    set_output_ownership(output_dir)
-    log.info("Kernel in Torizon OS image signed successfully!")
+    prepare_kernel_for_ostree_commit(storage_dir, kernel_fitimage_path, kernel_changes_dir)
+
+    log.info("Kernel in unpacked Torizon OS image signed successfully!")
 
 
-def sign_bootloader_hab(input_dir, output_dir, force,
-                        kernel_key_dir, kernel_key_name, kernel_key_algo, cst_dir, cst_args):
+def prepare_kernel_for_ostree_commit(storage_dir, kernel_path, kernel_changes_dir):
+    """
+    Setup a directory tree in kernel_changes_dir with the correct path to update the kernel
+    in an OSTree commit, and copy the file in kernel_path to it.
+
+    :param storage_dir: Path to storage directory, where the image was unpacked
+    :param kernel_path: Path of the kernel file to be committed
+    :param kernel_changes_dir: Path to directory with all kernel changes to be commited
+    """
+
+    # get kernel path of current deployment inside sysroot
+    # in this path there's a directory named after the kernel version, so we need to get it first
+    src_sysroot_dir = os.path.join(storage_dir, "sysroot")
+    src_sysroot = ostree.load_sysroot(src_sysroot_dir)
+    csum, _ = ostree.get_deployment_info_from_sysroot(src_sysroot)
+
+    kernel_version = ostree.get_kernel_version(src_sysroot.repo(), csum)
+
+    # create directory to store the finalized kernel
+    new_kernel_dst = os.path.join(kernel_changes_dir, "usr/lib/modules", kernel_version)
+    os.makedirs(new_kernel_dst, exist_ok=True)
+
+    shutil.copy2(kernel_path, os.path.join(new_kernel_dst, KERNEL_FIT_FILENAME))
+
+
+def sign_bootloader_hab(storage_dir, kernel_key_dir,
+                        kernel_key_name, kernel_key_algo, cst_dir, cst_args):
     """Sign bootloader container of a HAB-compatible image in input_dir
 
-    :param input_dir: Path to input Tezi image
-    :param output_dir: Path to output Tezi image
-    :param force: Whether to overwrite existing output
+    :param storage_dir: Path to storage directory, where the image was unpacked
     :param kernel_key_dir: Path to directory with the key to sign the kernel fitImage
     :param kernel_key_name: Name of the provided kernel key
     :param kernel_key_algo: Pair of hashing and crypto algorithms used to sign the kernel
@@ -684,16 +698,16 @@ def sign_bootloader_hab(input_dir, output_dir, force,
         check_if_file_exists(f"{kernel_key_name}.key", kernel_key_dir)
         check_if_file_exists(f"{kernel_key_name}.crt", kernel_key_dir)
 
-    check_valid_tezi_image(input_dir)
-
-    board = check_hab_signing_support(input_dir)
+    board = check_unpacked_tezi_hab_signing_support(storage_dir)
 
     # Using absolute path as the signing script will be executed relative from its own directory
     cst_dir = os.path.abspath(cst_dir)
 
     check_cst_dir(cst_dir, cst_args)
 
-    signing_binaries_file = check_if_file_exists(DEFAULT_TCB_SIGNING_FILES_TARNAME, input_dir)
+    tezi_dir = os.path.join(storage_dir, "tezi")
+
+    signing_binaries_file = check_if_file_exists(DEFAULT_TCB_SIGNING_FILES_TARNAME, tezi_dir)
 
     # Check if secure boot work directory exists, and if so, remove it
     # so we have a clean work directory
@@ -730,161 +744,25 @@ def sign_bootloader_hab(input_dir, output_dir, force,
     run_hab_signing_script(FLASH_BIN_SIGNING_DIR, uboot_config_path, BINMAN_OUTPUT_DIR, board,
                            cst_dir, cst_args)
 
-    create_output_image(input_dir, output_dir, board, force, "bootloader")
-    set_output_ownership(output_dir)
+    # Copy resulting bootloader container binary with the correct filename and fusing instructions
+    # text file to SIGNED_BOOTLOADER_ARTIFACTS_DIR
+    if os.path.isdir(SIGNED_BOOTLOADER_ARTIFACTS_DIR):
+        shutil.rmtree(SIGNED_BOOTLOADER_ARTIFACTS_DIR)
 
-    if kernel_key_dir:
-        log.info(f"Public key '{kernel_key_name}' in {kernel_key_dir} will be used by the "
-                 "bootloader to verify the kernel signature.")
-    else:
-        log.warning("The bootloader DTBs were NOT updated with a new public key.")
-        log.warning("If the kernel fitImage will be signed with a new key, please re-run the "
-                    "command with --kernel-key-dir and --kernel-key so the new kernel signature "
-                    "can be properly verified by the bootloader.")
-        log.warning("Otherwise, this message can be ignored.")
-    print()
+    os.mkdir(SIGNED_BOOTLOADER_ARTIFACTS_DIR)
 
-    log.info("Bootloader in Torizon OS image signed successfully!")
+    shutil.copy2(os.path.join(FLASH_BIN_SIGNING_DIR, FLASH_BIN),
+                 os.path.join(SIGNED_BOOTLOADER_ARTIFACTS_DIR, BOOTLOADER_CONTAINER_NAME[board]))
+    shutil.copy2(os.path.join(FLASH_BIN_SIGNING_DIR, FUSE_CMD_TXT_NAME),
+                 SIGNED_BOOTLOADER_ARTIFACTS_DIR)
 
-
-def copy_signed_kernel(tezi_dir):
-    """
-    Copy the kernel fitImage signed by TCB to the Torizon OS image in tezi_dir, overwriting
-    the previous kernel.
-
-    :param tezi_dir: Path of Torizon OS image in Toradex Easy Installer format (directory)
-    """
-
-    log.info("Copying signed kernel fitImage to image rootfs...")
-    with tempfile.TemporaryDirectory(dir=tezi_dir) as tempdir:
-
-        rootfs_compressed_tar = get_rootfs_tarball(tezi_dir)
-        untarcmd = [
-            "tar",
-            "-xf", rootfs_compressed_tar,
-            "-C", tempdir,
-        ] + get_tar_compress_program_options(rootfs_compressed_tar)
-
-        log.debug(f"Running tar command: {shlex.join(untarcmd)}")
-        subprocess.check_output(untarcmd, stderr=subprocess.STDOUT)
-
-        os.remove(rootfs_compressed_tar)
-
-        uenv_txt_path = os.path.join(tempdir, "boot/loader/uEnv.txt")
-        with open(uenv_txt_path, 'r') as uenv_txt_file:
-            uenv_txt_str = uenv_txt_file.read()
-
-        match = re.search(r"^kernel_image=(.*)", uenv_txt_str, re.MULTILINE)
-
-        if match:
-            # Transform the given kernel path into a relative one
-            kernel_path = str(match.group(1)).lstrip('/')
-        else:
-            raise InvalidDataError("Couldn't find the kernel fitImage path in the root filesystem.")
-
-        kernel_path = os.path.join(tempdir, kernel_path)
-
-        # Remove the old kernel fitImage and add the new one
-        os.remove(kernel_path)
-        shutil.copy2(check_if_file_exists(KERNEL_FITIMAGE, SECURE_BOOT_WORKDIR), kernel_path)
-
-        # Put everything back together again
-        rootfs_tar, _ = os.path.splitext(rootfs_compressed_tar)
-        tarcmd = [
-            "tar", "--xattrs", "--xattrs-include=*", "--owner=0", "--group=0",
-            "-C", tempdir,
-            "-cf", rootfs_tar, "."
-        ]
-        subprocess.check_output(tarcmd, stderr=subprocess.STDOUT)
-
-    # Compress rootfs, and delete the uncompressed file
-    zstdcmd = [
-        "zstd", "-f", "-k", "-c", "--threads=0", "-3", rootfs_tar, "-o", rootfs_compressed_tar
-    ]
-    subprocess.check_output(zstdcmd, stderr=subprocess.STDOUT)
-    os.remove(rootfs_tar)
-
-
-def copy_signed_bootloader(tezi_dir, board):
-    """
-    Copy the bootloader container signed by TCB to the Torizon OS image in tezi_dir, overwriting
-    the previous bootloader. Also copy the text file with the fusing instructions to tezi_dir.
-
-    :param tezi_dir: Path of Torizon OS image in Toradex Easy Installer format (directory)
-    :param board: Name of the board compatible with the OS image
-    """
-
-    # Add the new bootloader container to the tezi image, overwriting the old one
-    shutil.copy2(check_if_file_exists(FLASH_BIN, FLASH_BIN_SIGNING_DIR),
-                 os.path.join(tezi_dir, BOOTLOADER_CONTAINER_NAME[board]))
-
-    # Copy the text file with the fuse commands
-    shutil.copy2(check_if_file_exists(FUSE_CMD_TXT_NAME, FLASH_BIN_SIGNING_DIR), tezi_dir)
-
-    fuse_cmd_txt = os.path.join(tezi_dir, FUSE_CMD_TXT_NAME)
-    if os.path.isfile(fuse_cmd_txt):
-        with open(fuse_cmd_txt, 'r') as fuse_file:
-            print()
-            log.info("# Fusing instructions to be executed in U-Boot:")
-            print()
-            log.info(fuse_file.read())
-            log.info(f"# You can recheck the instructions given above in {FUSE_CMD_TXT_NAME} "
-                     f"created in directory '{tezi_dir}'.")
-            print()
-
-
-def create_output_image(input_dir, output_dir, board, force, signed_component):
-    """Create output image with the signed components
-
-    :param input_dir: Path to input Tezi image
-    :param output_dir: Path to output Tezi image
-    :param board: Name of the board compatible with the OS image
-    :param force: Whether to overwrite existing output
-    :param signed_component: String indicating which component has been signed
-    """
-
-    if not signed_component:
-        raise InvalidStateError("Internal error: No component to be signed has been specified. "
-                                "Aborting.")
-
-    if force and os.path.isdir(output_dir) and os.path.samefile(input_dir, output_dir):
-        log.info("Updating Torizon OS image in place.")
-    else:
-        if os.path.isdir(output_dir):
-            log.info(f"Removing pre-existing directory '{output_dir}'")
-            shutil.rmtree(output_dir)
-
-        # Copy input image contents to output directory
-        shutil.copytree(input_dir, output_dir)
-
-
-    # Remove the old signing binaries tar
-    output_signing_files_tar = os.path.join(output_dir, DEFAULT_TCB_SIGNING_FILES_TARNAME)
-    os.remove(output_signing_files_tar)
-    # Put the updated contents of the signing binaries to the tar file
+    # Tar the updated contents of the signing binaries to SIGNED_BOOTLOADER_ARTIFACTS_DIR,
+    # excluding work directories
     tarcmd = [
         "tar", "--xattrs", "--xattrs-include=*", "--owner=0", "--group=0",
         "-C", SECURE_BOOT_WORKDIR,
-        "-czf", output_signing_files_tar, "."
+        "--exclude", os.path.basename(BINMAN_OUTPUT_DIR),
+        "-czf", os.path.join(SIGNED_BOOTLOADER_ARTIFACTS_DIR, DEFAULT_TCB_SIGNING_FILES_TARNAME),
+        "."
     ]
     subprocess.check_output(tarcmd, stderr=subprocess.STDOUT)
-
-    try:
-        if signed_component == "kernel":
-            copy_signed_kernel(output_dir)
-
-        elif signed_component == "bootloader":
-            copy_signed_bootloader(output_dir, board)
-
-        else:
-            # Remove output directory if it was created previously
-            if not os.path.samefile(input_dir, output_dir):
-                shutil.rmtree(output_dir)
-            raise InvalidStateError("Internal error: Unknown component signed. Aborting.")
-
-    except (FileContentMissing, InvalidDataError,
-            subprocess.CalledProcessError, FileNotFoundError, OSError) as exception:
-        # Remove output directory if it was created previously
-        if not os.path.samefile(input_dir, output_dir):
-            shutil.rmtree(output_dir)
-        log.error(f"Error when copying signed content to output image: {exception}")

--- a/tcbuilder/backend/tcbuild.schema.yaml
+++ b/tcbuilder/backend/tcbuild.schema.yaml
@@ -236,6 +236,100 @@ properties:
               additionalProperties: false
         # No extra props inside 'kernel'
         additionalProperties: false
+      secboot:
+        type: object
+        description: "secure boot related configuration"
+        properties:
+          sign-kernel:
+            type: object
+            description: "kernel signing configuration"
+            properties:
+              kernel-key-dir:
+                type: string
+                description: "path to key directory"
+              kernel-key:
+                type: array
+                description: "list of keys to be used to sign the kernel FIT"
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      description: "name of the key, which correponds to its filename without the file extension"
+                    algo:
+                      type: string
+                      description: "comma-separated pair of the hashing the crypto algorithms to be used for the signing process"
+                  required:
+                    - name
+                  # No extra props inside 'kernel-key'
+                  additionalProperties: false
+            required:
+              - kernel-key-dir
+              - kernel-key
+            # No extra props inside 'sign-kernel'
+            additionalProperties: false
+          sign-bootloader-hab:
+            type: object
+            description: "bootloader signing configuration for NXP SoCs supporting HAB"
+            properties:
+              cst-dir:
+                type: string
+                description: "path to pre-configured CST directory"
+              cst-args:
+                type: object
+                description: "CST related options"
+                properties:
+                  crypto:
+                    type: string
+                    description: "type of cryptographic keys used to sign the bootloader"
+                  key-size:
+                    type: string
+                    description: "RSA: key length in bits; ECDSA: string from generated cert file"
+                  key-exp:
+                    type: string
+                    description: "RSA key exponent"
+                  dig-algo:
+                    type: string
+                    description: "digest algorithm as provided in CST"
+                  srk-index:
+                    type: string
+                    description: "index of the SRK table to be used for signing"
+                  srk-table:
+                    type: string
+                    description: "SRK table binary filename"
+                  srk-fuse:
+                    type: string
+                    description: "SRK fuse binary filename"
+                  srk-no-ca-flag:
+                    type: boolean
+                    description: "boolean indicating if the CA flag was not set when generating the SRK certificates"
+                # No extra props inside 'cst-args'
+                additionalProperties: false
+              kernel-key-dir:
+                type: string
+                description: "path to kernel key directory"
+              kernel-key:
+                type: array
+                description: "list of keys to be used to verify the kernel FIT"
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                      description: "name of the key, which correponds to its filename without the file extension"
+                    algo:
+                      type: string
+                      description: "comma-separated pair of the hashing the crypto algorithms used to verify and sign the kernel"
+                  required:
+                    - name
+                  # No extra props inside 'kernel-key'
+                  additionalProperties: false
+            required:
+              - cst-dir
+            # No extra props inside 'sign-bootloader-hab'
+            additionalProperties: false
+        # No extra props inside 'secboot'
+        additionalProperties: false
     # No extra props inside 'customization'
     additionalProperties: false
 

--- a/tcbuilder/backend/union.py
+++ b/tcbuilder/backend/union.py
@@ -1,9 +1,12 @@
 import datetime
 import logging
 import os
+import shutil
 
 from tcbuilder.backend import ostree
 from tcbuilder.backend.ostree import OSTREE_WHITEOUT_PREFIX, OSTREE_OPAQUE_WHITEOUT_NAME
+from tcbuilder.backend.secboot import SIGNED_BOOTLOADER_ARTIFACTS_DIR
+from tcbuilder.backend.common import SECBOOT_ARTIFACTS_DIR
 from tcbuilder.errors import TorizonCoreBuilderError
 
 # pylint: disable=wrong-import-order,wrong-import-position
@@ -165,4 +168,29 @@ def union_changes(changes_dir, ostree_archive_dir, union_branch,
         repo, ostree.OSTREE_BASE_REF, changes_dir, union_branch,
         subject, body, pre_apply_callback=pre_apply_callback)
 
+    track_signed_bootloader(final_commit)
+
     return final_commit
+
+
+def track_signed_bootloader(commit_hash):
+    """
+    If applicable, internally track the bootloader and fusing instructions text file in
+    FLASH_BIN_SIGNING_DIR by copying them inside a directory named after commit_hash
+    in SECBOOT_ARTIFACTS_DIR.
+
+    :param commit_hash: OSTree commit hash to be associated with the signed bootloader
+    """
+
+    # Check if there's any signed bootloader artifacts to track, and if so store them to be
+    # deployed with the new branch
+    if (os.path.isdir(SIGNED_BOOTLOADER_ARTIFACTS_DIR) and
+            os.listdir(SIGNED_BOOTLOADER_ARTIFACTS_DIR)):
+        log.info("Found signed bootloader in storage. Applying changes.")
+
+        # Create a new directory named after the commit hash (if it doesn't exist already)
+        # and put the signed bootloader in it
+        commit_dir = os.path.join(SECBOOT_ARTIFACTS_DIR, commit_hash)
+        shutil.copytree(SIGNED_BOOTLOADER_ARTIFACTS_DIR, commit_dir, dirs_exist_ok=True)
+        log.info(f"Signed bootloader will be applied when deploying {commit_hash} "
+                 "to a local directory.")

--- a/tcbuilder/cli/build.py
+++ b/tcbuilder/cli/build.py
@@ -16,13 +16,15 @@ from tcbuilder.backend.registryops import RegistryOperations
 from tcbuilder.errors import (
     FileContentMissing, FeatureNotImplementedError, InvalidDataError,
     InvalidStateError, LicenceAcceptanceError, TorizonCoreBuilderError,
-    ParseError, ParseErrors)
+    ParseError, ParseErrors, InvalidArgumentError)
 
 from tcbuilder.backend import common
 from tcbuilder.backend import build as bb
 from tcbuilder.backend import combine as comb_be
 from tcbuilder.backend import dt as dt_be
 from tcbuilder.backend import images as images_be
+from tcbuilder.backend import kernel as kernel_be
+from tcbuilder.backend import secboot as secboot_be
 from tcbuilder.cli import deploy as deploy_cli
 from tcbuilder.cli import dt as dt_cli
 from tcbuilder.cli import dto as dto_cli
@@ -30,6 +32,7 @@ from tcbuilder.cli import kernel as kernel_cli
 from tcbuilder.cli import images as images_cli
 from tcbuilder.cli import splash as splash_cli
 from tcbuilder.cli import union as union_cli
+from tcbuilder.cli import secboot as secboot_cli
 
 DEFAULT_BUILD_FILE = "tcbuild.yaml"
 TEMPLATE_BUILD_FILE = "tcbuild.template.yaml"
@@ -187,6 +190,9 @@ def handle_customization_section(props, storage_dir=None):
 
     assert storage_dir is not None, "Parameter `storage_dir` must be passed"
 
+    if "secboot" in props:
+        handle_secboot_customization(props["secboot"], storage_dir=storage_dir)
+
     if "splash-screen" in props:
         log.info(l2_pref("Setting splash screen"))
         splash_cli.splash(props["splash-screen"], storage_dir=storage_dir)
@@ -261,6 +267,119 @@ def handle_kernel_customization(props, storage_dir=None):
         kernel_cli.kernel_set_custom_args(
             kernel_args=props["arguments"],
             storage_dir=storage_dir)
+
+
+def handle_secboot_customization(props, storage_dir=None):
+    """Handle the secure boot customization section."""
+
+    common.images_unpack_executed(storage_dir)
+    if common.unpacked_image_type(storage_dir) == "raw":
+        raise InvalidDataError("TorizonCore Builder does not support signing components for "
+                               "WIC/raw images. Aborting.")
+
+    if "sign-kernel" in props:
+        sign_kernel_props = props["sign-kernel"]
+        key_dir = sign_kernel_props["kernel-key-dir"]
+
+        if len(sign_kernel_props["kernel-key"]) > 1:
+            raise InvalidArgumentError(
+                "TorizonCore Builder only supports signing the kernel FIT with one key. Aborting.")
+
+        kernel_key = sign_kernel_props["kernel-key"][0]
+
+        if not os.path.isdir(key_dir):
+            raise InvalidArgumentError(
+                f"Directory \"{key_dir}\" does not exist: aborting.")
+
+        assert "name" in kernel_key, "'kernel-key' requires 'name' property"
+
+        if "algo" not in kernel_key:
+            log.info(f"Could not find value of 'algo' for key '{kernel_key['name']}'. "
+                     f"Defaulting to {secboot_cli.KERNEL_KEY_DEFAULT_ALGO}.")
+
+        kernel_changes_dir = kernel_be.get_kernel_changes_dir(storage_dir)
+        if not os.path.isdir(kernel_changes_dir):
+            os.mkdir(kernel_changes_dir)
+
+        secboot_be.sign_kernel(
+            storage_dir=storage_dir,
+            kernel_changes_dir=kernel_changes_dir,
+            key_dir=key_dir,
+            key_algo=kernel_key.get("algo", secboot_cli.KERNEL_KEY_DEFAULT_ALGO),
+            key_name=kernel_key["name"]
+        )
+
+    if "sign-bootloader-hab" in props:
+        sign_hab_props = props["sign-bootloader-hab"]
+        cst_dir = sign_hab_props["cst-dir"]
+        cst_dict = sign_hab_props.get("cst-args", {})
+        kernel_key_dir = sign_hab_props.get("kernel-key-dir", None)
+        kernel_key_list = sign_hab_props.get("kernel-key", [])
+        kernel_key = {}
+
+        if not os.path.isdir(cst_dir):
+            raise InvalidArgumentError(
+                f"Directory \"{cst_dir}\" does not exist: aborting.")
+
+        if kernel_key_dir:
+            if not os.path.isdir(kernel_key_dir):
+                raise InvalidArgumentError(
+                    f"Directory \"{kernel_key_dir}\" does not exist: aborting.")
+            if not kernel_key_list:
+                raise InvalidArgumentError(
+                    "sign-bootloader-hab: 'kernel-key-dir' was passed but 'kernel-key' was "
+                    "not provided. Aborting.")
+
+        if kernel_key_list:
+            if not kernel_key_dir:
+                raise InvalidArgumentError(
+                    "sign-bootloader-hab: 'kernel-key' was passed but 'kernel-key-dir' was "
+                    "not provided. Aborting.")
+
+            if len(kernel_key_list) > 1:
+                raise InvalidArgumentError(
+                    "TorizonCore Builder only supports updating one public key. Aborting.")
+
+            kernel_key = kernel_key_list[0]
+
+            assert "name" in kernel_key, "'kernel-key' requires 'name' property"
+
+            if "algo" not in kernel_key:
+                log.info(f"Could not find value of 'algo' for key '{kernel_key['name']}'. "
+                         f"Defaulting to {secboot_cli.KERNEL_KEY_DEFAULT_ALGO}.")
+
+        cst_args = {
+            "crypto": cst_dict.get("crypto", secboot_cli.CST_CRYPTO_TYPES[0]),
+            "key_size": cst_dict.get("key-size", secboot_cli.CST_DEFAULT_KEY_SIZE),
+            "key_exp": cst_dict.get("key-exp", secboot_cli.CST_DEAFULT_KEY_EXP),
+            "dig_algo": cst_dict.get("dig-algo", secboot_cli.CST_DIG_ALGO_TYPES[0]),
+            "srk_index": cst_dict.get("srk-index", secboot_cli.CST_SRK_INDEXES[0]),
+            "srk_table": cst_dict.get("srk-table", secboot_cli.CST_SRK_DEFAULT_TABLE),
+            "srk_fuse": cst_dict.get("srk-fuse", secboot_cli.CST_SRK_DEFAULT_FUSE),
+            "srk_no_ca": cst_dict.get("srk-no-ca-flag", False)
+        }
+
+        secboot_be.sign_bootloader_hab(
+            storage_dir=storage_dir,
+            kernel_key_dir=kernel_key_dir,
+            kernel_key_name=kernel_key.get("name"),
+            kernel_key_algo=kernel_key.get("algo", secboot_cli.KERNEL_KEY_DEFAULT_ALGO),
+            cst_dir=cst_dir,
+            cst_args=cst_args
+        )
+
+        if kernel_key_dir:
+            log.info(f"Public key '{kernel_key['name']}' in {kernel_key_dir} will be used by "
+                     "the bootloader to verify the kernel signature.")
+        else:
+            log.warning("The bootloader DTBs were NOT updated with a new public key.")
+            log.warning("If the kernel fitImage will be signed with a new key, please set "
+                        "'kernel-key-dir' and 'kernel-key' and re-run the command so the new "
+                        "kernel signature can be properly verified by the bootloader.")
+            log.warning("Otherwise, this message can be ignored.")
+        print()
+
+        log.info("Bootloader in Torizon OS image signed successfully!")
 
 
 def handle_output_section(props, storage_dir, changes_dirs=None, default_base_raw_image=None):

--- a/tcbuilder/cli/deploy.py
+++ b/tcbuilder/cli/deploy.py
@@ -183,6 +183,10 @@ def deploy_ostree_remote(storage_dir, remote_host, remote_username,
 
     src_ostree_archive_dir = os.path.join(storage_dir_, "ostree-archive")
 
+    log.warning("WARNING: Beware that artifacts not managed by OSTree (e.g. bootloader, container "
+                "images, platform provisioning data, fuse values, U-Boot environment) will not be "
+                "deployed by this operation.")
+
     dbe.deploy_ostree_remote(remote_host, remote_username, remote_password,
                              remote_port, mdns_source, src_ostree_archive_dir,
                              ref, reboot)

--- a/tcbuilder/cli/secboot.py
+++ b/tcbuilder/cli/secboot.py
@@ -6,7 +6,9 @@ import logging
 import os
 
 from tcbuilder.backend import secboot
-from tcbuilder.errors import InvalidStateError, InvalidArgumentError
+from tcbuilder.backend import kernel
+from tcbuilder.backend.common import images_unpack_executed, unpacked_image_type
+from tcbuilder.errors import InvalidArgumentError, InvalidDataError
 
 log = logging.getLogger("torizon." + __name__)
 
@@ -56,36 +58,38 @@ def validate_kernel_key_arg(kernel_key):
 def do_sign_kernel(args):
     """Run 'secboot sign-kernel' subcommand"""
 
-    for directory in (args.input_dir, args.kernel_key_dir):
-        if not os.path.isdir(directory):
-            raise InvalidArgumentError(
-                f"Directory \"{directory}\" does not exist: aborting.")
-
-    # Create output directory or abort:
-    if os.path.isdir(args.output_dir) and not args.force:
-        raise InvalidStateError(
-            f"Output directory '{args.output_dir}' already exists; please remove "
-            "it, choose another output directory name or rerun with --force to overwrite it.")
+    if not os.path.isdir(args.kernel_key_dir):
+        raise InvalidArgumentError(
+            f"Directory \"{args.kernel_key_dir}\" does not exist: aborting.")
 
     kernel_key_name, kernel_key_algo = validate_kernel_key_arg(args.kernel_key)
 
+    storage_dir = os.path.abspath(args.storage_directory)
+
+    images_unpack_executed(storage_dir)
+    if unpacked_image_type(storage_dir) == "raw":
+        raise InvalidDataError("Secboot commands are not supported for WIC/raw images. "
+                               "Aborting.")
+
+    kernel_changes_dir = kernel.get_kernel_changes_dir(storage_dir)
+    if not os.path.isdir(kernel_changes_dir):
+        os.mkdir(kernel_changes_dir)
+
     secboot.sign_kernel(
-        input_dir=args.input_dir,
+        storage_dir=storage_dir,
+        kernel_changes_dir=kernel_changes_dir,
         key_dir=args.kernel_key_dir,
         key_algo=kernel_key_algo,
-        key_name=kernel_key_name,
-        output_dir=args.output_dir,
-        force=args.force
+        key_name=kernel_key_name
     )
 
 
 def do_sign_bootloader_hab(args):
     """Run 'secboot sign-bootloader-hab' subcommand"""
 
-    for directory in (args.input_dir, args.cst_dir):
-        if not os.path.isdir(directory):
-            raise InvalidArgumentError(
-                f"Directory \"{directory}\" does not exist: aborting.")
+    if not os.path.isdir(args.cst_dir):
+        raise InvalidArgumentError(
+            f"Directory \"{args.cst_dir}\" does not exist: aborting.")
 
     if args.kernel_key_dir:
         if not os.path.isdir(args.kernel_key_dir):
@@ -103,11 +107,12 @@ def do_sign_bootloader_hab(args):
                 "--kernel-key was passed but --kernel-key-dir was not provided. Aborting.")
         kernel_key_name, kernel_key_algo = validate_kernel_key_arg(args.kernel_key)
 
-    # Create output directory or abort:
-    if os.path.isdir(args.output_dir) and not args.force:
-        raise InvalidStateError(
-            f"Output directory '{args.output_dir}' already exists; please remove "
-            "it, choose another output directory name or rerun with --force to overwrite it.")
+    storage_dir = os.path.abspath(args.storage_directory)
+
+    images_unpack_executed(storage_dir)
+    if unpacked_image_type(storage_dir) == "raw":
+        raise InvalidDataError("Secboot commands are not supported for WIC/raw images. "
+                               "Aborting.")
 
     cst_args = {
         "crypto": args.cst_crypto,
@@ -121,9 +126,7 @@ def do_sign_bootloader_hab(args):
     }
 
     secboot.sign_bootloader_hab(
-        input_dir=args.input_dir,
-        output_dir=args.output_dir,
-        force=args.force,
+        storage_dir=storage_dir,
         kernel_key_dir=args.kernel_key_dir,
         kernel_key_name=kernel_key_name,
         kernel_key_algo=kernel_key_algo,
@@ -137,7 +140,7 @@ def init_parser(subparsers):
 
     parser = subparsers.add_parser(
         "secboot",
-        help=("Sign different components of a specified Torizon OS image in "
+        help=("Sign different components of an unpacked Torizon OS image in "
               "Toradex Easy Installer format."),
         allow_abbrev=False)
 
@@ -146,33 +149,15 @@ def init_parser(subparsers):
     # secboot sign-kernel
     subparser = subparsers.add_parser(
         "sign-kernel",
-        help=("Sign the kernel fitImage."),
+        help=("Sign the kernel fitImage of an unpacked Torizon OS image."),
         description=("Currently supported machines: "
                      f"{', '.join(secboot.KERNEL_SIGNING_SUPPORTED_MACHINES)}"))
 
     subparser.add_argument(
-        dest="input_dir",
-        metavar="INPUT_DIRECTORY",
-        help="Path of Torizon OS 7 image (in Toradex Easy Installer format) to be signed. "
-             "The kernel must be in fitImage format, and the image needs to have a file with "
-             "the required components to be signed named "
-             f"{secboot.DEFAULT_TCB_SIGNING_FILES_TARNAME}.")
-
-    subparser.add_argument(
-        dest="output_dir",
-        metavar="OUTPUT_DIRECTORY",
-        help="Path of resulting Torizon OS image.")
-
-    subparser.add_argument(
-        "--force", dest="force",
-        default=False, action="store_true",
-        help="Force program output, overwriting any existing file/directory.")
-
-    subparser.add_argument(
-        "--kernel-key-dir", dest="kernel_key_dir",
+        dest="kernel_key_dir",
+        metavar="KERNEL_KEY_DIR",
         help="Kernel fitImage key directory path. This directory must contain a private key in "
-             ".key format",
-        required=True)
+             "PEM format having the .key extension.")
 
     subparser.add_argument(
         "--kernel-key", dest="kernel_key",
@@ -196,29 +181,16 @@ def init_parser(subparsers):
                      f"{', '.join(secboot.HAB_SIGNING_SUPPORTED_MACHINES)}"))
 
     subparser.add_argument(
-        dest="input_dir",
-        metavar="INPUT_DIRECTORY",
-        help="Path of Torizon OS 7 image (in Toradex Easy Installer format) to be signed. U-Boot "
-             "needs to be built with secure boot support, and the image needs to have a file with "
-             "the required components to be signed named "
-             f"{secboot.DEFAULT_TCB_SIGNING_FILES_TARNAME}.")
-
-    subparser.add_argument(
-        dest="output_dir",
-        metavar="OUTPUT_DIRECTORY",
-        help="Path of resulting Torizon OS image.")
-
-    subparser.add_argument(
-        "--force", dest="force",
-        default=False, action="store_true",
-        help="Force program output, overwriting any existing file/directory.")
+        dest="cst_dir",
+        metavar="CST_DIR",
+        help="CST directory path.")
 
     subparser.add_argument(
         "--kernel-key-dir", dest="kernel_key_dir",
         help="Kernel fitImage key directory path. If specified the U-Boot DTB and Control DTBs "
              "will be updated with the public key before signing the bootloader. This directory "
-             "must contain a private key in .key format and a certificate with "
-             "the public key in .crt format, both with the same name.")
+             "must contain a private key (.key extension) and a certificate (.crt extension) with "
+             "the public key, both in PEM format and with the same name.")
 
     subparser.add_argument(
         "--kernel-key", dest="kernel_key",
@@ -227,11 +199,6 @@ def init_parser(subparsers):
              "hashing and crypto algorithms used to sign the kernel "
              "(e.g. 'name=prod;algo=sha256,rsa2048'). If <ALGO> is not provided, "
              f"it defaults to '{KERNEL_KEY_DEFAULT_ALGO}'.")
-
-    subparser.add_argument(
-        "--cst-dir", dest="cst_dir",
-        help="CST directory path.",
-        required=True)
 
     subparser.add_argument(
         "--cst-crypto", dest="cst_crypto", choices=CST_CRYPTO_TYPES,

--- a/tcbuilder/cli/secboot.py
+++ b/tcbuilder/cli/secboot.py
@@ -134,6 +134,19 @@ def do_sign_bootloader_hab(args):
         cst_args=cst_args
     )
 
+    if args.kernel_key_dir:
+        log.info(f"Public key '{kernel_key_name}' in {args.kernel_key_dir} will be used by "
+                 "the bootloader to verify the kernel signature.")
+    else:
+        log.warning("The bootloader DTBs were NOT updated with a new public key.")
+        log.warning("If the kernel fitImage will be signed with a new key, please re-run the "
+                    "command with --kernel-key-dir and --kernel-key so the new kernel signature "
+                    "can be properly verified by the bootloader.")
+        log.warning("Otherwise, this message can be ignored.")
+    print()
+
+    log.info("Bootloader in Torizon OS image signed successfully!")
+
 
 def init_parser(subparsers):
     """Initialize argument parser"""

--- a/tcbuilder/cli/tcbuild.template.yaml
+++ b/tcbuilder/cli/tcbuild.template.yaml
@@ -72,6 +72,45 @@ input:
     # modules:
       # - source-dir: virtual_touchscreen/
       #   autoload: false
+  # >> Secure Boot related Options
+  # >> NOTE: All secboot options need a Torizon OS image with secure boot support built-in.
+  # >> This includes kernel in FIT format, U-Boot built with the corresponding secure boot kconfigs, etc.
+  # secboot:
+    # >> Sign kernel FIT image
+    # sign-kernel:
+      # >> (REQUIRED) directory path with the keys to sign the kernel
+      # kernel-key-dir: ./kernel_keys/
+      # >> (REQUIRED) Key details
+      # kernel-key:
+         # >> 'algo' corresponds to the hashing and crypto algorithms to be used for the signing
+         # >> process. If not set it defaults to the value given below.
+         # - name: "prod"
+         #   algo: "sha256,rsa2048"
+    # >> Sign bootloader for NXP SoCs supporting High Assurance Boot (HAB)
+    # sign-bootloader-hab:
+      # >> (REQUIRED) directory path with the CST directory pre-configured with
+      # >> keys, cerfiticates, SRK table and e-fuse hash binaries
+      # cst-dir: ./cst-3.4.1/
+      # >> (OPTIONAL) CST related options. If an option is not set,
+      # >> it will default to the values given below
+      # cst-args:
+        # crypto: "rsa"
+        # key-size: "2048"
+        # key-exp: "65537"
+        # dig-algo: "sha256"
+        # srk-index: "1"
+        # srk-table: "SRK_1_2_3_4_table.bin"
+        # srk-fuse: "SRK_1_2_3_4_fuse.bin"
+        # srk-no-ca-flag: false
+      # >> (OPTIONAL) If the options below are provided, the public key used to verify
+      # >> the kernel FIT will be updated. These must be set if signing the kernel FIT
+      # >> with a new key.
+      # kernel-key-dir: ./kernel_keys/
+      # kernel-key:
+         # >> 'algo' corresponds to the hashing and crypto algorithms used to verify and sign the
+         # >> kernel, respectively. If not set it defaults to the value given below.
+         # - name: "prod"
+         #   algo: "sha256,rsa2048"
 
 # >> The output section defines properties of the output image.
 output:

--- a/tests/integration/testcases/build.bats
+++ b/tests/integration/testcases/build.bats
@@ -4,6 +4,27 @@ bats_load_library 'bats/bats-file/load.bash'
 load 'lib/registries.sh'
 load 'lib/common.bash'
 
+setup_file() {
+    KERNEL_SIGNING_SUPPORTED_MACHINES=$(torizoncore-builder secboot sign-kernel --help \
+                                        | grep '^Currently supported machines:')
+    if echo "${KERNEL_SIGNING_SUPPORTED_MACHINES}" | grep -q "${MACHINE}"; then
+        IS_KERNEL_SIGNING_SUPPORTED="1"
+    else
+        IS_KERNEL_SIGNING_SUPPORTED="0"
+    fi
+
+    HAB_SIGNING_SUPPORTED_MACHINES=$(torizoncore-builder secboot sign-bootloader-hab --help \
+                                     | grep '^Currently supported machines:')
+    if echo "${HAB_SIGNING_SUPPORTED_MACHINES}" | grep -q "${MACHINE}"; then
+        IS_HAB_SIGNING_SUPPORTED="1"
+    else
+        IS_HAB_SIGNING_SUPPORTED="0"
+    fi
+
+    export IS_KERNEL_SIGNING_SUPPORTED
+    export IS_HAB_SIGNING_SUPPORTED
+}
+
 teardown_file() {
     stop-registries
 }
@@ -90,6 +111,139 @@ teardown_file() {
     refute_output --partial 'is not valid under any of the given schemas'
     assert_output --partial 'Error: Could not fetch URL'
     rm -rf dummy_output_directory
+}
+
+@test "build: re-signing of kernel FIT and bootloader with HAB" {
+
+    requires-supported-kernel-signing-machine
+    requires-supported-hab-signing-machine
+    requires-signed-image
+
+    # sign-kernel related variables
+    local SIGNING_KEYS_DIR="${SAMPLES_DIR}/signing_keys"
+    local KERNEL_KEY_DIR="${SIGNING_KEYS_DIR}/kernel_fitimage"
+    local KERNEL_KEY_NAME="test"
+    local KERNEL_KEY_ALGO="sha256,rsa2048"
+
+    # sign-bootloader-hab related variables
+    local CST_DIRS="cst_dirs"
+    local CST_TARBALL="${SIGNING_KEYS_DIR}/${CST_DIRS}.tar.gz"
+    local CST_BINARIES_DIR="${CST_DIRS}/cst-3.4.1"
+    local CST_DIR="${CST_DIRS}/hab/cst-3.4.1_tcb_test_rsa_1024_no_ca"
+
+    local CST_CRYPTO="rsa"
+    local CST_KEY_SIZE="1024"
+    local CST_KEY_EXP="65537"
+    local CST_DIGEST_ALGO="sha256"
+    local CST_SRK_INDEX="3"
+    local CST_SRK_TABLE_NAME="SRK_1_2_3_4_table.bin"
+    local CST_SRK_FUSE_NAME="SRK_1_2_3_4_fuse.bin"
+    local CST_SRK_NO_CA_FLAG="1"
+
+    local TCBUILD_YAML="$SAMPLES_DIR/config/tcbuild-hab-re-signing-components.yaml"
+    local OUTDIR='re_signed_image'
+
+    unpack-image "${CST_TARBALL}"
+
+    # copy CST binaries to CST_DIR before running tests
+    cp -r "${CST_BINARIES_DIR}/linux32" "${CST_DIR}"
+    cp -r "${CST_BINARIES_DIR}/linux64" "${CST_DIR}"
+
+    if [ "$CST_SRK_NO_CA_FLAG" == "1" ]; then
+        # Enable `srk-no-ca-flag`
+        cat "$TCBUILD_YAML" | \
+                sed -Ee 's/## srk-no-ca-flag/srk-no-ca-flag/' > \
+                "$TCBUILD_YAML-no-ca.yaml"
+        TCBUILD_YAML="$TCBUILD_YAML-no-ca.yaml"
+
+        CST_SRK_NO_CA_FLAG="YES"
+    else
+        CST_SRK_NO_CA_FLAG="NO"
+    fi
+
+    run torizoncore-builder build \
+        --file "$TCBUILD_YAML" \
+        --set KERNEL_KEY_DIR="$KERNEL_KEY_DIR" \
+        --set KERNEL_KEY_NAME="$KERNEL_KEY_NAME" \
+        --set KERNEL_KEY_ALGO="$KERNEL_KEY_ALGO" \
+        --set CST_DIR="$CST_DIR" \
+        --set CST_CRYPTO="$CST_CRYPTO" \
+        --set CST_KEY_SIZE="$CST_KEY_SIZE" \
+        --set CST_KEY_EXP="$CST_KEY_EXP" \
+        --set CST_DIGEST_ALGO="$CST_DIGEST_ALGO" \
+        --set CST_SRK_INDEX="$CST_SRK_INDEX" \
+        --set CST_SRK_TABLE_NAME="$CST_SRK_TABLE_NAME" \
+        --set CST_SRK_FUSE_NAME="$CST_SRK_FUSE_NAME" \
+        --set INPUT_IMAGE="$DEFAULT_SIGNED_TEZI_IMAGE" \
+        --set OUTPUT_DIR="$OUTDIR" --force
+
+    assert_success
+    # sign-kernel output
+    assert_output --partial "Updating fitImage configurations to be signed with key name: ${KERNEL_KEY_NAME}"
+    assert_output --partial "Using ${KERNEL_KEY_ALGO} for the signing process"
+    assert_output --partial 'Kernel fitImage signed successfully'
+    assert_output --partial 'Kernel in unpacked Torizon OS image signed successfully'
+    # sign-bootloader-hab output
+    assert_output --partial "Key type: ${CST_CRYPTO}"
+    assert_output --partial "Key length: ${CST_KEY_SIZE}"
+    assert_output --partial "Key exponent: ${CST_KEY_EXP}"
+    assert_output --partial "Digest algorithm: ${CST_DIGEST_ALGO}"
+    assert_output --partial "SRK index: ${CST_SRK_INDEX}"
+    assert_output --partial "SRK table filename: ${CST_SRK_TABLE_NAME}"
+    assert_output --partial "SRK fuse filename: ${CST_SRK_FUSE_NAME}"
+    assert_output --partial "SRK CA flag disabled: ${CST_SRK_NO_CA_FLAG}"
+    assert_output --partial "Adding public key '${KERNEL_KEY_NAME}' in ${KERNEL_KEY_DIR} to U-Boot DTB"
+    assert_output --partial 'flash.bin created successfully'
+    assert_output --partial "Using SRK${CST_SRK_INDEX} for signing"
+    assert_output --partial 'Bootloader container signed successfully'
+    assert_output --partial 'Bootloader in Torizon OS image signed successfully'
+
+    assert_output --partial 'Deploying commit ref: re-signed-branch'
+
+    local ARCHIVE='/storage/ostree-archive/'
+    local COMMIT='re-signed-branch'
+
+    # Check output/ostree/commit-{subject,body} props:
+    run torizoncore-builder-shell "ostree --repo=$ARCHIVE log $COMMIT"
+    assert_output --partial 're-signed image subject'
+    assert_output --partial 're-signed image body'
+
+    # Check output/easy-installer/{name,description}:
+    run cat "$OUTDIR/image.json"
+    assert_output --partial '"name": "image with re-signed kernel FIT and bootloader"'
+    assert_output --partial '"description": "HAB image with both the kernel FIT and the bootloader re-signed"'
+
+    # Check the ostree branch ref-binding:
+    run torizoncore-builder-shell \
+      "ostree --repo=$ARCHIVE show --print-metadata-key='ostree.ref-binding' $COMMIT"
+    assert_success
+    assert_output --partial "['$COMMIT']"
+
+    run torizoncore-builder-shell "ls -l /storage/kernel/usr/lib/modules/*/vmlinuz"
+    assert_success
+
+    local CONFIG_LIST=$(torizoncore-builder-shell \
+                        "fdtget -ts /storage/kernel/usr/lib/modules/*/vmlinuz \
+                        /configurations -l")
+
+    local CONFIG1=$(echo "${CONFIG_LIST}" | head -n 1)
+
+    local CONFIG1_SUBNODES=$(torizoncore-builder-shell \
+                             "fdtget -ts /storage/kernel/usr/lib/modules/*/vmlinuz \
+                             /configurations/${CONFIG1} -l")
+
+    local SIG_NODE=$(echo "${CONFIG1_SUBNODES}" | grep signature)
+
+    local FOUND_KEY_NAME=$(torizoncore-builder-shell \
+                           "fdtget -ts /storage/kernel/usr/lib/modules/*/vmlinuz \
+                           /configurations/${CONFIG1}/${SIG_NODE} key-name-hint")
+
+    run test "${FOUND_KEY_NAME}" == "${KERNEL_KEY_NAME}"
+    assert_success
+
+    # delete copied CST binaries as they're no longer needed
+    rm -rf "${CST_DIR}/linux32"
+    rm -rf "${CST_DIR}/linux64"
 }
 
 @test "build: full customization checked on host" {

--- a/tests/integration/testcases/secboot.bats
+++ b/tests/integration/testcases/secboot.bats
@@ -55,69 +55,54 @@ setup_file() {
     run torizoncore-builder secboot sign-kernel
     assert_failure
     assert_output --partial \
-        "the following arguments are required: INPUT_DIRECTORY, OUTPUT_DIRECTORY, --kernel-key-dir, --kernel-key"
+        "the following arguments are required: KERNEL_KEY_DIR, --kernel-key"
+}
+
+@test "secboot sign-kernel: attempt to sign kernel FIT without images unpack" {
+    torizoncore-builder-clean-storage
+
+    run torizoncore-builder secboot sign-kernel "${KERNEL_KEY_DIR}" \
+                                                --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}"
+    assert_failure
+    assert_output --partial "Error: could not find an Easy Installer or WIC image in the storage"
+    assert_output --partial "Please use the 'images' command to unpack an image before running this command"
 }
 
 @test "secboot sign-kernel: invalid parameters" {
 
-    local INPUT_IMAGE_DIR="TEST_$(echo ${DEFAULT_TEZI_IMAGE} | sed 's/\.tar$//g')"
-    local OUTPUT_IMAGE_DIR="SIGNED_${INPUT_IMAGE_DIR}"
+    # Unpack an unsigned image just so the initial 'images unpack' check is passed
+    torizoncore-builder images --remove-storage unpack "${DEFAULT_TEZI_IMAGE}"
 
-    # create dummy input directory
-    mkdir -p "${INPUT_IMAGE_DIR}"
-
-    # non-existent input directory
-    run torizoncore-builder secboot sign-kernel "foo" "${OUTPUT_IMAGE_DIR}" \
-                                                --kernel-key-dir "${KERNEL_KEY_DIR}" \
-                                                --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}"
+    # kernel key directory not specified
+    run torizoncore-builder secboot sign-kernel --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}"
     assert_failure
-    assert_output --partial 'does not exist'
-
-    # output directory already exists and --force was not passed
-    mkdir -p "${OUTPUT_IMAGE_DIR}"
-    run torizoncore-builder secboot sign-kernel "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                --kernel-key-dir "${KERNEL_KEY_DIR}" \
-                                                --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}"
-    assert_failure
-    assert_output --partial 'already exists'
-    rm -rf "${OUTPUT_IMAGE_DIR}"
-
-    # --kernel-key-dir not specified
-    run torizoncore-builder secboot sign-kernel "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}"
-    assert_failure
-    assert_output --partial 'the following arguments are required: --kernel-key-dir'
+    assert_output --partial 'the following arguments are required: KERNEL_KEY_DIR'
 
     # --kernel-key not specified
-    run torizoncore-builder secboot sign-kernel "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                --kernel-key-dir "${KERNEL_KEY_DIR}"
+    run torizoncore-builder secboot sign-kernel "${KERNEL_KEY_DIR}"
     assert_failure
     assert_output --partial 'the following arguments are required: --kernel-key'
 
     # non-existent kernel fitImage key directory
-    run torizoncore-builder secboot sign-kernel "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                --kernel-key-dir "foo" \
+    run torizoncore-builder secboot sign-kernel "foo" \
                                                 --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}"
     assert_failure
     assert_output --partial 'does not exist'
 
     # key name that does not match file in key directory
-    run torizoncore-builder secboot sign-kernel "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                --kernel-key-dir "${KERNEL_KEY_DIR}" \
+    run torizoncore-builder secboot sign-kernel "${KERNEL_KEY_DIR}" \
                                                 --kernel-key "name=foo;algo=${KERNEL_KEY_ALGO}"
     assert_failure
     assert_output --partial 'Could not find'
 
     # Invalid --kernel-key format (comma instead of semicolon)
-    run torizoncore-builder secboot sign-kernel "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                --kernel-key-dir "${KERNEL_KEY_DIR}" \
+    run torizoncore-builder secboot sign-kernel "${KERNEL_KEY_DIR}" \
                                                 --kernel-key "name=${KERNEL_KEY_NAME},algo=${KERNEL_KEY_ALGO}"
     assert_failure
     assert_output --partial '--kernel-key is not correctly formatted'
 
     # --kernel-key without name
-    run torizoncore-builder secboot sign-kernel "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                --kernel-key-dir "${KERNEL_KEY_DIR}" \
+    run torizoncore-builder secboot sign-kernel "${KERNEL_KEY_DIR}" \
                                                 --kernel-key "algo=${KERNEL_KEY_ALGO}"
     assert_failure
     assert_output --partial "Could not find value of 'name' in --kernel-key"
@@ -126,25 +111,20 @@ setup_file() {
 @test "secboot sign-kernel: image with unsupported kernel format" {
     requires-supported-kernel-signing-machine
 
-    unpack-image "${DEFAULT_TEZI_IMAGE}"
-    local INPUT_IMAGE_DIR=$(echo ${DEFAULT_TEZI_IMAGE} | sed 's/\.tar$//g')
-    local OUTPUT_IMAGE_DIR="SIGNED_${INPUT_IMAGE_DIR}"
+    # Unpack an unsigned image, which has an unsupported kernel format
+    torizoncore-builder images --remove-storage unpack "${DEFAULT_TEZI_IMAGE}"
 
     # unsigned Torizon Docker images have the kernel in Image.gz format
-    run torizoncore-builder secboot sign-kernel "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                --kernel-key-dir "${KERNEL_KEY_DIR}" \
+    run torizoncore-builder secboot sign-kernel "${KERNEL_KEY_DIR}" \
                                                 --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}"
     assert_failure
-    assert_output --partial 'Provided input image does not have the kernel in fitImage format'
-
-    rm -rf "${INPUT_IMAGE_DIR}"
+    assert_output --partial 'Unpacked image does not have the kernel in fitImage format'
 }
 
 @test "secboot sign-kernel: unsupported machine" {
 
     unpack-image "${DEFAULT_TEZI_IMAGE}"
     local INPUT_IMAGE_DIR=$(echo ${DEFAULT_TEZI_IMAGE} | sed 's/\.tar$//g')
-    local OUTPUT_IMAGE_DIR="SIGNED_${INPUT_IMAGE_DIR}"
 
     # change the U-Boot environment file to change the machine name to an invalid one
     UBOOT_ENV_FILE=$(cat "${INPUT_IMAGE_DIR}/image.json" \
@@ -152,11 +132,14 @@ setup_file() {
                          | sed 's/.*"u_boot_env": "\(.*\)",/\1/')
     sed -i 's/^board=/board=dummy-/' "${INPUT_IMAGE_DIR}/${UBOOT_ENV_FILE}"
 
-    run torizoncore-builder secboot sign-kernel "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                --kernel-key-dir "${KERNEL_KEY_DIR}" \
+    # Unpack the image to internal storage
+    torizoncore-builder images --remove-storage unpack "${INPUT_IMAGE_DIR}"
+
+    run torizoncore-builder secboot sign-kernel "${KERNEL_KEY_DIR}" \
                                                 --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}"
     assert_failure
     assert_output --partial "TorizonCore Builder doesn't support signing the kernel of images for"
+    torizoncore-builder-clean-storage
     rm -rf "${INPUT_IMAGE_DIR}"
 }
 
@@ -165,62 +148,53 @@ setup_file() {
     requires-supported-kernel-signing-machine
     requires-signed-image
 
-    unpack-image "${DEFAULT_SIGNED_TEZI_IMAGE}"
-    local INPUT_IMAGE_DIR=$(echo ${DEFAULT_SIGNED_TEZI_IMAGE} | sed 's/\.tar$//g')
-    local OUTPUT_IMAGE_DIR="SIGNED_${INPUT_IMAGE_DIR}"
+    torizoncore-builder images --remove-storage unpack "${DEFAULT_SIGNED_TEZI_IMAGE}"
 
-    if [ -d  "${OUTPUT_IMAGE_DIR}" ]; then
-        rm -rf "${OUTPUT_IMAGE_DIR}"
-    fi
-    # run without --force
-    run torizoncore-builder secboot sign-kernel "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                --kernel-key-dir "${KERNEL_KEY_DIR}" \
+    run torizoncore-builder secboot sign-kernel "${KERNEL_KEY_DIR}" \
                                                 --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}"
     assert_success
     assert_output --partial "Updating fitImage configurations to be signed with key name: ${KERNEL_KEY_NAME}"
     assert_output --partial "Using ${KERNEL_KEY_ALGO} for the signing process"
     assert_output --partial 'Kernel fitImage signed successfully'
-    assert_output --partial 'Copying signed kernel fitImage to image rootfs'
-    assert_output --partial 'Kernel in Torizon OS image signed successfully'
+    assert_output --partial 'Kernel in unpacked Torizon OS image signed successfully'
 
-    # run with --force
-    run torizoncore-builder secboot sign-kernel "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                --kernel-key-dir "${KERNEL_KEY_DIR}" \
-                                                --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}" \
-                                                --force
+    run torizoncore-builder-shell "ls -l /storage/kernel/usr/lib/modules/*/vmlinuz"
+    assert_success
+
+    torizoncore-builder-clean-storage
+
+    # run with --kernel-key parameters separated with space (should still work)
+    torizoncore-builder images --remove-storage unpack "${DEFAULT_SIGNED_TEZI_IMAGE}"
+
+    run torizoncore-builder secboot sign-kernel "${KERNEL_KEY_DIR}" \
+                                                --kernel-key "name = ${KERNEL_KEY_NAME}; algo = ${KERNEL_KEY_ALGO}"
     assert_success
     assert_output --partial "Updating fitImage configurations to be signed with key name: ${KERNEL_KEY_NAME}"
     assert_output --partial "Using ${KERNEL_KEY_ALGO} for the signing process"
     assert_output --partial 'Kernel fitImage signed successfully'
-    assert_output --partial 'Removing pre-existing directory'
-    assert_output --partial 'Copying signed kernel fitImage to image rootfs'
-    assert_output --partial 'Kernel in Torizon OS image signed successfully'
+    assert_output --partial 'Kernel in unpacked Torizon OS image signed successfully'
 
-    # run with --force, --kernel-key parameters separated with space (should still work)
-    run torizoncore-builder secboot sign-kernel "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                --kernel-key-dir "${KERNEL_KEY_DIR}" \
-                                                --kernel-key "name = ${KERNEL_KEY_NAME}; algo = ${KERNEL_KEY_ALGO}" \
-                                                --force
+    run torizoncore-builder-shell "ls -l /storage/kernel/usr/lib/modules/*/vmlinuz"
     assert_success
-    assert_output --partial "Updating fitImage configurations to be signed with key name: ${KERNEL_KEY_NAME}"
-    assert_output --partial "Using ${KERNEL_KEY_ALGO} for the signing process"
-    assert_output --partial 'Kernel fitImage signed successfully'
-    assert_output --partial 'Removing pre-existing directory'
-    assert_output --partial 'Copying signed kernel fitImage to image rootfs'
-    assert_output --partial 'Kernel in Torizon OS image signed successfully'
 
-    # sign image in place
-    run torizoncore-builder secboot sign-kernel "${OUTPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                --kernel-key-dir "${KERNEL_KEY_DIR}" \
-                                                --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}" \
-                                                --force
+    local CONFIG_LIST=$(torizoncore-builder-shell \
+                        "fdtget -ts /storage/kernel/usr/lib/modules/*/vmlinuz \
+                        /configurations -l")
+
+    local CONFIG1=$(echo "${CONFIG_LIST}" | head -n 1)
+
+    local CONFIG1_SUBNODES=$(torizoncore-builder-shell \
+                             "fdtget -ts /storage/kernel/usr/lib/modules/*/vmlinuz \
+                             /configurations/${CONFIG1} -l")
+
+    local SIG_NODE=$(echo "${CONFIG1_SUBNODES}" | grep signature)
+
+    local FOUND_KEY_NAME=$(torizoncore-builder-shell \
+                           "fdtget -ts /storage/kernel/usr/lib/modules/*/vmlinuz \
+                           /configurations/${CONFIG1}/${SIG_NODE} key-name-hint")
+
+    run test "${FOUND_KEY_NAME}" == "${KERNEL_KEY_NAME}"
     assert_success
-    assert_output --partial "Updating fitImage configurations to be signed with key name: ${KERNEL_KEY_NAME}"
-    assert_output --partial "Using ${KERNEL_KEY_ALGO} for the signing process"
-    assert_output --partial 'Kernel fitImage signed successfully'
-    assert_output --partial 'Updating Torizon OS image in place'
-    assert_output --partial 'Copying signed kernel fitImage to image rootfs'
-    assert_output --partial 'Kernel in Torizon OS image signed successfully'
 }
 
 @test "secboot sign-bootloader-hab: check help output" {
@@ -234,37 +208,32 @@ setup_file() {
     run torizoncore-builder secboot sign-bootloader-hab
     assert_failure
     assert_output --partial \
-        "the following arguments are required: INPUT_DIRECTORY, OUTPUT_DIRECTORY, --cst-dir"
+        "the following arguments are required: CST_DIR"
+}
+
+@test "secboot sign-bootloader-hab: attempt to sign kernel FIT without images unpack" {
+    torizoncore-builder-clean-storage
+
+    local CST_DIR="${CST_DIRS}/hab/cst-3.4.1_tcb_test_rsa_2048"
+
+    run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" --cst-crypto rsa \
+                                                        --cst-dig-algo sha256 --cst-srk-index 1 \
+                                                        --kernel-key-dir "${KERNEL_KEY_DIR}" \
+                                                        --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}"
+    assert_failure
+    assert_output --partial "Error: could not find an Easy Installer or WIC image in the storage"
+    assert_output --partial "Please use the 'images' command to unpack an image before running this command"
 }
 
 @test "secboot sign-bootloader-hab: invalid parameters" {
 
-    local INPUT_IMAGE_DIR="TEST_$(echo ${DEFAULT_TEZI_IMAGE} | sed 's/\.tar$//g')"
-    local OUTPUT_IMAGE_DIR="SIGNED_${INPUT_IMAGE_DIR}"
     local CST_DIR="${CST_DIRS}/hab/cst-3.4.1_tcb_test_rsa_2048"
 
-    # create dummy input directory
-    mkdir -p "${INPUT_IMAGE_DIR}"
-
-    # non-existent input directory
-    run torizoncore-builder secboot sign-bootloader-hab "foo" "${OUTPUT_IMAGE_DIR}" \
-                                                        --cst-dir "${CST_DIR}" --cst-crypto rsa \
-                                                        --cst-dig-algo sha256 --cst-srk-index 1
-    assert_failure
-    assert_output --partial 'does not exist'
-
-    # output directory already exists and --force was not passed
-    mkdir -p "${OUTPUT_IMAGE_DIR}"
-    run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                        --cst-dir "${CST_DIR}" --cst-crypto rsa \
-                                                        --cst-dig-algo sha256 --cst-srk-index 1
-    assert_failure
-    assert_output --partial 'already exists'
-    rm -rf "${OUTPUT_IMAGE_DIR}"
+    # Unpack an unsigned image just so the initial 'images unpack' check is passed
+    torizoncore-builder images --remove-storage unpack "${DEFAULT_TEZI_IMAGE}"
 
     # non-existent kernel key directory
-    run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                        --cst-dir "${CST_DIR}" --cst-crypto rsa \
+    run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" --cst-crypto rsa \
                                                         --cst-dig-algo sha256 --cst-srk-index 1 \
                                                         --kernel-key-dir "foo" \
                                                         --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}"
@@ -272,8 +241,7 @@ setup_file() {
     assert_output --partial 'does not exist'
 
     # non-existent key with provided name
-    run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                        --cst-dir "${CST_DIR}" --cst-crypto rsa \
+    run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" --cst-crypto rsa \
                                                         --cst-dig-algo sha256 --cst-srk-index 1 \
                                                         --kernel-key-dir "${KERNEL_KEY_DIR}" \
                                                         --kernel-key "name=foo;algo=${KERNEL_KEY_ALGO}"
@@ -281,69 +249,57 @@ setup_file() {
     assert_output --partial 'Could not find'
 
     # Provide --kernel-key-dir but not --kernel-key
-    run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                        --cst-dir "${CST_DIR}" --cst-crypto rsa \
+    run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" --cst-crypto rsa \
                                                         --cst-dig-algo sha256 --cst-srk-index 1 \
                                                         --kernel-key-dir "${KERNEL_KEY_DIR}"
     assert_failure
     assert_output --partial '--kernel-key-dir was passed but --kernel-key was not'
 
     # Provide --kernel-key but not --kernel-key-dir
-    run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                        --cst-dir "${CST_DIR}" --cst-crypto rsa \
+    run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" --cst-crypto rsa \
                                                         --cst-dig-algo sha256 --cst-srk-index 1 \
                                                         --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}"
     assert_failure
     assert_output --partial '--kernel-key was passed but --kernel-key-dir was not'
 
     # invalid type of cryptographic keys
-    run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                        --cst-dir "${CST_DIR}" \
+    run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" \
                                                         --cst-crypto invalid_key_type
     assert_failure
     assert_output --partial 'argument --cst-crypto: invalid choice:'
 
     # invalid CST digest algorithm
-    run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                        --cst-dir "${CST_DIR}" \
+    run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" \
                                                         --cst-dig-algo invalid_dig_algo
     assert_failure
     assert_output --partial 'argument --cst-dig-algo: invalid choice:'
 
     # invalid SRK table index
-    run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                        --cst-dir "${CST_DIR}" --cst-srk-index 0
+    run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" --cst-srk-index 0
     assert_failure
     assert_output --partial 'argument --cst-srk-index: invalid choice:'
-
-    # delete dummy input directory
-    rm -rf "${INPUT_IMAGE_DIR}"
 }
 
 @test "secboot sign-bootloader-hab: image with unsupported kernel format" {
     requires-supported-hab-signing-machine
 
-    unpack-image "${DEFAULT_TEZI_IMAGE}"
-    local INPUT_IMAGE_DIR=$(echo ${DEFAULT_TEZI_IMAGE} | sed 's/\.tar$//g')
-    local OUTPUT_IMAGE_DIR="SIGNED_${INPUT_IMAGE_DIR}"
+    # Unpack an unsigned image, which has an unsupported kernel format
+    torizoncore-builder images --remove-storage unpack "${DEFAULT_TEZI_IMAGE}"
+
     local CST_DIR="${CST_DIRS}/hab/cst-3.4.1_tcb_test_rsa_2048"
 
     # unsigned Torizon Docker images have the kernel in Image.gz format
-    run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                        --cst-dir "${CST_DIR}" --cst-crypto rsa \
+    run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" --cst-crypto rsa \
                                                         --cst-key-size 2048 --cst-key-exp 65537 \
                                                         --cst-dig-algo sha256 --cst-srk-index 1
     assert_failure
-    assert_output --partial 'Provided input image does not have the kernel in fitImage format'
-
-    rm -rf "${INPUT_IMAGE_DIR}"
+    assert_output --partial 'Unpacked image does not have the kernel in fitImage format'
 }
 
 @test "secboot sign-bootloader-hab: machine not compatible with HAB" {
 
     unpack-image "${DEFAULT_TEZI_IMAGE}"
     local INPUT_IMAGE_DIR=$(echo ${DEFAULT_TEZI_IMAGE} | sed 's/\.tar$//g')
-    local OUTPUT_IMAGE_DIR="SIGNED_${INPUT_IMAGE_DIR}"
     local CST_DIR="${CST_DIRS}/hab/cst-3.4.1_tcb_test_rsa_2048"
 
     # change the U-Boot environment file to change the machine name to an invalid one
@@ -352,8 +308,10 @@ setup_file() {
                          | sed 's/.*"u_boot_env": "\(.*\)",/\1/')
     sed -i 's/^board=/board=dummy-/' "${INPUT_IMAGE_DIR}/${UBOOT_ENV_FILE}"
 
-    run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                        --cst-dir "${CST_DIR}" --cst-crypto rsa \
+    # Unpack the image to internal storage
+    torizoncore-builder images --remove-storage unpack "${INPUT_IMAGE_DIR}"
+
+    run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" --cst-crypto rsa \
                                                         --cst-key-size 2048 --cst-key-exp 65537 \
                                                         --cst-dig-algo sha256 --cst-srk-index 1
     assert_failure
@@ -365,30 +323,23 @@ setup_file() {
     requires-supported-hab-signing-machine
     requires-signed-image
 
-    unpack-image "${DEFAULT_SIGNED_TEZI_IMAGE}"
-    local INPUT_IMAGE_DIR=$(echo ${DEFAULT_SIGNED_TEZI_IMAGE} | sed 's/\.tar$//g')
-    local OUTPUT_IMAGE_DIR="SIGNED_${INPUT_IMAGE_DIR}"
     local CST_DIR="${CST_DIRS}/hab/cst-3.4.1_tcb_test_rsa_2048"
 
     # copy CST binaries to CST_DIR before running tests
     cp -r "${CST_BINARIES_DIR}/linux32" "${CST_DIR}"
     cp -r "${CST_BINARIES_DIR}/linux64" "${CST_DIR}"
 
-    if [ -d "${OUTPUT_IMAGE_DIR}" ]; then
-        rm -rf "${OUTPUT_IMAGE_DIR}"
-    fi
+    torizoncore-builder images --remove-storage unpack "${DEFAULT_SIGNED_TEZI_IMAGE}"
 
     # non-existent CST directory
-    run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                        --cst-dir "cst_foo" --cst-crypto rsa \
+    run torizoncore-builder secboot sign-bootloader-hab "cst_foo" --cst-crypto rsa \
                                                         --cst-key-size 2048 --cst-key-exp 65537 \
                                                         --cst-dig-algo sha256 --cst-srk-index 1
     assert_failure
     assert_output --partial 'does not exist'
 
     # non-existent SRK table binary
-    run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                        --cst-dir "${CST_DIR}" --cst-crypto rsa \
+    run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" --cst-crypto rsa \
                                                         --cst-key-size 2048 --cst-key-exp 65537 \
                                                         --cst-dig-algo sha256 --cst-srk-index 1 \
                                                         --cst-srk-table "foo.bin"
@@ -396,55 +347,38 @@ setup_file() {
     assert_output --partial 'Could not find'
 
     # non-existent SRK fuse binary
-    run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                        --cst-dir "${CST_DIR}" --cst-crypto rsa \
+    run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" --cst-crypto rsa \
                                                         --cst-key-size 2048 --cst-key-exp 65537 \
                                                         --cst-dig-algo sha256 --cst-srk-index 1 \
                                                         --cst-srk-fuse "foo.bin"
     assert_failure
     assert_output --partial 'Could not find'
 
-    # run without --force
-    run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                        --cst-dir "${CST_DIR}" --cst-crypto rsa \
+    # run without providing a kernel FIT public key
+    run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" --cst-crypto rsa \
                                                         --cst-key-size 2048 --cst-key-exp 65537 \
                                                         --cst-dig-algo sha256 --cst-srk-index 1
     assert_success
     assert_output --partial 'flash.bin created successfully'
     assert_output --partial 'Using SRK1 for signing'
     assert_output --partial 'Bootloader container signed successfully'
+    assert_output --partial 'The bootloader DTBs were NOT updated with a new public key'
     assert_output --partial 'Bootloader in Torizon OS image signed successfully'
 
-    # sign image in place
-    run torizoncore-builder secboot sign-bootloader-hab "${OUTPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
-                                                        --cst-dir "${CST_DIR}" --cst-crypto rsa \
-                                                        --cst-key-size 2048 --cst-key-exp 65537 \
-                                                        --cst-dig-algo sha256 --cst-srk-index 1 \
-                                                        --force
-    assert_success
-    assert_output --partial 'flash.bin created successfully'
-    assert_output --partial 'Using SRK1 for signing'
-    assert_output --partial 'Bootloader container signed successfully'
-    assert_output --partial 'Updating Torizon OS image in place'
-    assert_output --partial 'Bootloader in Torizon OS image signed successfully'
-
-
-    # run with --force for all four SRK indexes, adding kernel public key to U-Boot DTB before signing
+    # run for all four SRK indexes, adding kernel public key to U-Boot DTB before signing
     for i in {1..4}
     do
-        run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
+        run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" \
                                                             --kernel-key-dir "${KERNEL_KEY_DIR}" \
                                                             --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}" \
-                                                            --cst-dir "${CST_DIR}" --cst-crypto rsa \
-                                                            --cst-key-size 2048 --cst-key-exp 65537 \
-                                                            --cst-dig-algo sha256 --cst-srk-index ${i} \
-                                                            --force
+                                                            --cst-crypto rsa --cst-key-size 2048 \
+                                                            --cst-key-exp 65537 --cst-dig-algo sha256 \
+                                                            --cst-srk-index ${i}
         assert_success
         assert_output --partial "Adding public key '${KERNEL_KEY_NAME}' in ${KERNEL_KEY_DIR} to U-Boot DTB"
         assert_output --partial 'flash.bin created successfully'
         assert_output --partial "Using SRK${i} for signing"
         assert_output --partial 'Bootloader container signed successfully'
-        assert_output --partial 'Removing pre-existing directory'
         assert_output --partial 'Bootloader in Torizon OS image signed successfully'
     done
 
@@ -457,30 +391,29 @@ setup_file() {
     requires-supported-hab-signing-machine
     requires-signed-image
 
-    local INPUT_IMAGE_DIR=$(echo ${DEFAULT_SIGNED_TEZI_IMAGE} | sed 's/\.tar$//g')
-    local OUTPUT_IMAGE_DIR="SIGNED_${INPUT_IMAGE_DIR}"
     local CST_DIR="${CST_DIRS}/hab/cst-3.4.1_tcb_test_rsa_1024_no_ca"
 
     # copy CST binaries to CST_DIR before running tests
     cp -r "${CST_BINARIES_DIR}/linux32" "${CST_DIR}"
     cp -r "${CST_BINARIES_DIR}/linux64" "${CST_DIR}"
 
-    # run with --force for all four SRK indexes, adding kernel public key to U-Boot DTB before signing
+    torizoncore-builder images --remove-storage unpack "${DEFAULT_SIGNED_TEZI_IMAGE}"
+
+    # run for all four SRK indexes, adding kernel public key to U-Boot DTB before signing
     for i in {1..4}
     do
-        run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
+        run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" \
                                                             --kernel-key-dir "${KERNEL_KEY_DIR}" \
                                                             --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}" \
-                                                            --cst-dir "${CST_DIR}" --cst-crypto rsa \
-                                                            --cst-key-size 1024 --cst-key-exp 65537 \
-                                                            --cst-dig-algo sha256 --cst-srk-index ${i} \
-                                                            --cst-srk-no-ca --force
+                                                            --cst-crypto rsa --cst-key-size 1024 \
+                                                            --cst-key-exp 65537 --cst-dig-algo sha256 \
+                                                            --cst-srk-index ${i} --cst-srk-no-ca
+
         assert_success
         assert_output --partial "Adding public key '${KERNEL_KEY_NAME}' in ${KERNEL_KEY_DIR} to U-Boot DTB"
         assert_output --partial 'flash.bin created successfully'
         assert_output --partial "Using SRK${i} for signing"
         assert_output --partial 'Bootloader container signed successfully'
-        assert_output --partial 'Removing pre-existing directory'
         assert_output --partial 'Bootloader in Torizon OS image signed successfully'
     done
 
@@ -493,29 +426,28 @@ setup_file() {
     requires-supported-hab-signing-machine
     requires-signed-image
 
-    local INPUT_IMAGE_DIR=$(echo ${DEFAULT_SIGNED_TEZI_IMAGE} | sed 's/\.tar$//g')
-    local OUTPUT_IMAGE_DIR="SIGNED_${INPUT_IMAGE_DIR}"
     local CST_DIR="${CST_DIRS}/hab/cst-3.4.1_tcb_test_ecdsa_p384"
 
     # copy CST binaries to CST_DIR before running tests
     cp -r "${CST_BINARIES_DIR}/linux32" "${CST_DIR}"
     cp -r "${CST_BINARIES_DIR}/linux64" "${CST_DIR}"
 
-    # run with --force for all four SRK indexes, adding kernel public key to U-Boot DTB before signing
+    torizoncore-builder images --remove-storage unpack "${DEFAULT_SIGNED_TEZI_IMAGE}"
+
+    # run for all four SRK indexes, adding kernel public key to U-Boot DTB before signing
     for i in {1..4}
     do
-        run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
+        run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" \
                                                             --kernel-key-dir "${KERNEL_KEY_DIR}" \
                                                             --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}" \
-                                                            --cst-dir "${CST_DIR}" --cst-crypto ecdsa \
-                                                            --cst-key-size secp384r1 --cst-dig-algo sha256 \
-                                                            --cst-srk-index ${i} --force
+                                                            --cst-crypto ecdsa --cst-key-size secp384r1 \
+                                                            --cst-dig-algo sha256 --cst-srk-index ${i}
+
         assert_success
         assert_output --partial "Adding public key '${KERNEL_KEY_NAME}' in ${KERNEL_KEY_DIR} to U-Boot DTB"
         assert_output --partial 'flash.bin created successfully'
         assert_output --partial "Using SRK${i} for signing"
         assert_output --partial 'Bootloader container signed successfully'
-        assert_output --partial 'Removing pre-existing directory'
         assert_output --partial 'Bootloader in Torizon OS image signed successfully'
     done
 
@@ -528,29 +460,28 @@ setup_file() {
     requires-supported-hab-signing-machine
     requires-signed-image
 
-    local INPUT_IMAGE_DIR=$(echo ${DEFAULT_SIGNED_TEZI_IMAGE} | sed 's/\.tar$//g')
-    local OUTPUT_IMAGE_DIR="SIGNED_${INPUT_IMAGE_DIR}"
     local CST_DIR="${CST_DIRS}/hab/cst-3.4.1_tcb_test_ecdsa_p521_no_ca"
 
     # copy CST binaries to CST_DIR before running tests
     cp -r "${CST_BINARIES_DIR}/linux32" "${CST_DIR}"
     cp -r "${CST_BINARIES_DIR}/linux64" "${CST_DIR}"
 
-    # run with --force for all four SRK indexes, adding kernel public key to U-Boot DTB before signing
+    torizoncore-builder images --remove-storage unpack "${DEFAULT_SIGNED_TEZI_IMAGE}"
+
+    # run for all four SRK indexes, adding kernel public key to U-Boot DTB before signing
     for i in {1..4}
     do
-        run torizoncore-builder secboot sign-bootloader-hab "${INPUT_IMAGE_DIR}" "${OUTPUT_IMAGE_DIR}" \
+        run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" \
                                                             --kernel-key-dir "${KERNEL_KEY_DIR}" \
                                                             --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}" \
-                                                            --cst-dir "${CST_DIR}" --cst-crypto ecdsa \
-                                                            --cst-key-size secp521r1 --cst-dig-algo sha256 \
-                                                            --cst-srk-index ${i} --cst-srk-no-ca --force
+                                                            --cst-crypto ecdsa --cst-key-size secp521r1 \
+                                                            --cst-dig-algo sha256 --cst-srk-index ${i} \
+                                                            --cst-srk-no-ca
         assert_success
         assert_output --partial "Adding public key '${KERNEL_KEY_NAME}' in ${KERNEL_KEY_DIR} to U-Boot DTB"
         assert_output --partial 'flash.bin created successfully'
         assert_output --partial "Using SRK${i} for signing"
         assert_output --partial 'Bootloader container signed successfully'
-        assert_output --partial 'Removing pre-existing directory'
         assert_output --partial 'Torizon OS image signed successfully'
     done
 


### PR DESCRIPTION
Refactor sign-kernel and sign-bootloader-hab to affect the current unpacked image instead of asking for an input image. This way the secboot commands would follow the stateful workflow applied for other standalone commands, which is similar to this:

`images unpack` -> `secboot` commands -> `union` -> `deploy`

This workflow also guarantees that the re-signed kernel FIT is included in an OSTree commit and is properly tracked, which wasn't the case with the previous implementation of the sign-kernel command.

Also add the sign feature of the secboot commands above to the build command, covering the stateless workflow as well.

CI tests for the secboot commands were adapted for the refactoring, and new tests covering the new signing feature of the build command were added.

Related-to: TCB-731

Signed-off-by: Lucas Akira Morishita <lucas.morishita@toradex.com>