### PR TITLE
tests/integration: Fix platform tests failing due to pipeline parallelism

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -203,6 +203,7 @@ build-arm64:
 
 test-host-tc6-platform-release:
   extends: .test-base
+  resource_group: platform
   stage: test
   variables:
     YOCTO_BRANCH: "kirkstone-6.x.y"
@@ -213,9 +214,8 @@ test-host-tc6-platform-release:
       --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}
 
 test-host-tos7-platform-release:
-  needs:
-    - test-host-tc6-platform-release
   extends: .test-base
+  resource_group: platform
   stage: test
   variables:
     YOCTO_BRANCH: "scarthgap-7.x.y"
@@ -226,9 +226,8 @@ test-host-tos7-platform-release:
       --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}
 
 test-host-tos7-platform-nightly:
-  needs:
-    - test-host-tos7-platform-release
   extends: .test-base
+  resource_group: platform
   stage: test
   variables:
     YOCTO_BRANCH: "scarthgap-7.x.y"
@@ -239,9 +238,8 @@ test-host-tos7-platform-nightly:
       --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}
 
 wsl-test-host-tos7-platform-nightly:
-  needs:
-    - test-host-tos7-platform-nightly
   extends: test-host-tos7-platform-nightly
+  resource_group: platform
   tags:
     - windows-wsl
 


### PR DESCRIPTION
According to commit 08ed2e049255d9fb588b8f3493121169fffff1b6, when multiple executions of the "platform tests" occurred at roughly the same time — specifically during the push of a generic package to the Cloud servers — one execution would succeed while the other failed, seemingly at random. That commit introduced a dependency chain between jobs using GitLab CI’s "needs:" keyword. However, this approach does not prevent jobs from different pipelines from running simultaneously.

This commit switches to using GitLab’s "resource_group", which ensures that these jobs never run at the same time, even across different pipelines, since the "resource_group" is enforced at the project level.

Related-to: TCB-754