### PR TITLE
Add CI tests for signed images plus improvements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -315,7 +315,7 @@ wsl-test-host-tos7-64bit-nightly:
 
 test-torizoncore-common-intel:
   variables:
-    IS_WIC: true
+    IS_WIC: 1
   extends: .test-base
   script:
     - TCB_SKIP_PULL=1 source ./setup.sh
@@ -335,7 +335,7 @@ test-torizoncore-common-intel:
 
 test-torizoncore-common-rasp4:
   variables:
-    IS_WIC: true
+    IS_WIC: 1
   extends: .test-base
   script:
     # TODO: Since this creates a sub-shell, the environment variables created in setup.sh aren't persisting, because of this 'export TCBCMD' is required

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,13 @@ variables:
   TEST_IMAGES_TC_COMMON_VERSION: "6.6.0-common"
   TEST_IMAGE_TC_COMMON_INTEL: "torizon-core-common-docker-dev-intel-corei7-64-20240226043251.rootfs.wic"
   TEST_IMAGE_TC_COMMON_RASPI4: "torizon-core-common-docker-dev-v6.6.0-common-raspberrypi4-64.img"
-  # TC custom image parameters
+
+  # Parameters required for fetching signed images:
+  SIGIMG_ARTIFACTORY_URL: "" # http://artifacts.toradex.com/artifactory
+  SIGIMG_ARTIFACTORY_PROD_REPO: ""
+  SIGIMG_ARTIFACTORY_PRERELEASE_REPO: "" # torizoncore-oe-prerelease-frankfurt
+
+  # Parameters required when triggering the pipeline externally (e.g. Jenkins):
   INTERNAL_ARTIFACTORY_URL: "" # "https://artifactory-horw.int.toradex.com/artifactory"
   ARTIFACTORY_SRC_REPO: "" # "devtorizoncore-oe-prerelease-horw"
   BUILD_DISTRO: "" # "torizon-upstream"
@@ -44,6 +50,7 @@ variables:
   BUILD_RECIPE: "" # "torizon-core-docker""
   DISTRO_VERSION: "" # "5.7.3-devel-20230502+build.25"
   MATRIX_BUILD_NUMBER: "" # "25""
+
   # Set to "echo" for dry running specific actions:
   D: ""        # deployment actions
   T: ""        # test actions
@@ -314,6 +321,48 @@ wsl-test-host-tos7-64bit-nightly:
   extends: test-host-tos7-64bit-nightly
   tags:
     - windows-wsl
