### PR TITLE
Throw error when running unsupported features for kernel in FIT format

### DIFF
--- a/tcbuilder/backend/common.py
+++ b/tcbuilder/backend/common.py
@@ -844,38 +844,6 @@ def check_if_file_exists(filename, directory):
     return file_list[0]
 
 
-def get_unpacked_uenv_txt_vars(storage_dir, var_list):
-    """
-    Get the values of specific U-Boot variables declared in uEnv.txt in a
-    Torizon OS image unpacked in storage_dir
-
-    :param storage_dir: Path of the unpacked image. The rootfs dir is assumed to be named 'sysroot'
-    :param var_list: List of variables to get the values
-    :returns: Dictionary with the values for each variable in var_list. If an entry is not in
-              uEnv.txt, its value will be None
-    """
-
-    result = {}
-    rootfs_dir = os.path.join(storage_dir, "sysroot")
-    uenv_txt_path = glob.glob(os.path.join(rootfs_dir, "boot/loader*/uEnv.txt"))[0]
-
-    if not os.path.isfile(uenv_txt_path):
-        raise FileContentMissing("Couldn't find uEnv.txt in unpacked image rootfs! Aborting.")
-
-    with open(uenv_txt_path, 'r') as uenv_txt_file:
-        uenv_txt_str = uenv_txt_file.read()
-
-    for var in var_list:
-        match = re.search(r"^" + var + r"=(.*)", uenv_txt_str, re.MULTILINE)
-        if match:
-            result[var] = str(match.group(1))
-        else:
-            log.warning(f'"{var}=" variable not found in uEnv.txt.')
-            result[var] = None
-
-    return result
-
-
 def is_file_type_dtb(file_path):
     """
     Check if the file located in file_path is in DTB format by looking at the first bytes

--- a/tcbuilder/backend/common.py
+++ b/tcbuilder/backend/common.py
@@ -63,6 +63,14 @@ RAW_PROP_DEFAULTS = {
     "raw_rootfs_label" : DEFAULT_RAW_ROOTFS_LABEL
 }
 
+#  Hex value taken from the Devicetree Specification available at:
+#  https://devicetree-specification.readthedocs.io/en/stable/flattened-format.html
+FDT_HEADER_MAGIC = "d00dfeed"
+
+OSTREE_KERNEL_FILENAME = "vmlinuz"
+
+OSTREE_KERNEL_DEPLOY_PATH = "ostree/deploy/torizon/deploy/{csum}/usr/lib/modules/{kver}/"
+
 REMOTE_CMD_TIMEOUT = 30
 
 SECBOOT_ARTIFACTS_DIR = "/storage/secboot_tracked_artifacts"
@@ -866,3 +874,96 @@ def get_unpacked_uenv_txt_vars(storage_dir, var_list):
             result[var] = None
 
     return result
+
+
+def is_file_type_dtb(file_path):
+    """
+    Check if the file located in file_path is in DTB format by looking at the first bytes
+    of the file, which must be the value FDT_HEADER_MAGIC.
+    This can be used to quickly check if a binary is a Device Tree Blob or a Flattened Image
+    Tree (FIT) file.
+
+    :param file_path: Path of the file to be checked.
+    :returns: True if the first bytes of the file match FDT_HEADER_MAGIC, False otherwise.
+    """
+
+    expected_value = bytes.fromhex(FDT_HEADER_MAGIC)
+    value_length = len(expected_value)
+
+    with open(file_path, "rb") as _file:
+        found_value = _file.read(value_length)
+
+    return found_value == expected_value
+
+
+def is_file_type_fit(file_path):
+    """
+    Check if the binary located in file_path is a valid Flattened Image Tree (FIT) file by looking
+    if it has the required nodes and properties at the root node. Raises an error if the file is in
+    FDT format but doesn't have the required FIT properties or nodes.
+
+    :param file_path: Path of the file to be checked.
+    :returns: True if the file has the required properties and nodes,
+              False if the file is not in FDT format.
+    """
+
+    # Values taken from 'Flattened Image Tree (FIT) Format' in the U-Boot v2024.07 Documentation:
+    # https://docs.u-boot.org/en/v2024.07/usage/fit/source_file_format.html
+    required_props = ["timestamp"]
+    required_nodes = ["images", "configurations"]
+
+    if not is_file_type_dtb(file_path):
+        return False
+
+    try:
+        output = subprocess.run(["fdtget", file_path, "/", "-p"],
+                                text=True, check=True, stdout=subprocess.PIPE)
+
+        # Check if file has the required properties in the root node
+        if not all(prop in output.stdout for prop in required_props):
+            raise InvalidDataError("File is in FDT format but doesn't have the required FIT "
+                                   "properties. Aborting.")
+
+        output = subprocess.run(["fdtget", file_path, "/", "-l"],
+                                text=True, check=True, stdout=subprocess.PIPE)
+
+        # Check if file has the required nodes in the root node
+        if not all(node in output.stdout for node in required_nodes):
+            raise InvalidDataError("File is in FDT format but doesn't have the required FIT "
+                                   "nodes. Aborting.")
+
+    except subprocess.CalledProcessError as exc:
+        raise TorizonCoreBuilderError(f"Error running fdtget: {exc.output.strip()}")
+
+    return True
+
+
+def find_kernel_in_sysroot(storage_dir):
+    """
+    Find kernel binary path in the unpacked image sysroot. Raises an error if it cannot find it.
+
+    :param storage_dir: Path of the unpacked image. The rootfs dir is assumed to be named 'sysroot'
+    :returns: String with absolute path of the kernel binary inside sysroot.
+    """
+
+    sysroot_path = os.path.join(storage_dir, "sysroot")
+
+    # As the kernel path is composed of directories named after the deployment commit and the
+    # kernel version, get them via OSTree metadata.
+
+    sysroot_obj = ostree.load_sysroot(sysroot_path)
+
+    csum, _ = ostree.get_deployment_info_from_sysroot(sysroot_obj)
+    kernel_version = ostree.get_kernel_version(sysroot_obj.repo(), csum)
+
+    # Add deployment index part to checksum string, which is 0 for a new deployment
+    csum += ".0"
+
+    kernel_path = OSTREE_KERNEL_DEPLOY_PATH.format(csum=csum, kver=kernel_version)
+
+    kernel_path = os.path.join(sysroot_path, kernel_path, OSTREE_KERNEL_FILENAME)
+
+    if not os.path.isfile(kernel_path):
+        raise PathNotExistError("Kernel not found in unpacked rootfs. Aborting.")
+
+    return kernel_path

--- a/tcbuilder/backend/common.py
+++ b/tcbuilder/backend/common.py
@@ -71,7 +71,7 @@ OSTREE_KERNEL_FILENAME = "vmlinuz"
 
 OSTREE_KERNEL_DEPLOY_PATH = "ostree/deploy/torizon/deploy/{csum}/usr/lib/modules/{kver}/"
 
-REMOTE_CMD_TIMEOUT = 30
+REMOTE_CMD_TIMEOUT = 90
 
 SECBOOT_ARTIFACTS_DIR = "/storage/secboot_tracked_artifacts"
 

--- a/tcbuilder/backend/secboot.py
+++ b/tcbuilder/backend/secboot.py
@@ -11,8 +11,8 @@ import subprocess
 
 from tcbuilder.backend.common import \
     (set_output_ownership, get_tar_compress_program_options, is_tcb_container_64bit,
-     check_if_file_exists, get_unpacked_uenv_txt_vars, get_tezi_image_version,
-     OSTREE_KERNEL_DEPLOY_PATH, OSTREE_KERNEL_FILENAME)
+     check_if_file_exists, find_kernel_in_sysroot, get_tezi_image_version, is_file_type_fit,
+     OSTREE_KERNEL_FILENAME)
 from tcbuilder.backend.ubootenv import \
     (get_env_filename, find_board)
 from tcbuilder.backend.platform import \
@@ -511,17 +511,14 @@ def check_basic_signing_prerequisites(storage_dir):
     if img_major < 7:
         raise InvalidArgumentError("Feature only supported on Torizon OS 7 images. Aborting.")
 
-    log.info("Checking if the unpacked image has the kernel in fitImage format...")
-    uenv_var = get_unpacked_uenv_txt_vars(storage_dir, ["kernel_image_type"])
+    log.debug("Checking if the unpacked image has the kernel in FIT format...")
 
-    if uenv_var["kernel_image_type"]:
-        log.info(f"Detected kernel image format: {uenv_var['kernel_image_type']}")
-    else:
-        log.info("Could not determine the kernel image format")
-
-    if uenv_var["kernel_image_type"] != "fitImage":
+    unpacked_kernel_path = find_kernel_in_sysroot(storage_dir)
+    if not is_file_type_fit(unpacked_kernel_path):
         raise InvalidArgumentError(
-            "Unpacked image does not have the kernel in fitImage format. Aborting.")
+            "Unpacked image does not have the kernel in FIT format. Aborting.")
+
+    log.info("Found kernel in FIT format.")
 
 
 def check_unpacked_tezi_kernel_signing_support(storage_dir):
@@ -642,9 +639,7 @@ def sign_kernel(storage_dir, kernel_changes_dir, key_dir, key_algo, key_name):
     os.mkdir(SECURE_BOOT_WORKDIR)
 
     # Copy kernel FIT in current image deployment to the work directory
-    kernel_deploy_path = check_if_file_exists(KERNEL_FIT_FILENAME,
-                                              os.path.join(storage_dir, "sysroot",
-                                                           OSTREE_KERNEL_DEPLOY_PATH))
+    kernel_deploy_path = find_kernel_in_sysroot(storage_dir)
     kernel_fitimage_path = os.path.join(SECURE_BOOT_WORKDIR, KERNEL_FIT_FILENAME)
     shutil.copy2(kernel_deploy_path, kernel_fitimage_path)
 

--- a/tcbuilder/backend/secboot.py
+++ b/tcbuilder/backend/secboot.py
@@ -11,7 +11,8 @@ import subprocess
 
 from tcbuilder.backend.common import \
     (set_output_ownership, get_tar_compress_program_options, is_tcb_container_64bit,
-     check_if_file_exists, get_unpacked_uenv_txt_vars, get_tezi_image_version)
+     check_if_file_exists, get_unpacked_uenv_txt_vars, get_tezi_image_version,
+     OSTREE_KERNEL_DEPLOY_PATH, OSTREE_KERNEL_FILENAME)
 from tcbuilder.backend.ubootenv import \
     (get_env_filename, find_board)
 from tcbuilder.backend.platform import \
@@ -29,8 +30,8 @@ DEFAULT_TCB_SIGNING_FILES_TARNAME = "tcb_signing_files.tar.gz"
 UBOOT_TOOLS_DIR = "/u-boot/tools"
 SECURE_BOOT_WORKDIR = "/storage/secure_boot_workdir"
 UBOOT_DTB = "u-boot.dtb"
-KERNEL_FIT_FILENAME = "vmlinuz"
-KERNEL_DEPLOY_PATH_WILDCARD = "ostree/deploy/torizon/deploy/*/usr/lib/modules/*/"
+KERNEL_FIT_FILENAME = OSTREE_KERNEL_FILENAME
+
 UBOOT_CONFIG_FILE = "uboot_config"
 UBOOT_DTBS_DIR = "u-boot-dtbs"
 
@@ -643,7 +644,7 @@ def sign_kernel(storage_dir, kernel_changes_dir, key_dir, key_algo, key_name):
     # Copy kernel FIT in current image deployment to the work directory
     kernel_deploy_path = check_if_file_exists(KERNEL_FIT_FILENAME,
                                               os.path.join(storage_dir, "sysroot",
-                                                           KERNEL_DEPLOY_PATH_WILDCARD))
+                                                           OSTREE_KERNEL_DEPLOY_PATH))
     kernel_fitimage_path = os.path.join(SECURE_BOOT_WORKDIR, KERNEL_FIT_FILENAME)
     shutil.copy2(kernel_deploy_path, kernel_fitimage_path)
 

--- a/tcbuilder/cli/dt.py
+++ b/tcbuilder/cli/dt.py
@@ -17,9 +17,12 @@ from tcbuilder.backend.common import (checkout_dt_git_repo,
                                       set_output_ownership,
                                       images_unpack_executed,
                                       update_dt_git_repo,
-                                      unpacked_image_type)
+                                      unpacked_image_type,
+                                      find_kernel_in_sysroot,
+                                      is_file_type_fit)
 from tcbuilder.errors import (
-    TorizonCoreBuilderError, InvalidArgumentError, InvalidStateError, InvalidDataError)
+    TorizonCoreBuilderError, InvalidArgumentError, InvalidStateError, InvalidDataError,
+    FeatureNotImplementedError)
 
 log = logging.getLogger("torizon." + __name__)
 
@@ -29,8 +32,12 @@ def do_dt_status(args):
 
     images_unpack_executed(args.storage_directory)
     if unpacked_image_type(args.storage_directory) == "raw":
-        raise InvalidDataError("dt commands are not supported for WIC/raw images. "
-                               "Aborting.")
+        raise InvalidDataError("Command not supported for WIC/raw images. Aborting.")
+
+    unpacked_kernel_path = find_kernel_in_sysroot(args.storage_directory)
+    if is_file_type_fit(unpacked_kernel_path):
+        raise FeatureNotImplementedError("Command not supported for kernel in FIT format. "
+                                         "Aborting.")
 
     dtb_basename = dt.get_current_dtb_basename(args.storage_directory)
     if not dtb_basename:
@@ -71,8 +78,13 @@ def dt_apply(dts_path, storage_dir, include_dirs=None):
 
     images_unpack_executed(storage_dir)
     if unpacked_image_type(storage_dir) == "raw":
-        raise InvalidDataError("dt commands are not supported for WIC/raw images. "
+        raise InvalidDataError("Device tree customization is not supported for WIC/raw images. "
                                "Aborting.")
+
+    unpacked_kernel_path = find_kernel_in_sysroot(storage_dir)
+    if is_file_type_fit(unpacked_kernel_path):
+        raise FeatureNotImplementedError("Device tree customization is not supported for kernel in "
+                                         "FIT format. Aborting.")
 
     # Sanity check parameters.
     assert dts_path, "panic: missing device tree source parameter"

--- a/tcbuilder/cli/dto.py
+++ b/tcbuilder/cli/dto.py
@@ -9,14 +9,15 @@ import sys
 import tempfile
 
 from tcbuilder.backend import dt, dto, common
-from tcbuilder.backend.common import images_unpack_executed, unpacked_image_type
+from tcbuilder.backend.common import (images_unpack_executed, unpacked_image_type, is_file_type_fit,
+                                      find_kernel_in_sysroot)
 
 from tcbuilder.cli import images as images_cli
 from tcbuilder.cli import dt as dt_cli
 from tcbuilder.cli import union as union_cli
 from tcbuilder.cli import deploy as deploy_cli
 
-from tcbuilder.errors import InvalidDataError
+from tcbuilder.errors import InvalidDataError, FeatureNotImplementedError
 
 log = logging.getLogger("torizon." + __name__)
 
@@ -50,8 +51,13 @@ def dto_apply(dtos_path, dtb_path, include_dirs, storage_dir,
 
     images_unpack_executed(storage_dir)
     if unpacked_image_type(storage_dir) == "raw":
-        raise InvalidDataError("dto commands are not supported for WIC/raw images. "
-                               "Aborting.")
+        raise InvalidDataError("Device tree overlay customization is not supported for WIC/raw "
+                               "images. Aborting.")
+
+    unpacked_kernel_path = find_kernel_in_sysroot(storage_dir)
+    if is_file_type_fit(unpacked_kernel_path):
+        raise FeatureNotImplementedError("Device tree overlay customization is not supported for "
+                                         "kernel in FIT format. Aborting.")
 
     applied_overlay_basenames = dto.get_applied_overlays_base_names(storage_dir)
     dtob_target_basename = os.path.splitext(os.path.basename(dtos_path))[0] + ".dtbo"
@@ -148,6 +154,15 @@ def do_dto_apply(args):
 def do_dto_list(args):
     '''Perform the 'dto list' command.'''
 
+    images_unpack_executed(args.storage_directory)
+    if unpacked_image_type(args.storage_directory) == "raw":
+        raise InvalidDataError("Command not supported for WIC/raw images. Aborting.")
+
+    unpacked_kernel_path = find_kernel_in_sysroot(args.storage_directory)
+    if is_file_type_fit(unpacked_kernel_path):
+        raise FeatureNotImplementedError("Command not supported for kernel in FIT format. "
+                                         "Aborting.")
+
     # Sanity check for overlay sources to scan.
     overlays_subdir = "device-trees/overlays"
     if not os.path.isdir(overlays_subdir):
@@ -161,11 +176,6 @@ def do_dto_list(args):
         log.error("Please pass either a device tree source file or device "
                   "tree binary to --device-tree.")
         sys.exit(1)
-
-    images_unpack_executed(args.storage_directory)
-    if unpacked_image_type(args.storage_directory) == "raw":
-        raise InvalidDataError("dto commands are not supported for WIC/raw images. "
-                               "Aborting.")
 
     # Find a device tree to check overlay compatibility against.
     dtb_path = args.device_tree
@@ -266,8 +276,12 @@ def do_dto_status(args):
 
     images_unpack_executed(args.storage_directory)
     if unpacked_image_type(args.storage_directory) == "raw":
-        raise InvalidDataError("dto commands are not supported for WIC/raw images. "
-                               "Aborting.")
+        raise InvalidDataError("Command not supported for WIC/raw images. Aborting.")
+
+    unpacked_kernel_path = find_kernel_in_sysroot(args.storage_directory)
+    if is_file_type_fit(unpacked_kernel_path):
+        raise FeatureNotImplementedError("Command not supported for kernel in FIT format. "
+                                         "Aborting.")
 
     # Show the enabled device tree.
     (dtb_path, is_dtb_exact) = dt.get_current_dtb_path(args.storage_directory)
@@ -287,8 +301,13 @@ def dto_remove_single(dtob_basename, storage_dir, presence_required=True):
 
     images_unpack_executed(storage_dir)
     if unpacked_image_type(storage_dir) == "raw":
-        raise InvalidDataError("dto commands are not supported for WIC/raw images. "
-                               "Aborting.")
+        raise InvalidDataError("Device tree overlay customization is not supported for WIC/raw "
+                               "images. Aborting.")
+
+    unpacked_kernel_path = find_kernel_in_sysroot(storage_dir)
+    if is_file_type_fit(unpacked_kernel_path):
+        raise FeatureNotImplementedError("Device tree overlay customization is not supported for "
+                                         "kernel in FIT format. Aborting.")
 
     dtob_basenames = dto.get_applied_overlays_base_names(storage_dir)
     if not dtob_basename in dtob_basenames:
@@ -323,8 +342,13 @@ def dto_remove_all(storage_dir):
 
     images_unpack_executed(storage_dir)
     if unpacked_image_type(storage_dir) == "raw":
-        raise InvalidDataError("dto commands are not supported for WIC/raw images. "
-                               "Aborting.")
+        raise InvalidDataError("Device tree overlay customization is not supported for WIC/raw "
+                               "images. Aborting.")
+
+    unpacked_kernel_path = find_kernel_in_sysroot(storage_dir)
+    if is_file_type_fit(unpacked_kernel_path):
+        raise FeatureNotImplementedError("Device tree overlay customization is not supported for "
+                                         "kernel in FIT format. Aborting.")
 
     log.debug("Removing all overlays")
 

--- a/tcbuilder/cli/kernel.py
+++ b/tcbuilder/cli/kernel.py
@@ -10,11 +10,13 @@ import tempfile
 import subprocess
 
 from tcbuilder.errors import PathNotExistError
-from tcbuilder.errors import FileContentMissing, InvalidDataError
+from tcbuilder.errors import FileContentMissing, InvalidDataError, FeatureNotImplementedError
 from tcbuilder.backend.common import (get_tar_compress_program_options,
                                       images_unpack_executed,
                                       unpacked_image_type,
-                                      get_branch_and_major_from_metadata)
+                                      get_branch_and_major_from_metadata,
+                                      find_kernel_in_sysroot,
+                                      is_file_type_fit)
 from tcbuilder.backend import kernel, dt, dto
 from tcbuilder.cli import dto as dto_cli
 
@@ -53,8 +55,13 @@ def kernel_build_module(source_dir, storage_dir, autoload):
 
     images_unpack_executed(storage_dir)
     if unpacked_image_type(storage_dir) == "raw":
-        raise InvalidDataError("Kernel commands are not supported for WIC/raw images. "
+        raise InvalidDataError("Kernel customization is not supported for WIC/raw images. "
                                "Aborting.")
+
+    unpacked_kernel_path = find_kernel_in_sysroot(storage_dir)
+    if is_file_type_fit(unpacked_kernel_path):
+        raise FeatureNotImplementedError("Kernel customization is not supported for FIT format. "
+                                         "Aborting.")
 
     # Check for valid Makefile
     if not os.path.exists(source_dir):
@@ -140,8 +147,13 @@ def kernel_set_custom_args(kernel_args, storage_dir):
 
     images_unpack_executed(storage_dir)
     if unpacked_image_type(storage_dir) == "raw":
-        raise InvalidDataError("Kernel commands are not supported for WIC/raw images. "
+        raise InvalidDataError("Kernel customization is not supported for WIC/raw images. "
                                "Aborting.")
+
+    unpacked_kernel_path = find_kernel_in_sysroot(storage_dir)
+    if is_file_type_fit(unpacked_kernel_path):
+        raise FeatureNotImplementedError("Kernel customization is not supported for FIT format. "
+                                         "Aborting.")
 
     kargs = " ".join(kernel_args)
     if not kargs.rstrip():
@@ -186,8 +198,12 @@ def do_kernel_get_custom_args(args):
 
     images_unpack_executed(args.storage_directory)
     if unpacked_image_type(args.storage_directory) == "raw":
-        raise InvalidDataError("Kernel commands are not supported for WIC/raw images. "
-                               "Aborting.")
+        raise InvalidDataError("Command not supported for WIC/raw images. Aborting.")
+
+    unpacked_kernel_path = find_kernel_in_sysroot(args.storage_directory)
+    if is_file_type_fit(unpacked_kernel_path):
+        raise FeatureNotImplementedError("Command not supported for kernel in FIT format. "
+                                         "Aborting.")
 
     # Make sure image can handle kernel arguments.
     assert_custom_kargs_compat_image(args.storage_directory)
@@ -224,8 +240,13 @@ def do_kernel_clear_custom_args(args):
 
     images_unpack_executed(args.storage_directory)
     if unpacked_image_type(args.storage_directory) == "raw":
-        raise InvalidDataError("Kernel commands are not supported for WIC/raw images. "
+        raise InvalidDataError("Kernel customization is not supported for WIC/raw images. "
                                "Aborting.")
+
+    unpacked_kernel_path = find_kernel_in_sysroot(args.storage_directory)
+    if is_file_type_fit(unpacked_kernel_path):
+        raise FeatureNotImplementedError("Kernel customization is not supported for FIT format. "
+                                         "Aborting.")
 
     # Make sure image can handle kernel arguments.
     assert_custom_kargs_compat_image(args.storage_directory)

--- a/tcbuilder/cli/splash.py
+++ b/tcbuilder/cli/splash.py
@@ -7,9 +7,10 @@ import os
 import shutil
 import logging
 
-from tcbuilder.errors import PathNotExistError, InvalidArgumentError
+from tcbuilder.errors import PathNotExistError, InvalidArgumentError, FeatureNotImplementedError
 from tcbuilder.backend import splash as sbe
-from tcbuilder.backend.common import images_unpack_executed
+from tcbuilder.backend.common import (images_unpack_executed, is_file_type_fit,
+                                      find_kernel_in_sysroot)
 
 log = logging.getLogger("torizon." + __name__)  # use name hierarchy for "main" to be the parent
 
@@ -24,6 +25,11 @@ def splash(splash_image, storage_dir):
     """
 
     storage_dir = os.path.abspath(storage_dir)
