### PR TITLE
isolate, deploy: Use Fabric library to run shell commands remotely

### DIFF
--- a/requirements_debian.txt
+++ b/requirements_debian.txt
@@ -5,3 +5,4 @@ python-dateutil==2.8.2
 pyyaml==5.3.1
 requests-oauthlib==1.3.0
 debugpy==1.8.7
+fabric==3.2.2

--- a/tcbuilder/backend/common.py
+++ b/tcbuilder/backend/common.py
@@ -65,6 +65,8 @@ RAW_PROP_DEFAULTS = {
     "raw_rootfs_label" : DEFAULT_RAW_ROOTFS_LABEL
 }
 
+REMOTE_CMD_TIMEOUT = 30
+
 # Based on this solution: https://stackoverflow.com/a/50690347
 # Usage of Event object to stop thread was based on:
 # https://www.pythontutorial.net/python-concurrency/python-stop-thread/
@@ -806,16 +808,6 @@ def validate_compose_file(compose_file_data):
         image_name = svc_spec.get('image')
         if not image_name:
             raise InvalidDataError(f"Error: No image specified for service '{svc_name}'.")
-
-
-def run_command_without_sudo(client, command) -> dict:
-    _stdin, stdout, _stderr = client.exec_command(command)
-    status = stdout.channel.recv_exit_status()  # wait for exec_command to finish
-
-    return {
-        "status": status,
-        "stdout": stdout.read().decode("utf-8").strip(),
-    }
 
 
 def is_tcb_container_64bit():

--- a/tcbuilder/backend/deploy.py
+++ b/tcbuilder/backend/deploy.py
@@ -11,7 +11,7 @@ import threading
 import shlex
 
 import guestfs
-import paramiko
+import fabric
 
 # pylint: disable=wrong-import-position
 import gi
@@ -20,7 +20,7 @@ from gi.repository import Gio, OSTree
 
 from tcbuilder.backend import ostree
 from tcbuilder.backend.common import (get_rootfs_tarball, resolve_remote_host,
-                                      run_with_loading_animation, run_command_without_sudo)
+                                      run_with_loading_animation, REMOTE_CMD_TIMEOUT)
 from tcbuilder.backend.rforward import reverse_forward_tunnel, request_port_forward
 from tcbuilder.errors import TorizonCoreBuilderError, InvalidDataError
 from tezi.utils import find_rootfs_content