+
+test-host-tos7-32bit-signed-nightly:
+  # TODO: Review once signed images are available publicly.
+  tags:
+    - "all"
+  extends: .test-base
+  variables:
+    YOCTO_BRANCH: "scarthgap-7.x.y"
+    TARGET_BUILD_TYPE: "nightly"
+    TCB_MACHINE: "apalis-imx6"
+    TARGET_SIGNING_CLASS: "tdx-signed"
+    ACCEPT_VARIANTS: "torizon-minimal"
+  script:
+    # set extra variables for downloading signed images from the internal Artifactory
+    - export BASE_ARTIFACTORY_URL_PROD=""
+    - export BASE_ARTIFACTORY_URL_PRERELEASE=""
+    - '[ -n "${SIGIMG_ARTIFACTORY_URL}" ] || { echo "SIGIMG_ARTIFACTORY_URL not set"; exit 1; }'
+    - '[ -n "${SIGIMG_ARTIFACTORY_PROD_REPO}" ] && BASE_ARTIFACTORY_URL_PROD="${SIGIMG_ARTIFACTORY_URL}/${SIGIMG_ARTIFACTORY_PROD_REPO}"'
+    - '[ -n "${SIGIMG_ARTIFACTORY_PRERELEASE_REPO}" ] && BASE_ARTIFACTORY_URL_PRERELEASE="${SIGIMG_ARTIFACTORY_URL}/${SIGIMG_ARTIFACTORY_PRERELEASE_REPO}"'
+    - ./run_all.sh --machine $TCB_MACHINE --report --testcase "$TCB_HOST_TESTS"
+      --tcb-custom-image "${TCB_IMAGE_UNDER_TEST}"
+
+test-host-tos7-64bit-signed-nightly:
+  # TODO: Review once signed images are available publicly.
+  tags:
+    - "all"
+  extends: .test-base
+  variables:
+    YOCTO_BRANCH: "scarthgap-7.x.y"
+    TARGET_BUILD_TYPE: "nightly"
+    TCB_MACHINE: "verdin-imx8mp"
+    TARGET_SIGNING_CLASS: "tdx-signed"
+    ACCEPT_VARIANTS: "torizon-minimal"
+  script:
+    # set extra variables for downloading signed images from the internal Artifactory
+    - export BASE_ARTIFACTORY_URL_PROD=""
+    - export BASE_ARTIFACTORY_URL_PRERELEASE=""
+    - '[ -n "${SIGIMG_ARTIFACTORY_URL}" ] || { echo "SIGIMG_ARTIFACTORY_URL not set"; exit 1; }'
+    - '[ -n "${SIGIMG_ARTIFACTORY_PROD_REPO}" ] && BASE_ARTIFACTORY_URL_PROD="${SIGIMG_ARTIFACTORY_URL}/${SIGIMG_ARTIFACTORY_PROD_REPO}"'
+    - '[ -n "${SIGIMG_ARTIFACTORY_PRERELEASE_REPO}" ] && BASE_ARTIFACTORY_URL_PRERELEASE="${SIGIMG_ARTIFACTORY_URL}/${SIGIMG_ARTIFACTORY_PRERELEASE_REPO}"'
+    - ./run_all.sh --machine $TCB_MACHINE --report --testcase "$TCB_HOST_TESTS"
+      --tcb-custom-image "${TCB_IMAGE_UNDER_TEST}"
 
 test-torizoncore-common-intel:
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -186,11 +186,13 @@ build-arm64:
     - apk update && apk add git sshpass zstd wget bash tar openssl zip curl jq
     - cd tests/integration/
     - rm -Rf workdir/reports/*
+    # define TCB image name to be used by the test job:
+    - export TCB_IMAGE_UNDER_TEST="${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
     # pull latest build of TorizonCore Builder
     - echo -e "\e[0Ksection_start:$(date +%s):pull_eval_tcb_section\r\e[0KPull TorizonCore Builder to be evaluated"
     - ${T} docker login -u "${CI_DOCKER_HUB_PULL_USER}" -p "${CI_DOCKER_HUB_PULL_PASSWORD}"
     - ${T} docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
-    - ${T} docker pull "${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
+    - ${T} docker pull "${TCB_IMAGE_UNDER_TEST}"
     - echo -e "\e[0Ksection_end:$(date +%s):pull_eval_tcb_section\r\e[0K"
     # get all .bats files (excluding raw/wic ones) except platform.bats
     - export TCB_HOST_TESTS="torizoncore-builder $(cd testcases/ && ls -1 *.bats | sed -e 's/\.bats//' -e '/^\(platform\|torizoncore-builder\)$/d' | sort)"
@@ -211,7 +213,7 @@ test-host-tc6-platform-release:
     TCB_MACHINE: "apalis-imx8"
   script:
     - ./run_all.sh --machine $TCB_MACHINE --report --testcase platform
-      --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}
+      --tcb-custom-image "${TCB_IMAGE_UNDER_TEST}"
 
 test-host-tos7-platform-release:
   extends: .test-base
@@ -223,7 +225,7 @@ test-host-tos7-platform-release:
     TCB_MACHINE: "apalis-imx6"
   script:
     - ./run_all.sh --machine $TCB_MACHINE --report --testcase platform
-      --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}
+      --tcb-custom-image "${TCB_IMAGE_UNDER_TEST}"
 
 test-host-tos7-platform-nightly:
   extends: .test-base
@@ -235,7 +237,7 @@ test-host-tos7-platform-nightly:
     TCB_MACHINE: "apalis-imx6"
   script:
     - ./run_all.sh --machine $TCB_MACHINE --report --testcase platform
-      --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}
+      --tcb-custom-image "${TCB_IMAGE_UNDER_TEST}"
 
 wsl-test-host-tos7-platform-nightly:
   extends: test-host-tos7-platform-nightly
@@ -251,7 +253,7 @@ test-host-tc6-32bit-release:
     TCB_MACHINE: "apalis-imx6"
   script:
     - ./run_all.sh --machine $TCB_MACHINE --report --testcase "$TCB_HOST_TESTS"
-      --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}
+      --tcb-custom-image "${TCB_IMAGE_UNDER_TEST}"
 
 wsl-test-host-tc6-32bit-release:
   extends: test-host-tc6-32bit-release
@@ -266,7 +268,7 @@ test-host-tc6-64bit-release:
     TCB_MACHINE: "apalis-imx8"
   script:
     - ./run_all.sh --machine $TCB_MACHINE --report --testcase "$TCB_HOST_TESTS"
-      --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}
+      --tcb-custom-image "${TCB_IMAGE_UNDER_TEST}"
 
 test-host-tos7-32bit-release:
   extends: .test-base
@@ -276,7 +278,7 @@ test-host-tos7-32bit-release:
     TCB_MACHINE: "apalis-imx6"
   script:
     - ./run_all.sh --machine $TCB_MACHINE --report --testcase "$TCB_HOST_TESTS"
-      --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}
+      --tcb-custom-image "${TCB_IMAGE_UNDER_TEST}"
 
 test-host-tos7-32bit-nightly:
   extends: .test-base
@@ -286,7 +288,7 @@ test-host-tos7-32bit-nightly:
     TCB_MACHINE: "apalis-imx6"
   script:
     - ./run_all.sh --machine $TCB_MACHINE --report --testcase "$TCB_HOST_TESTS"
-      --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}
+      --tcb-custom-image "${TCB_IMAGE_UNDER_TEST}"
 
 test-host-tos7-64bit-release:
   extends: .test-base
@@ -296,7 +298,7 @@ test-host-tos7-64bit-release:
     TCB_MACHINE: "apalis-imx8"
   script:
     - ./run_all.sh --machine $TCB_MACHINE --report --testcase "$TCB_HOST_TESTS"
-      --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}
+      --tcb-custom-image "${TCB_IMAGE_UNDER_TEST}"
 
 test-host-tos7-64bit-nightly:
   extends: .test-base
@@ -306,7 +308,7 @@ test-host-tos7-64bit-nightly:
     TCB_MACHINE: "apalis-imx8"
   script:
     - ./run_all.sh --machine $TCB_MACHINE --report --testcase "$TCB_HOST_TESTS"
-      --tcb-custom-image ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}
+      --tcb-custom-image "${TCB_IMAGE_UNDER_TEST}"
 
 wsl-test-host-tos7-64bit-nightly:
   extends: test-host-tos7-64bit-nightly
@@ -320,7 +322,7 @@ test-torizoncore-common-intel:
   script:
     - TCB_SKIP_PULL=1 source ./setup.sh
     # TODO: Switch to Bash and use tcb-env-setup.sh script later
-    - export TCBCMD="docker run --rm -v /deploy -v $(pwd)/workdir:/workdir -v storage:/storage --net=host -v /var/run/docker.sock:/var/run/docker.sock ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
+    - export TCBCMD="docker run --rm -v /deploy -v $(pwd)/workdir:/workdir -v storage:/storage --net=host -v /var/run/docker.sock:/var/run/docker.sock ${TCB_IMAGE_UNDER_TEST}"
     # prepare image
     - echo -e "\e[0Ksection_start:$(date +%s):download_rawimgs_section\r\e[0KDownload WIC/raw test images"
     - mkdir -p workdir/images
@@ -341,7 +343,7 @@ test-torizoncore-common-rasp4:
     # TODO: Since this creates a sub-shell, the environment variables created in setup.sh aren't persisting, because of this 'export TCBCMD' is required
     - TCB_SKIP_PULL=1 source ./setup.sh
     # TODO: Switch to Bash and use tcb-env-setup.sh script later
-    - export TCBCMD="docker run --rm -v /deploy -v $(pwd)/workdir:/workdir -v storage:/storage --net=host -v /var/run/docker.sock:/var/run/docker.sock ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
+    - export TCBCMD="docker run --rm -v /deploy -v $(pwd)/workdir:/workdir -v storage:/storage --net=host -v /var/run/docker.sock:/var/run/docker.sock ${TCB_IMAGE_UNDER_TEST}"
     # prepare image
     - echo -e "\e[0Ksection_start:$(date +%s):download_rawimgs_section\r\e[0KDownload WIC/raw test images"
     - mkdir -p workdir/images
@@ -367,7 +369,7 @@ test-torizoncore:
   script:
     - TCB_SKIP_PULL=1 source ./setup.sh
     # TODO: Switch to Bash and use tcb-env-setup.sh script later
-    - export TCBCMD="docker run --rm -v /deploy -v $(pwd)/workdir:/workdir -v storage:/storage --net=host -v /var/run/docker.sock:/var/run/docker.sock ${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
+    - export TCBCMD="docker run --rm -v /deploy -v $(pwd)/workdir:/workdir -v storage:/storage --net=host -v /var/run/docker.sock:/var/run/docker.sock ${TCB_IMAGE_UNDER_TEST}"
     - if [ -z ${INTERNAL_ARTIFACTORY_URL} ]; then echo "Missing variable INTERNAL_ARTIFACTORY_URL." && exit 1; fi
     - if [ -z ${ARTIFACTORY_SRC_REPO} ]; then echo "Missing variable ARTIFACTORY_SRC_REPO." && exit 1; fi
     - if [ -z ${BUILD_MANIFEST_BRANCH} ]; then echo "Missing variable BUILD_MANIFEST_BRANCH." && exit 1; fi

--- a/tests/integration/README
+++ b/tests/integration/README
@@ -44,7 +44,7 @@ the respectively enviroment variables, an example would be:
 $ TARGET_BUILD_TYPE=release YOCTO_BRANCH=kirkstone-6.x.y TCB_MACHINE=verdin-am62 ./get_tezi_images.sh
 
 Download Common Torizon OS WIC/raw images
-=====================================
+=========================================
 
 You can manually download Torizon OS WIC/raw images from the Common Torizon
 GitHub repository:

--- a/tests/integration/get_tezi_images.sh
+++ b/tests/integration/get_tezi_images.sh
@@ -1,86 +1,132 @@
-#!/bin/sh
+#!/bin/bash
 
-# location to save images
-OUTDIR="$PWD/workdir/images"
-STAMP="$OUTDIR/.images_downloaded"
-
-# default values
+# default values (commonly overridden)
 TARGET_BUILD_TYPE="${TARGET_BUILD_TYPE:-nightly}"
 YOCTO_BRANCH="${YOCTO_BRANCH:-scarthgap-7.x.y}"
 TCB_MACHINE="${TCB_MACHINE:-colibri-imx6}"
+TARGET_SIGNING_CLASS="${TARGET_SIGNING_CLASS-}"
+
+# low-level control (less commonly overridden)
+ACCEPT_DISTROS=${ACCEPT_DISTROS-torizon torizon-upstream}
+ACCEPT_VARIANTS=${ACCEPT_VARIANTS-torizon-docker torizon-core-docker}
+BASE_ARTIFACTORY_URL_PROD=${BASE_ARTIFACTORY_URL_PROD-https://artifacts.toradex.com/artifactory/torizoncore-oe-prod-frankfurt}
+BASE_ARTIFACTORY_URL_PRERELEASE=${BASE_ARTIFACTORY_URL_PRERELEASE-https://artifacts.toradex.com/artifactory/torizoncore-oe-prerelease-frankfurt}
+
+# logging
+ENABLE_LOG=${ENABLE_LOG:-1}
+ENABLE_DBG=${ENABLE_DBG:-0}
+
+# location to save images
+OUTDIR="${PWD}/workdir/images"
+STAMP="${OUTDIR}/.images_downloaded"
+
+log() {
+    if [ "${ENABLE_LOG}" = "1" ]; then
+        echo "$@"
+    fi
+}
+
+dbg() {
+    if [ "${ENABLE_DBG}" = "1" ]; then
+        echo "$@"
+    fi
+}
+
+error() {
+    echo "ERROR:" "$@" >&2
+    exit 1
+}
 
 prepare() {
     rm -rf workdir/images
-    mkdir -p "$OUTDIR"
+    mkdir -p "${OUTDIR}"
 }
 
 download() {
-    if [ "$TARGET_BUILD_TYPE" = "release" ]; then
-        artifactory_url="https://artifacts.toradex.com/artifactory/torizoncore-oe-prod-frankfurt/$YOCTO_BRANCH/$TARGET_BUILD_TYPE"
-    elif [ "$TARGET_BUILD_TYPE" = "nightly" ]; then
-        artifactory_url="https://artifacts.toradex.com/artifactory/torizoncore-oe-prerelease-frankfurt/$YOCTO_BRANCH/$TARGET_BUILD_TYPE"
+    if [ "${TARGET_BUILD_TYPE}" = "release" ]; then
+        _base_url="${BASE_ARTIFACTORY_URL_PROD:?variable not set}"
+    elif [ "${TARGET_BUILD_TYPE}" = "nightly" ]; then
+        _base_url="${BASE_ARTIFACTORY_URL_PRERELEASE:?variable not set}"
     else
-        echo "ERROR: Invalid TARGET_BUILD_TYPE. Expected 'nightly' or 'release'."
-        exit 1
+        error "Invalid TARGET_BUILD_TYPE. Expected 'nightly' or 'release'."
     fi
 
-    # Step 1: Catch all build numbers for a specific machine, in descending order
-    build_numbers=$(wget -qO- "$artifactory_url" | grep -o '<a href="[0-9]*/"' |
-                    sed -e 's#<a href="##' -e 's#/"##' | sort -nr)
+    artifactory_url="${_base_url}/${YOCTO_BRANCH}/${TARGET_BUILD_TYPE}"
 