+
+    unpacked_kernel_path = find_kernel_in_sysroot(storage_dir)
+    if is_file_type_fit(unpacked_kernel_path):
+        raise FeatureNotImplementedError("Changing the splash screen is not supported for kernel "
+                                         "in FIT format. Aborting.")
 
     work_dir = os.path.join(storage_dir, "splash")
     if os.path.exists(work_dir):

--- a/tests/integration/functions.sh
+++ b/tests/integration/functions.sh
@@ -248,3 +248,75 @@ requires-supported-hab-signing-machine() {
     fi
 }
 export -f requires-supported-hab-signing-machine
+
+contains-all-words() {
+    local haystack=$(echo "$1" | tr '\n' ' ')
+    local needle=$(echo "$2" | tr '\n' ' ')
+    local word
+
+    for word in $needle; do
+        case " $haystack " in
+            *" $word "*) ;; # found — continue
+            *) return 1 ;;  # missing — fail immediately
+        esac
+    done
+    return 0
+}
+export -f contains-all-words
+
+unpacked-kernel-in-fit-format() {
+    local FDT_HEADER_MAGIC="d00dfeed"
+    local OSTREE_KERNEL_FILENAME="vmlinuz"
+    local OSTREE_KERNEL_DEPLOY_PATH="/storage/sysroot/ostree/deploy/torizon/deploy/*/usr/lib/modules/*/"
+
+    local REQUIRED_PROPS="timestamp"
+    local REQUIRED_NODES="images configurations"
+
+    local OSTREE_KERNEL="${OSTREE_KERNEL_DEPLOY_PATH}${OSTREE_KERNEL_FILENAME}"
+
+    local kernel_header found_props found_nodes
+
+    if torizoncore-builder-shell "[ ! -f ${OSTREE_KERNEL} ]"; then
+        # Error case
+        echo "Cannot find kernel in unpacked image. Did you run 'images unpack' beforehand?" >&2
+        return 3
+    fi
+
+    kernel_header=$(torizoncore-builder-shell "hexdump -n 4 -e '4/1 \"%02x\"' ${OSTREE_KERNEL}")
+
+    if [ "${kernel_header}" = "${FDT_HEADER_MAGIC}" ]; then
+        found_props=$(torizoncore-builder-shell "fdtget ${OSTREE_KERNEL} / -p")
+        found_nodes=$(torizoncore-builder-shell "fdtget ${OSTREE_KERNEL} / -l")
+
+        if ! contains-all-words "${found_props}" "${REQUIRED_PROPS}"; then
+            # Error case
+            echo "Kernel in invalid FIT format" >&2
+            return 2
+        fi
+
+        if ! contains-all-words "${found_nodes}" "${REQUIRED_NODES}"; then
+            # Error case
+            echo "Kernel in invalid FIT format" >&2
+            return 2
+        fi
+
+        return 0 # Kernel is in FIT format
+    else
+        return 1 # Kernel is not in FIT format
+    fi
+}
+export -f unpacked-kernel-in-fit-format
+
+requires-non-fit-kernel() {
+    if [ "${IS_DEFAULT_TEZI_IMAGE_FIT}" = "1" ]; then
+        skip "kernel in FIT format is unsupported"
+    fi
+}
+export -f requires-non-fit-kernel
+
+requires-fit-kernel() {
+    if [ "${IS_DEFAULT_TEZI_IMAGE_FIT}" != "1" ]; then
+        skip "kernel is not in FIT format"
+    fi
+}
+export -f requires-fit-kernel

