### PR TITLE
tests/integration: Remove docker network usage in zeroconf test

### DIFF
--- a/tests/integration/functions.sh
+++ b/tests/integration/functions.sh
@@ -37,21 +37,13 @@ export TCB_BG_CONTAINER=""
 
 # run torizoncore-builder-bg
 torizoncore-builder-bg() {
-    # If this function was called by torizoncore-builder-bg-alt_network,
-    # use --network=$TCB_BG_ALT_NETWORK, otherwise use --network=host
-    local tcbcmd
-    if [ -z "${TCBCMD_BG_OVERRIDE}" ]; then
-	    tcbcmd="${TCBCMD}"
-    else
-	    tcbcmd="${TCBCMD_BG_OVERRIDE}"
-    fi
     # Make sure no other process is running in the background
     assert [ -z $TCB_BG_CONTAINER ]
     # Make sure the docker command does not have the "-it" parameter(s)
     [[ $TCBCMD == *" -it"* ]] && assert false
     # Replace the "run" in "docker run ..." with "run -d" to run it in detached mode
     # and to output the ID of the container.
-    local CMD=$(eval echo ${tcbcmd/ run / run -d })
+    local CMD=$(eval echo ${TCBCMD/ run / run -d })
     # Print alias definition if test fail
     echo "torizoncore-builder-bg alias was defined as: $CMD $@"
     # Run container in the background
@@ -64,14 +56,6 @@ torizoncore-builder-bg() {
     sleep 5
 }
 export -f torizoncore-builder-bg
-
-# run torizoncore-builder-bg-alt_network
-torizoncore-builder-bg-alt_network() {
-    local tcbcmd="${TCBCMD/--network=host/--network=$TCB_BG_ALT_NETWORK}"
-    tcbcmd="${tcbcmd/--net=host/--net=$TCB_BG_ALT_NETWORK}"
-    TCBCMD_BG_OVERRIDE="${tcbcmd}" torizoncore-builder-bg "$@"
-}
-export -f torizoncore-builder-bg-alt_network
 
 # run stop-torizoncore-builder-bg
 stop-torizoncore-builder-bg() {

--- a/tests/integration/setup.sh
+++ b/tests/integration/setup.sh
@@ -86,27 +86,10 @@ tcb_tests_clean_storage_volume() {
     fi
 }
 
-# Create a docker network for TCB tests
-tcb_create_docker_network() {
-    export TCB_BG_ALT_NETWORK="tcb_network"
-    if docker network ls --format '{{.Name}}' | grep -q "^${TCB_BG_ALT_NETWORK}$"; then
-        echo "Docker network '${TCB_BG_ALT_NETWORK}' already exists."
-        return 0
-    fi
-
-    if docker network create "$TCB_BG_ALT_NETWORK" > /dev/null; then
-        echo "Docker network '${TCB_BG_ALT_NETWORK}' created successfully."
-    else
-        echo "Error: could not create docker network!"
-        return 1
-    fi
-}
-
 tcb_tests_main() {
     local WORKDIR="workdir"
     tcb_tests_prepare $WORKDIR && \
         tcb_tests_install_bats $WORKDIR && \
-        tcb_create_docker_network && \
         tcb_tests_pull_container $WORKDIR && \
         tcb_tests_clean_storage_volume && \
         echo "Environment successfully configured to start integration tests."

--- a/tests/integration/testcases/images-serve.bats
+++ b/tests/integration/testcases/images-serve.bats
@@ -25,9 +25,9 @@ teardown() {
 
 @test "images serve: check zeroconf tezi service response." {
     IMAGE_DIR="samples/images"
-    torizoncore-builder-bg-alt_network images serve $IMAGE_DIR
+    torizoncore-builder-bg images serve $IMAGE_DIR
 
-    run docker run -i --rm --privileged --network=$TCB_BG_ALT_NETWORK alpine:latest sh -c "
+    run docker run -i --rm --privileged --network=host alpine:latest sh -c "
         apk update && apk add avahi avahi-tools dbus &&
         mkdir -p /run/dbus &&
         dbus-uuidgen > /var/lib/dbus/machine-id &&


### PR DESCRIPTION
First of all, this approach of creating a Docker network does not reflect the behavior of the user when running this command, since the torizoncore-builder commands do not use Docker networks, but instead use "--network=host" in Linux.

In addition, this Docker network is not necessary for these tests; they succeed in Linux just fine using the standard approach of passing "--network=host" to the torizoncore-builder Docker command. It fails in WSL, but images serve commands are not suported in WSL.