-    # Step 2: Find the highest build number for $TCB_MACHINE
-    for build in $build_numbers; do
+    # Determine the available build numbers (limited to 10)
+    build_numbers=$(wget -qO- "${artifactory_url}" | grep -o '<a href="[0-9]*/"' |
+                    sed -e 's#<a href="##' -e 's#/"##' | sort -nr | head -n10)
+
+    torizon_tar_url=""
+
+    # shellcheck disable=SC2086
+    echo "Available build numbers:" ${build_numbers}
+    for build in ${build_numbers}; do
         machine_url="${artifactory_url}/${build}/${TCB_MACHINE}/"
-
-        # Checks if machine exists in current build
-        if wget --spider -q "$machine_url"; then
-            latest_build=$build
-            break  # Exit the loop when it finds the first valid build
+        dbg "Accessing ${machine_url}"
+        if ! wget --spider -q "${machine_url}"; then
+            log "Build #${build}: not available for machine ${TCB_MACHINE}"
+            continue
         fi
+
+        distros=$(wget -qO- "${machine_url}" |
+                      grep -Eo "href=\"(${ACCEPT_DISTROS/ /|})/*\"" |
+                      sed 's/href="\([-a-z]*\).*"/\1/')
+        # shellcheck disable=SC2086
+        log "Build #${build}: available distros:" ${distros}
+
+        for distro in ${distros}; do
+            distro_url="${artifactory_url}/${build}/${TCB_MACHINE}/${distro}/"
+            dbg "Accessing ${distro_url}"
+            variants=$(wget -qO- "${distro_url}" |
+                          grep -Eo "href=\"(${ACCEPT_VARIANTS/ /|})/*\"" |
+                          sed 's/href="\([-a-z]*\).*"/\1/')
+            # shellcheck disable=SC2086
+            log "Build #${build}: available variants:" ${variants}
+
+            for variant in ${variants}; do
+                variant_url="${artifactory_url}/${build}/${TCB_MACHINE}/${distro}/${variant}/"
+
+                # Select between signed classes (if any):
+                if [ -n "${TARGET_SIGNING_CLASS}" ]; then
+                    oedeploy_url="${variant_url}${TARGET_SIGNING_CLASS}/oedeploy/"
+                else
+                    oedeploy_url="${variant_url}oedeploy/"
+                fi
+
+                dbg "Accessing ${oedeploy_url}"
+                filename=$(wget -qO- "${oedeploy_url}" | grep '<a href="' |
+                               sed -n 's#.*<a href="\([^"]*-Tezi_[^"]*\.tar\)".*#\1#p' |
+                               sort -r | head -n1)
+                [ -z "${filename}" ] && continue
+
+                torizon_tar_url="${oedeploy_url}${filename}"
+                # Leave all loops:
+                break 3
+            done
+        done
     done
 