--- a/tests/integration/functions.sh
+++ b/tests/integration/functions.sh
@@ -320,3 +320,17 @@ requires-fit-kernel() {
     fi
 }
 export -f requires-fit-kernel
+
+signing-artifacts-in-unpacked-tezi-image() {
+    local DEFAULT_TCB_SIGNING_FILES_TARNAME="tcb_signing_files.tar.gz"
+
+    if torizoncore-builder-shell "[ ! -d /storage/tezi ]"; then
+        # Error case
+        echo "Cannot find unpacked image in internal storage. Did you run 'images unpack' beforehand?" >&2
+        return 1
+    fi
+
+    # Check if image has signing artifacts
+    torizoncore-builder-shell "[ -f /storage/tezi/${DEFAULT_TCB_SIGNING_FILES_TARNAME} ]"
+}
+export -f signing-artifacts-in-unpacked-tezi-image

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -223,11 +223,28 @@ fi
 
 # prepare tests
 export BATS_LIB_PATH="$WORK_DIR"
+export IS_DEFAULT_TEZI_IMAGE_FIT=""
 cd $WORK_DIR
 rm -rf $SAMPLES_DIR && cp -a ../$SAMPLES_DIR .
 mkdir -p $REPORT_DIR
 echo -e "Starting integration tests...\n"
 