@@ -420,51 +420,41 @@ def deploy_raw_image(base_raw_img, src_sysroot_dir, src_ostree_archive_dir,
     log.info(f"Image {os.path.basename(output_raw_img)} created successfully!")
 
 
-def run_command_with_sudo(client, command, password) -> dict[str, str]:
-    stdin, stdout, stderr = client.exec_command("sudo -S -- " + command)
-    stdin.write(f"{password}\n")
-    stdin.flush()
-    status = stdout.channel.recv_exit_status()  # wait for exec_command to finish
+def run_command_with_sudo(ssh_connection, command) -> dict:
 
-    stdout_str = stdout.read().decode('utf-8').strip()
-    stderr_str = stderr.read().decode('utf-8').strip()
+    result = ssh_connection.sudo(command, pty=True, hide=True, timeout=REMOTE_CMD_TIMEOUT)
 
-    if status != 0:
-        if len(stdout_str) > 0:
-            log.info(stdout_str)
-        if len(stderr_str) > 0:
-            log.error(stderr_str)
+    # Check exit status
+    if result.failed:
+        log.error(result.stdout.strip())
+        ssh_connection.close()
         raise TorizonCoreBuilderError(f"Failed to run command on module: {command}")
+
+    stdout_str = result.stdout.strip()
 
     if len(stdout_str) > 0:
         log.debug(stdout_str)
-    if len(stderr_str) > 0:
-        log.debug(stderr_str)
 
-    return {'stdout': stdout_str, 'stderr': stderr_str}
+    return {"status": result.exited, "stdout": stdout_str}
 
 
-def is_ostree_compatible(srcmeta, client):
+def is_ostree_compatible(srcmeta, ssh_conn):
     # Check if OSTree is present on the device
-    hash_result = run_command_without_sudo(
-        client,
-        r"ostree admin status | sed -ne 's/^ *\* .* \([0-9a-f]\+\)\.[0-9]\+/\1/p'",
+    hash_result = ssh_conn.run(
+        r"ostree admin status | sed -ne 's/^ *\* .* \([0-9a-f]\+\)\.[0-9]\+/\1/p'"
     )
-    hash_status = hash_result.get("status", 1)
-    hash_stdout = hash_result.get("stdout", "")
+    hash_stdout = hash_result.stdout.strip()
 
-    if hash_status > 0 or not hash_stdout:
+    if hash_result.failed or not hash_stdout:
         log.warning("OSTree not present on host device.")
         return False
 
-    machine_result = run_command_without_sudo(
-        client,
+    machine_result = ssh_conn.run(
         f"ostree show {hash_stdout} --print-metadata-key oe.machine",
     )
-    machine_status = machine_result.get("status", 1)
-    machine_stdout = machine_result.get("stdout", "")
+    machine_stdout = machine_result.stdout.strip()
 
-    if machine_status > 0 or not machine_stdout:
+    if machine_result.failed or not machine_stdout:
         log.warning("Machine is not set in device OSTree metadata.")
         return False
 
@@ -523,75 +513,74 @@ def deploy_ostree_remote(remote_host, remote_username, remote_password, remote_p
     local_ostree_server_port = http_server_thread.server_port
     log.info(f'OSTree server listening on "localhost:{local_ostree_server_port}".')
 
-    client = paramiko.SSHClient()
-    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
     resolved_remote_host = resolve_remote_host(remote_host, remote_mdns)
-    client.connect(hostname=resolved_remote_host,
-                   username=remote_username,
-                   password=remote_password,
-                   port=remote_port)
+    connection_args = {
+        "host": resolved_remote_host,
+        "user": remote_username,
+        "port": remote_port,
+        "connect_kwargs": {'password': remote_password},
+        "config": fabric.Config(overrides={'sudo': {'password': remote_password}})
+    }
+    with fabric.Connection(**connection_args) as conn:
 
-    # Get the reverse TCP port that was chosen by the remote SSH
-    reverse_ostree_server_port = request_port_forward(client.get_transport())
+        conn.open()
+        # Get the reverse TCP port that was chosen by the remote SSH
+        reverse_ostree_server_port = request_port_forward(conn.transport)
 
-    forwarding_thread = threading.Thread(target=reverse_forward_tunnel,
-                                         args=("localhost",
-                                               local_ostree_server_port,
-                                               client.get_transport()))
-    forwarding_thread.daemon = True
-    forwarding_thread.start()
+        forwarding_thread = threading.Thread(target=reverse_forward_tunnel,
+                                             args=("localhost",
+                                                   local_ostree_server_port,
+                                                   conn.transport))
+        forwarding_thread.daemon = True
+        forwarding_thread.start()
 
-    is_compatible = is_ostree_compatible(srcmeta, client)
+        is_compatible = is_ostree_compatible(srcmeta, conn)
 
-    if not is_compatible:
-        raise TorizonCoreBuilderError("Device is NOT compatible. Operation aborted.")
+        if not is_compatible:
+            raise TorizonCoreBuilderError("Device is NOT compatible. Operation aborted.")
 
-    log.debug("Device compatible with image.")
+        log.debug("Device compatible with image.")
 
-    run_command_with_sudo(
-        client,
-        "ostree remote add --no-gpg-verify --force tcbuilder "
-        f"http://localhost:{reverse_ostree_server_port}/",
-        remote_password)
+        run_command_with_sudo(
+            conn,
+            "ostree remote add --no-gpg-verify --force tcbuilder "
+            f"http://localhost:{reverse_ostree_server_port}/")
 
-    log.info("Starting OSTree pull on the device...")
-    run_command_with_sudo(
-        client, f"ostree pull tcbuilder:{csumdeploy}", remote_password)
+        log.info("Starting OSTree pull on the device...")
+        run_command_with_sudo(
+            conn, f"ostree pull tcbuilder:{csumdeploy}")
 
-    log.info("Deploying new OSTree on the device...")
-    # Do the final staging after we set upgrade_available, therefore option --stage
-    run_command_with_sudo(
-        client, f"ostree admin deploy --stage {args_cli} tcbuilder:{csumdeploy}", remote_password)
+        log.info("Deploying new OSTree on the device...")
+        # Do the final staging after we set upgrade_available, therefore option --stage
+        run_command_with_sudo(
+            conn, f"ostree admin deploy --stage {args_cli} tcbuilder:{csumdeploy}")
 
-    # Make sure we set bootcount to 0, it can be > 1 from previous runs
-    run_command_with_sudo(
-        client, "fw_setenv bootcount 0", remote_password)
+        # Make sure we set bootcount to 0, it can be > 1 from previous runs
+        run_command_with_sudo(
+            conn, "fw_setenv bootcount 0")
 
-    # Make sure we remove the rollback flag from previous runs
-    run_command_with_sudo(
-        client, "fw_setenv rollback 0", remote_password)
+        # Make sure we remove the rollback flag from previous runs
+        run_command_with_sudo(
+            conn, "fw_setenv rollback 0")
 
-    # Set upgrade_available for U-Boot
-    run_command_with_sudo(
-        client, "fw_setenv upgrade_available 1", remote_password)
+        # Set upgrade_available for U-Boot
+        run_command_with_sudo(
+            conn, "fw_setenv upgrade_available 1")
 
-    # Finalize the update after we set upgrade_available for U-Boot
-    run_command_with_sudo(
-        client, "ostree admin finalize-staged", remote_password)
+        # Finalize the update after we set upgrade_available for U-Boot
+        run_command_with_sudo(
+            conn, "ostree admin finalize-staged")
 
-    log.info("Deploying successfully finished.")
+        log.info("Deploying successfully finished.")
 
-    if reboot:
-        # If reboot is started in foreground it leads to exit code <> 0 sometimes
-        # which leads to a stack trace in torizoncore-builder. Start in background
-        # to make the command run successfully always.
-        run_command_with_sudo(client, "sh -c 'reboot &'", remote_password)
-        log.info("Device reboot initiated...")
-    else:
-        log.info("Please reboot the device to boot into the new deployment.")
-
-    client.close()
+        if reboot:
+            # If reboot is started in foreground it leads to exit code <> 0 sometimes
+            # which leads to a stack trace in torizoncore-builder. Start in background
+            # to make the command run successfully always.
+            run_command_with_sudo(conn, "sh -c 'reboot &'")
+            log.info("Device reboot initiated...")
+        else:
+            log.info("Please reboot the device to boot into the new deployment.")
 
     ostree.serve_ostree_stop(http_server_thread)
 # pylint: enable=too-many-locals

--- a/tcbuilder/backend/images.py
+++ b/tcbuilder/backend/images.py
@@ -20,7 +20,7 @@ from zipfile import ZipFile
 from tempfile import TemporaryDirectory
 
 import guestfs
-import paramiko
+import fabric
 
 from tcbuilder.backend.common import (get_rootfs_tarball, get_tar_compress_program_options,
                                       set_output_ownership, run_with_loading_animation,
@@ -126,16 +126,14 @@ def get_device_info(r_host, r_username, r_password, r_port):
         container: Container runtime engine.
     """
 
-    client = paramiko.SSHClient()
-    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-
-    client.connect(hostname=r_host,
-                   username=r_username,
-                   password=r_password,
-                   port=r_port)
+    conn = fabric.Connection(host=r_host,
+                             user=r_username,
+                             port=r_port,
+                             connect_kwargs={'password': r_password})
+    conn.open()
 
     # Gather module and version information remotely from device
-    sftp = client.open_sftp()
+    sftp = conn.sftp()
     if sftp is not None:
         release_file = sftp.file("/etc/os-release")
         for line in release_file:
@@ -150,10 +148,10 @@ def get_device_info(r_host, r_username, r_password, r_port):
             container = "docker"
         sftp.close()
     else:
-        client.close()
+        conn.close()
         raise TorizonCoreBuilderError("Unable to create SSH connection")
 
-    client.close()
+    conn.close()
 
     return version, hostname, container
 

--- a/tcbuilder/backend/isolate.py
+++ b/tcbuilder/backend/isolate.py
@@ -3,11 +3,11 @@ import os
 import subprocess
 import shlex
 
-import paramiko
+import fabric
 
 from tcbuilder.errors import OperationFailureError, TorizonCoreBuilderError
 from tcbuilder.backend.ostree import OSTREE_WHITEOUT_PREFIX, OSTREE_OPAQUE_WHITEOUT_NAME
-from tcbuilder.backend.common import resolve_remote_host, run_command_without_sudo
+from tcbuilder.backend.common import resolve_remote_host, REMOTE_CMD_TIMEOUT
 
 IGNORE_FILES = [
     'group-',
@@ -35,15 +35,6 @@ NO_CHANGES = 0
 CHANGES_CAPTURED = 1
 
 
-def run_command_with_sudo(client, command, password):
-    stdin, stdout, _stderr = client.exec_command(command=command, get_pty=True)
-    stdin.write(password + '\n')
-    stdin.flush()
-    status = stdout.channel.recv_exit_status()  # wait for exec_command to finish
-
-    return status, stdin, stdout
-
-
 def ignore_changes_deletion(change):
     # NOTE: this offset must match the output of `ostree admin config`:
     fname = change[5:]
@@ -53,8 +44,8 @@ def ignore_changes_deletion(change):
     return True
 
 
-def remove_tmp_dir(client, tmp_dir_name):
-    run_command_without_sudo(client, 'rm -rf ' + tmp_dir_name)
+def remove_tmp_dir(conn, tmp_dir_name):
+    conn.run('rm -rf ' + tmp_dir_name, hide=True, timeout=REMOTE_CMD_TIMEOUT)
 
 
 def check_path(path):
@@ -62,7 +53,7 @@ def check_path(path):
         path.rsplit('/', 1)[0])
 
 
-def whiteouts(client, sftp_channel, tmp_dir_name, deleted_f_d):
+def whiteouts(ssh_conn, sftp_channel, tmp_dir_name, deleted_f_d):
     # check if deleted file/dir was in subdirectory of /etc --> '/' for file/dir at /etc
     path = check_path(deleted_f_d)
     if path != '/':  # file/dir was in subdirectory of /etc
@@ -81,37 +72,38 @@ def whiteouts(client, sftp_channel, tmp_dir_name, deleted_f_d):
     create_deleted_info_cmd = 'mkdir -p {0}/{1} && touch {0}/{2}'.format(
         tmp_dir_name, deleted_file_dir_to_tar.rsplit('/', 1)[0],
         shlex.quote(deleted_file_dir_to_tar))
-    output = run_command_without_sudo(client, create_deleted_info_cmd)
-    if output.get("status", 1) > 0:
+    result = ssh_conn.run(create_deleted_info_cmd, hide=True, timeout=REMOTE_CMD_TIMEOUT)
+    if result.failed:
         raise OperationFailureError(
             f'Could not create dir in {tmp_dir_name}',
-            output.get("stdout", ""))
+            result.stdout)
 
 
-def get_tcattr_file_content(files_dir_to_tar, ssh_client, sftp_client,
-                            remote_password, tmp_dir_name):
+def get_tcattr_file_content(files_dir_to_tar, ssh_conn, tmp_dir_name):
     """
     Get the content (permission/ownership) for the "/etc/.tcattr"
     metadata file of all files that will be isolated and will be
     used later by the "union" command.
     """
 
-    facl_command = "sudo getfacl -n {0} 2>/dev/null".format(files_dir_to_tar)
-    status, _stdin, stdout = run_command_with_sudo(ssh_client, facl_command,
-                                                   remote_password)
-    if status > 0:
-        remove_tmp_dir(ssh_client, tmp_dir_name)
-        sftp_client.close()
-        ssh_client.close()
-        facl_command_error = 'Unable to save permissions/ownership at target'
-        raise OperationFailureError(facl_command_error,
-                                    stdout.read().decode('utf-8').strip())
+    facl_command = "getfacl -n {0}".format(files_dir_to_tar)
+    result = ssh_conn.sudo(facl_command, pty=True, hide=True, timeout=REMOTE_CMD_TIMEOUT)
 
-    tcattr = stdout.read().decode("utf-8").strip().split("\r\n")
+    if result.failed:
+        remove_tmp_dir(ssh_conn, tmp_dir_name)
+        ssh_conn.close()
+        facl_command_error = 'Unable to save permissions/ownership at target'
+        raise OperationFailureError(facl_command_error, result.stdout.strip())
+
+    tcattr = result.stdout.strip("\r").split("\r\n")
     # remove upto password keyword
-    indx = tcattr.index("Password: ")
+    indx = tcattr.index("[sudo] password: ")
     tcattr = tcattr[(indx + 1):]
-    tcattr = "\n".join(tcattr) + "\n"
+
+    # remove any getfacl warnings from the list
+    tcattr = [e for e in tcattr if 'getfacl:' not in e]
+
+    tcattr = "\n".join(tcattr)
     return tcattr
 
 
@@ -135,25 +127,26 @@ def list_to_string_with_quote(args_list):
 
 # pylint: disable=too-many-locals
 def isolate_user_changes(diff_dir, r_name_ip, r_username, r_password, r_port, r_mdns):
-    client = paramiko.SSHClient()
-    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
     resolved_remote_host = resolve_remote_host(r_name_ip, r_mdns)
-    client.connect(hostname=resolved_remote_host,
-                   username=r_username,
-                   password=r_password,
-                   port=r_port)
+    conn = fabric.Connection(host=resolved_remote_host,
+                             user=r_username,
+                             port=r_port,
+                             connect_kwargs={'password': r_password},
+                             config=fabric.Config(overrides={'sudo': {'password': r_password}}))
+    conn.open()
     # get config diff
-    status, _stdin, stdout = run_command_with_sudo(
-        client, 'sudo ostree admin config-diff', r_password)
-    if status > 0:
-        client.close()
-        raise OperationFailureError('Unable to get user changes',
-                                    stdout.read().decode('utf-8').strip())
+    result = conn.sudo('ostree admin config-diff', pty=True, hide=True, timeout=REMOTE_CMD_TIMEOUT)
 
-    output = stdout.read().decode("utf-8").split("\r\n")
+    # Check exit status
+    if result.failed:
+        conn.close()
+        raise OperationFailureError('Unable to get user changes',
+                                    result.stdout.strip())
+
+    output = result.stdout.split("\r\n")
     # remove upto password keyword
-    indx = output.index("Password: ")
+    indx = output.index("[sudo] password: ")
     output = output[(indx + 1):]
 
     # filter out files
@@ -165,7 +158,7 @@ def isolate_user_changes(diff_dir, r_name_ip, r_username, r_password, r_port, r_
     # Buffer to store the content for the ".tcattr" file
     tcattr = None
 
-    sftp = client.open_sftp()
+    sftp = conn.sftp()
     if sftp is not None:
         # perform all operations in /tmp
         tmp_dir_name = '/tmp/torizon-builder-' + str(datetime.datetime.now().date()) + '_' + str(
@@ -182,38 +175,37 @@ def isolate_user_changes(diff_dir, r_name_ip, r_username, r_password, r_port, r_
                 files_list.append('/etc/' + f_name)
             else:
                 f_delete_exists = True
-                whiteouts(client, sftp, tmp_dir_name, f_name)
+                whiteouts(conn, sftp, tmp_dir_name, f_name)
 
         files_dir_to_tar = list_to_string_with_quote(files_list)
         if f_delete_exists:
-            tar_command = "sudo tar --exclude={0} --xattrs --acls -cf {1}/{0} -C {1} . {2}". \
+            tar_command = "tar --exclude={0} --xattrs --acls -cf {1}/{0} -C {1} . {2}". \
                 format(TAR_NAME, tmp_dir_name, files_dir_to_tar)
         else:
             # don't include current directory i.e. '.':
             # whiteout files does not exist in /tmp/torizon-builder/
-            tar_command = "sudo tar --xattrs --acls -cf {1}/{0} {2}".format(
+            tar_command = "tar --xattrs --acls -cf {1}/{0} {2}".format(
                 TAR_NAME, tmp_dir_name, files_dir_to_tar)
         # make tar
-        status, _stdin, stdout = run_command_with_sudo(client, tar_command, r_password)
-        if status > 0:
-            remove_tmp_dir(client, tmp_dir_name)
+        result = conn.sudo(tar_command, pty=True, hide=True, timeout=REMOTE_CMD_TIMEOUT)
+        if result.failed:
+            remove_tmp_dir(conn, tmp_dir_name)
             sftp.close()
-            client.close()
+            conn.close()
             raise OperationFailureError('Unable to bundle up changes at target',
-                                        stdout.read().decode('utf-8').strip())
+                                        result.stdout.strip())
 
         # get the tar
         sftp.get(tmp_dir_name + '/' + TAR_NAME, diff_dir + '/' + TAR_NAME, None)
-        remove_tmp_dir(client, tmp_dir_name)
+        remove_tmp_dir(conn, tmp_dir_name)
         sftp.close()
 
-        tcattr = get_tcattr_file_content(files_dir_to_tar, client, sftp,
-                                         r_password, tmp_dir_name)
+        tcattr = get_tcattr_file_content(files_dir_to_tar, conn, tmp_dir_name)
     else:
-        client.close()
+        conn.close()
         raise TorizonCoreBuilderError('Unable to create SSH connection for transferring of files')
 
-    client.close()
+    conn.close()
 
     # Extract tar to diff_dir/usr/ so that at time of union
     # they can be committed to /usr/etc of unpacked image as it is

--- a/tcbuilder/backend/isolate.py
+++ b/tcbuilder/backend/isolate.py
@@ -2,6 +2,7 @@ import datetime
 import os
 import subprocess
 import shlex
+import re
 
 import fabric
 
@@ -103,18 +104,27 @@ def get_tcattr_file_content(files_dir_to_tar, ssh_conn, tmp_dir_name):
     # remove any getfacl warnings from the list
     tcattr = [e for e in tcattr if 'getfacl:' not in e]
 
-    tcattr = "\n".join(tcattr)
     return tcattr
 
 
-def create_tcattr_file(diff_dir, tcattr):
+def create_tcattr_file(diff_dir, tcattr_list):
     """
         Create the {diff_dir}/usr/etc/.tcattr file using the content of
         tcattr buffer so it can be used later by the "union" command to
         set file and/or directory permissions and/or ownership.
     """
+
+    # Replace any space characters in the file name with its 3-digit octal ASCII code (\040)
+    # so that setfacl can properly include them when searching the file.
+    _tcattr_list = ["# file: " + line[8:].replace(" ", "\\040") if line.startswith("# file: ")
+                    else line for line in tcattr_list]
+
+    tcattr_str = "\n".join(_tcattr_list)
+    # Remove etc/ at the beginning of the file path
+    tcattr_str = re.sub(r'^# file: etc/', '# file: ', tcattr_str, flags=re.MULTILINE)
+
     with open(f"{diff_dir}/usr/etc/.tcattr", "w") as fd_tcattr:
-        fd_tcattr.write(tcattr.replace('# file: etc/', '# file: '))
+        fd_tcattr.write(tcattr_str)
 
 
 def list_to_string_with_quote(args_list):


### PR DESCRIPTION
This fixes an IO desynchronization issue when sending remote sudo commands that could happen if the device has Torizon OS 7.3.0 or higher installed: the password would be sent to the device before sudo is ready to receive it, which would cause sudo to hang waiting for the password until its default timeout (5 minutes) gets reached and fail.

This wasn't reproducible on previous Torizon OS 7 versions. 7.3.0 introduced a newer version of sudo (1.9.17p1), which could explain this difference in behavior: probably this version takes a bit longer to show the password prompt, just enough for the issue to show up.

One way avoid this problem is to send shell commands remotely using a library designed to do this task, like Fabric. It can detect the sudo password prompt and auto-respond to it accordingly, which is a more robust method than the previous one.

-----

Also included is a fix to `isolate` when the device `/etc` has files or directories with leading or trailing whitespaces in their names. This was found in our CI pipeline while testing the fix above.

Closes TCB-729