-    if [ -z "$latest_build" ]; then
-        echo "ERROR: No image found for $TCB_MACHINE."
-        exit 1
-    fi
+    [ -n "${torizon_tar_url}" ] || return 1
 
-    torizon_tar_url="${artifactory_url}/${latest_build}/${TCB_MACHINE}"
-
-    # 'torizon' or 'torizon-upstream'
-    upstream_variant=$(wget -qO- "$torizon_tar_url" | grep '<a href="torizon' |
-                        sed -n 's#.*<a href="\([^"/]*\)/".*#\1#p' |
-                        grep -E '^(torizon|torizon-upstream)$' | head -n1)
-    torizon_tar_url="$torizon_tar_url/$upstream_variant"
-
-    # 'torizon-docker' or 'torizon-core-docker'
-    docker_type=$(wget -qO- "$torizon_tar_url" | grep '<a href="torizon' |
-                    grep 'docker/' | sed -n 's#.*<a href="\([^"/]*\)/".*#\1#p' |
-                    tail -n1)
-    torizon_tar_url="$torizon_tar_url/$docker_type/oedeploy"
-
-    # Find Torizon .tar image
-    filename=$(wget -qO- "$torizon_tar_url" | grep '<a href="' |
-                sed -n 's#.*<a href="\([^"]*-Tezi_[^"]*\.tar\)".*#\1#p' |
-                sort -r | head -n1)
-    torizon_tar_url="$torizon_tar_url/$filename"
+    log "Image URL: ${torizon_tar_url}"
 
     # The loading bar of wget is dynamically rendered using terminal control characters,
     # this breaks the logs. So, disable the loading bar in CI