+# If using TEZI image, check if it has a kernel in FIT format as some tests need this info
+if [ "$IS_WIC" != "1" ] && [ -n "$DEFAULT_TEZI_IMAGE" ]; then
+    torizoncore-builder images --remove-storage unpack "$DEFAULT_TEZI_IMAGE"
+    if unpacked-kernel-in-fit-format; then
+        echo "Image has kernel in FIT format"
+        IS_DEFAULT_TEZI_IMAGE_FIT="1" # valid FIT kernel
+    else
+        status=$?
+        if [ $status -eq 1 ]; then
+            IS_DEFAULT_TEZI_IMAGE_FIT="0" # non-FIT kernel
+        else
+            # Error case: specific error message provided by the function
+            exit $status
+        fi
+    fi
+fi
 # run tests
 if [ "$TCB_REPORT" = "1" ]; then
     if [ "$TCB_UNDER_CI" = "1" ]; then

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -3,7 +3,6 @@
 BASE_DIR=$PWD
 WORK_DIR=$PWD/workdir
 IMAGES_DIR=$WORK_DIR/images
-SIGNED_IMAGES_DIR=$WORK_DIR/images-tdx-signed
 TESTCASES_DIR=$BASE_DIR/testcases
 
 REPORT_DIR=$WORK_DIR/reports
