### PR TITLE
tests/integration: Fix build and bundle commands failing in WSL

### DIFF
--- a/tests/integration/functions.sh
+++ b/tests/integration/functions.sh
@@ -118,6 +118,23 @@ device-reboot() {
 }
 export -f device-reboot
 
+# run get-host-ip
+get-host-ip() {
+    local TARGET_IP=${1?target IP must be passed}
+    if uname -r 2>/dev/null | grep -iq "microsoft"; then
+        ipconfig.exe 2>/dev/null |
+        sed -n '/adapter \(Ethernet\|Wi[- ]Fi\)/,/^[^[:space:]]/{
+            /^[[:space:]]*IPv4 Address/{
+                s/.*: *\([0-9.]\+\).*/\1/p
+                q
+            }
+        }'
+    else
+        ip route get $TARGET_IP | sed -ne 's/.*\bsrc\b \b\([^ ]\+\)\b.*/\1/p'
+    fi
+}
+export -f get-host-ip
+
 # skip test if device not configured
 requires-device() {
     if [ -z "$DEVICE_ADDR" ]; then

--- a/tests/integration/setup.sh
+++ b/tests/integration/setup.sh
@@ -54,7 +54,7 @@ tcb_tests_pull_container() {
     local SCRIPT_PARAMS="-a remote"
     if uname -r | grep -i "microsoft" > /dev/null; then
         # Add extra parameters to allow "ostree serve" to work under Windows.
-        SCRIPT_PARAMS="${SCRIPT_PARAMS} -- -p 8080:8080"
+        SCRIPT_PARAMS="${SCRIPT_PARAMS} -- --network=host"
     fi
 
     echo "Pulling TorizonCore Builder container..."

--- a/tests/integration/testcases/images-serve.bats
+++ b/tests/integration/testcases/images-serve.bats
@@ -52,3 +52,19 @@ teardown() {
     assert_output --partial '/image.json'
     stop-torizoncore-builder-bg
 }
+
+# bats test_tags=requires-device
+@test "images serve: check if 'image_list.json' is reachable by device." {
+    skip-under-ci
+    requires-device
+    IMAGE_DIR="samples/images"
+    torizoncore-builder-bg images serve $IMAGE_DIR
+
+    HOST_IP=$(get-host-ip $DEVICE_ADDR)
+    run device-shell "wget -S http://$HOST_IP/image_list.json -O -"
+    assert_success
+    assert_output --partial 'Cache-Control: no-store,max-age=0'
+    assert_output --partial 'config_format'
+    assert_output --partial '/image.json'
+    stop-torizoncore-builder-bg
+}

--- a/tests/integration/testcases/ostree.bats
+++ b/tests/integration/testcases/ostree.bats
@@ -62,6 +62,39 @@ teardown() {
     stop-torizoncore-builder-bg
 }
 
+# bats test_tags=requires-device
+@test "ostree serve: serve repo from storage and check if it's reachable by device" {
+    skip-under-ci
+    requires-device
+    ORIGINAL_REFERENCES=("base")
+    run torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+    assert_success
+    assert_output --partial "Unpacked OSTree from Toradex Easy Installer image"
+
+    run torizoncore-builder-shell "ostree --repo=/storage/sysroot/ostree/repo refs"
+    assert_success
+    while IFS= read -r line; do
+      ORIGINAL_REFERENCES+=("${line#*:}")
+    done < <(echo "$output" | sed -E '/ostree\/[0-9]+\/[0-9]+\/[0-9]+/d')
+
+    torizoncore-builder-bg ostree serve
+
+    HOST_IP=$(get-host-ip $DEVICE_ADDR)
+    run device-shell "wget -S http://$HOST_IP:8080/config -O -"
+    assert_success
+
+    run device-shell "ostree --repo=/tmp/test-repo init && \
+      ostree --repo=/tmp/test-repo remote add srv1 http://$HOST_IP:8080 && \
+      ostree --repo=/tmp/test-repo remote refs srv1"
+    assert_success
+
+    for ref in "${ORIGINAL_REFERENCES[@]}"; do
+        assert_line --partial "$ref"
+    done
+    stop-torizoncore-builder-bg
+}
+
+
 @test "ostree serve: serve repo from external directory" {
     run torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
     assert_success
@@ -70,6 +103,22 @@ teardown() {
     torizoncore-builder-bg ostree serve --ostree-repo-directory "samples/ostree-empty/"
 
     run docker run --rm --network=host busybox:stable wget -S http://localhost:8080/config -O -
+    assert_success
+    stop-torizoncore-builder-bg
+}
+
+# bats test_tags=requires-device
+@test "ostree serve: serve repo from external directory and check if it's reachable by device" {
+    skip-under-ci
+    requires-device
+    run torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+    assert_success
+    assert_output --partial "Unpacked OSTree from Toradex Easy Installer image"
+
+    torizoncore-builder-bg ostree serve --ostree-repo-directory "samples/ostree-empty/"
+
+    HOST_IP=$(get-host-ip $DEVICE_ADDR)
+    run device-shell "wget -S http://$HOST_IP:8080/config -O -"
     assert_success
     stop-torizoncore-builder-bg
 }


### PR DESCRIPTION
The `build` and `bundle` tests are passing in GitLab CI. The failing tests in `wsl-aval` jobs are known and related to TCB-729.

The new tests are being skipped in CI, for the reasons explained in commit message. These are the results running in local WSL.

```
🐧 testuser @rdwin-nb~/torizoncore-builder/tests/integration: git rev-parse HEAD
45a4397e80109dc309510e906173d6e9f3dec4d6
🐧 testuser @rdwin-nb~/torizoncore-builder/tests/integration: source setup.sh
Installing bats-core v1.12.0...
Installing bats-assert v2.1.0...
Installing bats-file v0.4.0...
Installing bats-support v0.3.0...
Downloading TorizonCore Builder setup script...
Pulling TorizonCore Builder container...
Testing TorizonCore Builder installation...
Removing all stopped containers...
Removing storage volume...
Environment successfully configured to start integration tests.
🐧 testuser @rdwin-nb~/torizoncore-builder/tests/integration: TCB_DEVICE=10.22.1.160 TCB_MACHINE=verdin-imx8mp DEVICE_PASSWORD=xxxxxxxxx TCB_TESTCASE=images-serve ./run.sh
Checking connection with device 10.22.1.160...OK! Found machine verdin-imx8mp.
Test cases using image torizon-docker-verdin-imx8mp-Tezi_7.4.0-devel-20250918+build.305.tar for machine verdin-imx8mp.
Starting integration tests...

Running without report...
images-serve.bats
 ✓ images serve: check help output [1043]
 ✓ images serve: check if 'image_list.json' file exists [974]
 ✓ images serve: check zeroconf tezi service response. [14384]
 ✓ images serve: check if 'image_list.json' is being served. [10897]
 ✓ images serve: check if 'image_list.json' is reachable by device. [11184]

5 tests, 0 failures in 39 seconds

Integration tests finished!
🐧 testuser @rdwin-nb~/torizoncore-builder/tests/integration: TCB_DEVICE=10.22.1.160 TCB_MACHINE=verdin-imx8mp DEVICE_PASSWORD=xxxxxxxxxxxxxx TCB_TESTCASE=ostree ./run.sh
Checking connection with device 10.22.1.160...OK! Found machine verdin-imx8mp.
Test cases using image torizon-docker-verdin-imx8mp-Tezi_7.4.0-devel-20250918+build.305.tar for machine verdin-imx8mp.
Starting integration tests...

Running without report...
ostree.bats
 ✓ ostree: run without parameters [977]
 ✓ ostree: check help output [949]
 ✓ ostree serve: check help output [918]
 ✓ ostree serve: run without images unpack [2074]
 ✓ ostree serve: serve repo from storage [23147]
 ✓ ostree serve: serve repo from storage and check if it's reachable by device [26561]
 ✓ ostree serve: serve repo from external directory [26223]
 ✓ ostree serve: serve repo from external directory and check if it's reachable by device [25081]

8 tests, 0 failures in 107 seconds

Integration tests finished!
```

Note that to get this results, I needed to implement some rules in Windows Firewall. For default Windows Firewall configs, the new tests will failed, what is expected, the purpose of these tests is to monitor this.