-    if [ "$TCB_UNDER_CI" = "1" ]; then
-        wget --no-verbose -P workdir/images "$torizon_tar_url"
+    if [ "${TCB_UNDER_CI}" = "1" ]; then
+        wget --no-verbose -P workdir/images "${torizon_tar_url}"
     else
-        wget -P workdir/images "$torizon_tar_url"
+        wget -P workdir/images "${torizon_tar_url}"
     fi
 }
 
 main() {
     prepare
-    download
-    if [ $? -ne 0 ]; then
-        echo "ERROR: Couldn't download Torizon image"
+    if ! download; then
+        error "Couldn't download Torizon image"
         exit 1
     fi
-    touch "$STAMP"
+    touch "${STAMP}"
     echo "Image successfully downloaded."
 }
 

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -76,8 +76,12 @@ if [[ -n "$TCB_DEVICE" ]]; then
     fi
 fi
 
+# Variable IS_WIC can be passed to force a specific value; when not passed, it
+# is automatically set with a default value that depends on the current machine.
 if [[ "$WIC_MACHINES" == *"$MACHINE"* ]]; then
-    export IS_WIC="1"
+    export IS_WIC="${IS_WIC:-1}"
+else
+    export IS_WIC="${IS_WIC:-0}"
 fi
 
 # test case to run