@@ -197,7 +196,7 @@ fi
 
 # copy image that will be used in the tests
 export DEFAULT_TEZI_IMAGE="$(basename $(ls $IMAGES_DIR/*-${MACHINE}*.tar 2>&-) 2>&-)"
-export DEFAULT_SIGNED_TEZI_IMAGE="$(basename $(ls $SIGNED_IMAGES_DIR/*-${MACHINE}*.tar 2>&-) 2>&-)"
+export DEFAULT_SIGNED_TEZI_IMAGE=""
 export DEFAULT_WIC_IMAGE="$(basename $(ls $IMAGES_DIR/*-${MACHINE}*.wic 2>&-) 2>&-)"
 
 # There's probably a better way to put the .wic and .img search in a single regex,
@@ -209,10 +208,6 @@ fi
 if [ "$IS_WIC" != "1" ] && [ ! -z "$DEFAULT_TEZI_IMAGE" ]; then
     echo "Test cases using image $DEFAULT_TEZI_IMAGE for machine $MACHINE."
     cp $IMAGES_DIR/$DEFAULT_TEZI_IMAGE $WORK_DIR
-    if [ -n "$DEFAULT_SIGNED_TEZI_IMAGE" ]; then
-        cp $SIGNED_IMAGES_DIR/$DEFAULT_SIGNED_TEZI_IMAGE $WORK_DIR
-        echo "Secure boot related test cases using signed image $DEFAULT_SIGNED_TEZI_IMAGE for machine $MACHINE."
-    fi
 elif [ "$IS_WIC" = "1" ] && [ ! -z "$DEFAULT_WIC_IMAGE" ]; then
     echo "Test cases using image $DEFAULT_WIC_IMAGE for machine $MACHINE."
     cp $IMAGES_DIR/$DEFAULT_WIC_IMAGE $WORK_DIR