--- a/tests/integration/run_all.sh
+++ b/tests/integration/run_all.sh
@@ -38,6 +38,8 @@ usage() {
     exit 0
 }
 
+export IS_WIC=${IS_WIC:-0}
+
 USE_DEVICE=0
 DEVICE_INFO_FILE="device_information.json"
 export TCB_TESTCASE=""
@@ -126,7 +128,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-if [ "$(echo "$IS_WIC" | tr '[:upper:]' '[:lower:]')" != "true" ]; then
+if [ $IS_WIC = "0" ]; then
     if [ ! -e workdir/images/.images_downloaded ]; then
         echo "Images not found. Attempting to download images..."
         ./get_tezi_images.sh
@@ -137,9 +139,7 @@ if [ "$(echo "$IS_WIC" | tr '[:upper:]' '[:lower:]')" != "true" ]; then
             exit 1
         fi
     fi
-fi
-
-if [ "$(echo "$IS_WIC" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
+elif [ $IS_WIC = "1" ]; then
     if [ ! -e workdir/images/.raw_images_downloaded ]; then
         echo "Raw Images not found. Attempting to download images..."
         ./get_raw_images.sh
@@ -150,6 +150,9 @@ if [ "$(echo "$IS_WIC" | tr '[:upper:]' '[:lower:]')" = "true" ]; then
             exit 1
         fi
     fi
+else
+    echo "Error: IS_WIC (${IS_WIC}) is not set correctly (\"0\" or \"1\")."
+    exit 1
 fi
 
 echo "Running integration tests..."
@@ -164,4 +167,3 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Integration tests completed successfully."
-

--- a/tests/integration/testcases/build.bats
+++ b/tests/integration/testcases/build.bats
@@ -114,7 +114,6 @@ teardown_file() {
 }
 
 @test "build: re-signing of kernel FIT and bootloader with HAB" {
-
     requires-supported-kernel-signing-machine
     requires-supported-hab-signing-machine
     requires-signed-image
@@ -246,7 +245,8 @@ teardown_file() {
     rm -rf "${CST_DIR}/linux64"
 }
 
-@test "build: full customization checked on host" {
+@test "build: full customization checked on host (non-FIT)" {
+    requires-non-fit-kernel
     requires-image-version "$DEFAULT_TEZI_IMAGE" "5.3.0"
 
     local OUTDIR='fully_customized_image'
@@ -311,6 +311,21 @@ teardown_file() {
       "ostree --repo=$ARCHIVE show --print-metadata-key='ostree.ref-binding' $COMMIT"
     assert_success
     assert_output --partial "['$COMMIT']"
+}
+
+@test "build: full customization checked on host (FIT)" {
+    requires-fit-kernel
+    requires-image-version "$DEFAULT_TEZI_IMAGE" "5.3.0"
+
+    local OUTDIR='fully_customized_image'
+    run torizoncore-builder build \
+        --file "$SAMPLES_DIR/config/tcbuild-full-customization.yaml" \
+        --set INPUT_IMAGE="$DEFAULT_TEZI_IMAGE" \
+        --set OUTPUT_DIR="$OUTDIR" --force
+
+    assert_failure
+    assert_output --partial \
+	'Error: Changing the splash screen is not supported for kernel in FIT format'
 }
 
 # bats test_tags=requires-device
@@ -428,7 +443,9 @@ teardown_file() {
     rm -rf "$DUMMY_OUTPUT"
 }
 
-@test "build: check overlays's clear" {
+@test "build: check overlays's clear (non-FIT)" {
+    requires-non-fit-kernel
+
     local OVERLAY_IMAGE="overlay_image"
     local DUMMY_OUTPUT="dummy_output_directory"
 
@@ -510,6 +527,34 @@ teardown_file() {
     actual_result=$(echo "$output" | sed -En -e 's/^\s*-\s*(\S+)\.dtbo/\1/p' | tr -s '\n\r' '  ')
     expect_result="sample_overlay sample_overlay1 sample_overlay2 "
     assert_equal "$actual_result" "$expect_result"
+
+    rm -rf $DUMMY_OUTPUT $OVERLAY_IMAGE
+}
+
+@test "build: check overlays's clear (FIT)" {
+    requires-fit-kernel
+
+    local OVERLAY_IMAGE="overlay_image"
+    local DUMMY_OUTPUT="dummy_output_directory"
+
+    rm -rf $DUMMY_OUTPUT $OVERLAY_IMAGE
+
+    torizoncore-builder-clean-storage
+
+    # Create input image, clearing all overlays and adding 2 dummy overlays.
+    cat "$SAMPLES_DIR/config/tcbuild-with-clear.yaml" | \
+              sed -Ee 's/## add:/add:/' \
+                  -Ee '/\badd:/ s/sample_overlay2/sample_overlay/' \
+                  -Ee '/\badd:/ s@]@, samples/dts/sample_overlay1.dts]@' > \
+              "$SAMPLES_DIR/config/tcbuild-modified.yaml"
+
+    run torizoncore-builder build \
+              --file "$SAMPLES_DIR/config/tcbuild-modified.yaml" \
+              --set INPUT_IMAGE="$DEFAULT_TEZI_IMAGE" \
+              --set OUTPUT_DIR="$OVERLAY_IMAGE" --force
+    assert_failure
+    assert_output --partial \
+        'Error: Device tree overlay customization is not supported for kernel in FIT format'
 
     rm -rf $DUMMY_OUTPUT $OVERLAY_IMAGE
 }

--- a/torizoncore-builder.py
+++ b/torizoncore-builder.py
@@ -240,10 +240,12 @@ if __name__ == "__main__":
         sys.exit(-1)
     except subprocess.CalledProcessError as ex:
         logging.error(f"{ex}")
-        if b"\n" in ex.output:
+        if not ex.output:
+            pass
+        elif b"\n" in ex.output:
             outxt = "\n  ".join(ex.output.decode().split("\n")) # pylint: disable=invalid-name
             logging.error(f"Output:\n  {outxt}")
-        elif ex.output:
+        else:
             logging.error(f"Output: {ex.output.decode()}")
         logging.debug(traceback.format_exc())  # full traceback to be shown for debugging only
         sys.exit(4)


### PR DESCRIPTION
This includes:

- A series of improvements to the script responsible for fetching Tezi images, adding flexibility and the ability to fetch images from the internal Artifactory repository.
- New test jobs for running "host-only" tests with signed images.
- Other minor changes.

Please check the commit messages for details.

Related-to: TCB-756, TCB-740