@@ -235,6 +230,12 @@ if [ "$IS_WIC" != "1" ] && [ -n "$DEFAULT_TEZI_IMAGE" ]; then
     if unpacked-kernel-in-fit-format; then
         echo "Image has kernel in FIT format"
         IS_DEFAULT_TEZI_IMAGE_FIT="1" # valid FIT kernel
+
+        # Check if image with FIT kernel has signing artifacts
+        if signing-artifacts-in-unpacked-tezi-image; then
+            echo "Image has signing artifacts - Secure boot related tests will be executed for machine $MACHINE"
+            DEFAULT_SIGNED_TEZI_IMAGE="${DEFAULT_TEZI_IMAGE}"
+        fi
     else
         status=$?
         if [ $status -eq 1 ]; then

--- a/tests/integration/testcases/dt.bats
+++ b/tests/integration/testcases/dt.bats
@@ -97,6 +97,8 @@ load 'lib/common.bash'
 }
 
 @test "dt: check currently enabled device tree" {
+    requires-non-fit-kernel
+
     torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
 
     run torizoncore-builder dt status
@@ -114,6 +116,8 @@ load 'lib/common.bash'
 }
 
 @test "dt: apply device tree in the image" {
+    requires-non-fit-kernel
+
     torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
     torizoncore-builder-shell "rm -rf device-trees"
 
@@ -146,6 +150,7 @@ load 'lib/common.bash'
 # bats test_tags=requires-device
 @test "dt: deploy device tree in the device" {
     requires-device
+    requires-non-fit-kernel
     torizoncore-builder-shell "rm -rf device-trees"
     torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
 
@@ -200,4 +205,17 @@ load 'lib/common.bash'
     run device-shell "cat /proc/device-tree/model"
     assert_success
     assert_output --partial "$MODEL"
+}
+
+@test "dt: throw error on kernel FIT format" {
+    requires-fit-kernel
+
+    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+    run torizoncore-builder dt status
+    assert_failure
+    assert_output --partial "not supported for kernel in FIT format"
+
+    run torizoncore-builder dt apply foo.dtb
+    assert_failure
+    assert_output --partial "not supported for kernel in FIT format"
 }

--- a/tests/integration/testcases/dto.bats
+++ b/tests/integration/testcases/dto.bats
@@ -66,6 +66,8 @@ bats_load_library 'bats/bats-file/load.bash'
 }
 
 @test "dto: apply overlay in the image" {
+    requires-non-fit-kernel
+
     torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
 
     run torizoncore-builder dto apply --force $SAMPLES_DIR/dts/sample_overlay.dts
@@ -91,6 +93,8 @@ bats_load_library 'bats/bats-file/load.bash'
 }
 
 @test "dto: check currently applied overlays" {
+    requires-non-fit-kernel
+
     torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
     torizoncore-builder dto apply --force $SAMPLES_DIR/dts/sample_overlay.dts
 
@@ -102,6 +106,7 @@ bats_load_library 'bats/bats-file/load.bash'
 # bats test_tags=requires-device
 @test "dto: deploy overlay on the device" {
     requires-device
+    requires-non-fit-kernel
 
     run device-shell "cat /proc/device-tree/tcb_prop_test"
     assert_failure 1
@@ -124,6 +129,8 @@ bats_load_library 'bats/bats-file/load.bash'
 }
 
 @test "dto: remove overlay in the image" {
+    requires-non-fit-kernel
+
     run torizoncore-builder dto remove sample_overlay.dtbo
     assert_success
 
@@ -135,6 +142,7 @@ bats_load_library 'bats/bats-file/load.bash'
 # bats test_tags=requires-device
 @test "dto: remove overlay from the device" {
     requires-device
+    requires-non-fit-kernel
 
     # This test assumes that sample_overlay.dtbo is already
     # present and used in the device
@@ -171,6 +179,8 @@ bats_load_library 'bats/bats-file/load.bash'
 }
 
 @test "dto: remove all overlays in the image" {
+    requires-non-fit-kernel
+
     run torizoncore-builder dto remove --all
     assert_success
 
@@ -186,4 +196,21 @@ bats_load_library 'bats/bats-file/load.bash'
     assert_failure
     assert_output --partial "Error: could not find an Easy Installer or WIC image in the storage."
     assert_output --partial "Please use the 'images' command to unpack an image before running this command."
+}
+
+@test "dto throw error on kernel FIT format" {
+    requires-fit-kernel
+
+    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+    run torizoncore-builder dto apply --force $SAMPLES_DIR/dts/sample_overlay.dts
+    assert_failure
+    assert_output --partial "not supported for kernel in FIT format"
+
+    run torizoncore-builder dto status
+    assert_failure
+    assert_output --partial "not supported for kernel in FIT format"
+
+    run torizoncore-builder dto remove sample_overlay.dtbo
+    assert_failure
+    assert_output --partial "not supported for kernel in FIT format"
 }

--- a/tests/integration/testcases/kernel.bats
+++ b/tests/integration/testcases/kernel.bats
@@ -19,6 +19,8 @@ load 'lib/common.bash'
 }
 
 @test "kernel: check build_module ownership for output files" {
+    requires-non-fit-kernel
+
     local MOD_FILE="hello"
     local MAKEFILE="Makefile"
     local README="README.md"
@@ -63,4 +65,26 @@ load 'lib/common.bash'
     assert_output --partial "Please use the 'images' command to unpack an image before running this command."
 
     torizoncore-builder-shell "rm -rf $SRC_DIR"
+}
+
+@test "kernel: throw error on kernel FIT format" {
+    requires-fit-kernel
+
+    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+
+    run torizoncore-builder kernel build_module $SRC_DIR
+    assert_failure
+    assert_output --partial "not supported for FIT format"
+
+    run torizoncore-builder kernel set_custom_args "foo=bar"
+    assert_failure
+    assert_output --partial "not supported for FIT format"
+
+    run torizoncore-builder kernel get_custom_args
+    assert_failure
+    assert_output --partial "not supported for kernel in FIT format"
+
+    run torizoncore-builder kernel clear_custom_args
+    assert_failure
+    assert_output --partial "not supported for FIT format"
 }

--- a/tests/integration/testcases/secboot.bats
+++ b/tests/integration/testcases/secboot.bats
@@ -110,11 +110,10 @@ setup_file() {
 
 @test "secboot sign-kernel: image with unsupported kernel format" {
     requires-supported-kernel-signing-machine
+    requires-non-fit-kernel
 
-    # Unpack an unsigned image, which has an unsupported kernel format
     torizoncore-builder images --remove-storage unpack "${DEFAULT_TEZI_IMAGE}"
 
-    # unsigned Torizon Docker images have the kernel in Image.gz format
     run torizoncore-builder secboot sign-kernel "${KERNEL_KEY_DIR}" \
                                                 --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}"
     assert_failure
@@ -282,13 +281,12 @@ setup_file() {
 
 @test "secboot sign-bootloader-hab: image with unsupported kernel format" {
     requires-supported-hab-signing-machine
+    requires-non-fit-kernel
 
-    # Unpack an unsigned image, which has an unsupported kernel format
     torizoncore-builder images --remove-storage unpack "${DEFAULT_TEZI_IMAGE}"
 
     local CST_DIR="${CST_DIRS}/hab/cst-3.4.1_tcb_test_rsa_2048"
 
-    # unsigned Torizon Docker images have the kernel in Image.gz format
     run torizoncore-builder secboot sign-bootloader-hab "${CST_DIR}" --cst-crypto rsa \
                                                         --cst-key-size 2048 --cst-key-exp 65537 \
                                                         --cst-dig-algo sha256 --cst-srk-index 1

--- a/tests/integration/testcases/secboot.bats
+++ b/tests/integration/testcases/secboot.bats
@@ -118,7 +118,7 @@ setup_file() {
     run torizoncore-builder secboot sign-kernel "${KERNEL_KEY_DIR}" \
                                                 --kernel-key "name=${KERNEL_KEY_NAME};algo=${KERNEL_KEY_ALGO}"
     assert_failure
-    assert_output --partial 'Unpacked image does not have the kernel in fitImage format'
+    assert_output --partial 'Unpacked image does not have the kernel in FIT format'
 }
 
 @test "secboot sign-kernel: unsupported machine" {
@@ -293,7 +293,7 @@ setup_file() {
                                                         --cst-key-size 2048 --cst-key-exp 65537 \
                                                         --cst-dig-algo sha256 --cst-srk-index 1
     assert_failure
-    assert_output --partial 'Unpacked image does not have the kernel in fitImage format'
+    assert_output --partial 'Unpacked image does not have the kernel in FIT format'
 }
 
 @test "secboot sign-bootloader-hab: machine not compatible with HAB" {

--- a/tests/integration/testcases/splash.bats
+++ b/tests/integration/testcases/splash.bats
@@ -40,6 +40,8 @@ bats_load_library 'bats/bats-file/load.bash'
 }
 
 @test "splash: create splash" {
+    requires-non-fit-kernel
+
     torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
 
     run torizoncore-builder splash $SAMPLES_DIR/splash/fast-banana.png
@@ -51,4 +53,13 @@ bats_load_library 'bats/bats-file/load.bash'
 
     run torizoncore-builder-shell "ls -l /storage/splash/usr/share/plymouth/themes/spinner/watermark.png"
     assert_success
+}
+
+@test "splash: throw error on kernel FIT format" {
+    requires-fit-kernel
+
+    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+    run torizoncore-builder splash $SAMPLES_DIR/splash/fast-banana.png
+    assert_failure
+    assert_output --partial "not supported for kernel in FIT format"
 }


### PR DESCRIPTION
When running certain commands/features, TorizonCore Builder will now first check if the unpacked image has the kernel in FIT format, and abort execution if the current implementation doesn't support it.

This applies to dt, dto, kernel and splash commands, as well as their respective features in the build command.

Related-to: TCB-755

Also, increase the timeout for remote commands sent via SSH to 90 seconds. Some tests in recent pipeline executions were failing early due to the command timeout being reached.

Signed-off-by: Lucas Akira Morishita <lucas.morishita@toradex.com>