### PR TITLE
Introduce support for DT operations (apply, status) when the kernel is in the FIT format

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,7 +1,5 @@
 [MASTER]
 init-hook="from pylint.config import find_pylintrc;import os, sys; sys.path.append(os.path.dirname(find_pylintrc()))"
-[LOGGING]
-logging-format-style=new
 [BASIC]
 good-names=torizoncore-builder,ex
 [TYPECHECK]

--- a/requirements_debian.txt
+++ b/requirements_debian.txt
@@ -6,3 +6,4 @@ pyyaml==5.3.1
 requests-oauthlib==1.3.0
 debugpy==1.8.7
 fabric==3.2.2
+pylibfdt==1.7.2

--- a/tcbuilder/backend/common.py
+++ b/tcbuilder/backend/common.py
@@ -928,10 +928,23 @@ def find_kernel_in_sysroot(storage_dir):
     csum += ".0"
 
     kernel_path = OSTREE_KERNEL_DEPLOY_PATH.format(csum=csum, kver=kernel_version)
-
     kernel_path = os.path.join(sysroot_path, kernel_path, OSTREE_KERNEL_FILENAME)
 
     if not os.path.isfile(kernel_path):
         raise PathNotExistError("Kernel not found in unpacked rootfs. Aborting.")
 
     return kernel_path
+
+
+def get_kernel_dir(storage_dir):
+    """Get the versioned kernel directory.
+
+    Returns "usr/lib/modules/<kver>" where <kver> is determined
+    automatically. This is where the kernel binary is supposed to live.
+    """
+
+    src_sysroot_dir = os.path.join(storage_dir, "sysroot")
+    src_sysroot = ostree.load_sysroot(src_sysroot_dir)
+    csum, _ = ostree.get_deployment_info_from_sysroot(src_sysroot)
+    kernel_version = ostree.get_kernel_version(src_sysroot.repo(), csum)
+    return os.path.join("usr/lib/modules", kernel_version)

--- a/tcbuilder/backend/dt.py
+++ b/tcbuilder/backend/dt.py
@@ -21,13 +21,23 @@ def get_dt_changes_dir(storage_dir):
 
 def get_current_uenv_txt_path(storage_dir):
     '''Get the path to the currently applied uEnv.txt, the bootloader environment file.'''
+    # Check for file in the changes directory.
     path = os.path.join(get_dt_changes_dir(storage_dir), "usr", "lib", "ostree-boot", "uEnv.txt")
     if os.path.exists(path):
-        # Found a recently applied (but not yet deployed) uEnv.txt.
+        log.debug("Found uEnv.txt in changes dir: '{path}'")
         return path
-    # Fallback to uEnv.txt from the base image.
-    path = os.path.join(storage_dir, "sysroot", "boot", "loader", "uEnv.txt")
-    assert os.path.exists(path), "panic: missing uEnv.txt in base image!"
+
+    # Check for the ostree-managed version of the file in the deployment; this
+    # finds the commited version of the file rather the modified copy produced
+    # by libostree in the boot directory when a deployment is created.
+    path = subprocess.check_output(
+        ["find", f"{storage_dir}/sysroot/ostree/deploy",
+         "-wholename", "*/usr/lib/ostree-boot/uEnv.txt",
+         "-print", "-quit"],
+        shell=False, text=True).strip()
+    assert path and os.path.exists(path), "panic: missing uEnv.txt in base image!"
+    log.debug("Found uEnv.txt in deployment: '{path}'")
+
     return path
 
 

--- a/tcbuilder/backend/dt.py
+++ b/tcbuilder/backend/dt.py
@@ -11,6 +11,9 @@ import sys
 import io
 import re
 
+from tcbuilder.errors import InvalidStateError
+from tcbuilder.backend.kernel import get_kernel_changes_dir
+
 log = logging.getLogger("torizon." + __name__)
 
 
@@ -21,31 +24,42 @@ def get_dt_changes_dir(storage_dir):
 
 def get_current_uenv_txt_path(storage_dir):
     '''Get the path to the currently applied uEnv.txt, the bootloader environment file.'''
-    # Check for file in the changes directory.
-    path = os.path.join(get_dt_changes_dir(storage_dir), "usr", "lib", "ostree-boot", "uEnv.txt")
-    if os.path.exists(path):
-        log.debug("Found uEnv.txt in changes dir: '{path}'")
-        return path
+
+    # Look for the file in two changes directories; the former is used with
+    # non-FIT whereas the latter with FIT images.
+    dchangesdir = get_dt_changes_dir(storage_dir)
+    dpath = os.path.join(dchangesdir, "usr", "lib", "ostree-boot", "uEnv.txt")
+    kchangesdir = get_kernel_changes_dir(storage_dir)
+    kpath = os.path.join(kchangesdir, "usr", "lib", "ostree-boot", "uEnv.txt")
+
+    if os.path.exists(dpath) and os.path.exists(kpath):
+        raise InvalidStateError(
+            "Bad state: uEnv.txt was found both in '{dpath}' and '{kpath}'")
+
+    for _path in (dpath, kpath):
+        if os.path.exists(_path):
+            log.debug(f"Found uEnv.txt in changes dir: '{_path}'")
+            return _path
 
     # Check for the ostree-managed version of the file in the deployment; this
     # finds the commited version of the file rather the modified copy produced
     # by libostree in the boot directory when a deployment is created.
-    path = subprocess.check_output(
+    dpath = subprocess.check_output(
         ["find", f"{storage_dir}/sysroot/ostree/deploy",
          "-wholename", "*/usr/lib/ostree-boot/uEnv.txt",
          "-print", "-quit"],
         shell=False, text=True).strip()
-    assert path and os.path.exists(path), "panic: missing uEnv.txt in base image!"
-    log.debug("Found uEnv.txt in deployment: '{path}'")
+    assert dpath and os.path.exists(dpath), "panic: missing uEnv.txt in base image!"
+    log.debug(f"Found uEnv.txt in deployment: '{dpath}'")
 
-    return path
+    return dpath
 
 
 def get_uboot_initial_env_path(storage_dir):
     '''Get the path to u-boot-initial-env-sd, the initial bootloader environment set by Tezi.'''
     image_json_path = os.path.join(storage_dir, "tezi", "image.json")
     assert os.path.exists(image_json_path), "panic: missing image.json in Tezi directory!"
-    with open(image_json_path, "r") as jsonf:
+    with open(image_json_path, "r", encoding="utf-8") as jsonf:
         image_json = json.load(jsonf)
     try:
         initial_env_basename = image_json["u_boot_env"]

--- a/tcbuilder/backend/kernelfit.py
+++ b/tcbuilder/backend/kernelfit.py
@@ -1,0 +1,686 @@
+"""
+This module offers the class `KernelFit` for manipulating FIT images.
+"""
+
+import logging
+import re
+from typing import Dict, List, Union, Optional, Any, BinaryIO
+
+import libfdt
+from libfdt import QUIET_NOTFOUND
+
+log = logging.getLogger("torizon." + __name__)
+
+MAX_FIT_IMAGE_SIZE = 64*1024*1024
+CONFIG_NODE_PATH = "/configurations"
+IMAGES_NODE_PATH = "/images"
+DTB_IMAGE_NAME_PROP = "fdt"
+DTB_IMAGE_DATA_PROP = "data"
+DTBO_NODE_SUFFIX = ".dtbo"
+DTB_NODE_SUFFIX = ".dtb"
+DEFAULT_DTB_PROP = "default"
+
+SIGNATURE_PROPS_TO_DELETE = [
+    "hashed-nodes",
+    "hashed-strings",
+    "padding",
+    "sign-images",
+    "signer-name",
+    "signer-version",
+    "timestamp",
+    "value"
+]
+
+HASH_PROPS_TO_DELETE = [
+    "value"
+]
+
+DELETE_PROPS_ON_DTB_COPY = True
+
+
+class KernelFitException(Exception):
+    """Exception thrown by KernelFit class methods and internal helpers"""
+
+
+def _get_prop(fdt: libfdt.Fdt,
+              node_path: str, prop_name: str, defval: Any = None):
+    try:
+        node_off = fdt.path_offset(node_path)
+        value = fdt.getprop(node_off, prop_name)
+        return value
+    except libfdt.FdtException as exc:
+        if defval is not None:
+            log.debug("_get_prop: ignoring libfdt exception %s.", str(exc))
+            return defval
+        raise KernelFitException(
+            f"Could not read property {node_path}/{prop_name} from FDT.") \
+            from exc
+
+
+def _del_prop(fdt: libfdt.Fdt,
+              node_path: str, prop_name: str, ignore_errors: bool = True):
+    try:
+        fdt_size_org = fdt.totalsize()
+        node_off = fdt.path_offset(node_path)
+        fdt.delprop(node_off, prop_name, quiet=QUIET_NOTFOUND)
+        fdt.pack()
+        fdt_size_new = fdt.totalsize()
+        log.debug("_del_prop(%s/%s): size: %d -> %d",
+                  node_path, prop_name, fdt_size_org, fdt_size_new)
+    except libfdt.FdtException as exc:
+        if ignore_errors:
+            log.debug("_del_prop: ignoring libfdt exception %s.", str(exc))
+            return
+        raise KernelFitException(
+            f"Could not delete property {node_path}/{prop_name} from FDT.") \
+            from exc
+
+
+def _set_prop(fdt: libfdt.Fdt,
+              ptype: str, node_path: str, prop_name: str, val: Any):
+    fdt_size_org = fdt.totalsize()
+    # Make room from the property name and value:
+    fdt.resize(fdt.totalsize() + (len(prop_name) + len(val) + 64))
+
+    # Set property:
+    node_off = fdt.path_offset(node_path)
+
+    if ptype == "raw":
+        fdt.setprop(node_off, prop_name, val)
+    elif ptype == "str":
+        fdt.setprop_str(node_off, prop_name, val)
+    elif ptype == "u32":
+        fdt.setprop_u32(node_off, prop_name, val)
+    elif ptype == "u64":
+        fdt.setprop_u64(node_off, prop_name, val)
+    else:
+        raise KernelFitException(
+            f"Invalid ptype={ptype} passed when setting {node_path}/{prop_name}.")
+
+    # Determine final size:
+    fdt.pack()
+    fdt_size_new = fdt.totalsize()
+    log.debug("_set_prop(%s/%s): size: %d -> %d",
+              node_path, prop_name, fdt_size_org, fdt_size_new)
+
+
+def _node_present(fdt: libfdt.Fdt, *args: str):
+    node_path = "/".join(args)
+    try:
+        node_off = fdt.path_offset(node_path, quiet=QUIET_NOTFOUND)
+    except libfdt.FdtException as exc:
+        raise KernelFitException(
+            f"Error obtaining offset of '{node_path}' within FDT.") \
+            from exc
+    return node_off >= 0
+
+
+def _estimate_node_size(fdt: libfdt.Fdt, node_offset: int):
+    """Estimate the size in bytes of an FDT node.
+
+    Estimate the size in bytes of an FDT node, including its
+    properties and children recursively.
+    """
+    def _align4(num: int) -> int:
+        """Round up to next multiple of 4."""
+        return (num + 3) & ~3
+
+    size = 0
+
+    # Opening tag (FDT_BEGIN_NODE) + name + NUL + padding
+    name = fdt.get_name(node_offset)
+    size += 4  # token
+    size += _align4(len(name) + 1)  # name + '\0' + padding
+
+    # Properties
+    prop_off = fdt.first_property_offset(node_offset)
+    while prop_off >= 0:
+        prop = fdt.get_property_by_offset(prop_off)
+        size += 4  # token
+        size += 4  # len
+        size += 4  # nameoff
+        size += _align4(len(prop))  # property value + padding
+        prop_off = fdt.next_property_offset(prop_off, QUIET_NOTFOUND)
+
+    # Children
+    child_off = fdt.first_subnode(node_offset, QUIET_NOTFOUND)
+    while child_off >= 0:
+        size += _estimate_node_size(fdt, child_off)
+        child_off = fdt.next_subnode(child_off, QUIET_NOTFOUND)
+
+    # End node tag
+    size += 4
+
+    return size
+
+
+def _copy_node_across_fdts(fdt_src: libfdt.Fdt, src_off: int,
+                           fdt_dst: libfdt.Fdt, dst_parent_off: int,
+                           new_name: str = None):
+    if new_name is None:
+        new_name = fdt_src.get_name(src_off)
+    dst_off = fdt_dst.add_subnode(dst_parent_off, new_name)
+
+    # copy properties
+    poff = fdt_src.first_property_offset(src_off, QUIET_NOTFOUND)
+    while poff >= 0:
+        prop = fdt_src.get_property_by_offset(poff)
+        fdt_dst.setprop(dst_off, prop.name, bytes(prop))
+        poff = fdt_src.next_property_offset(poff, QUIET_NOTFOUND)
+
+    # copy children
+    child_off = fdt_src.first_subnode(src_off, QUIET_NOTFOUND)
+    while child_off >= 0:
+        _copy_node_across_fdts(fdt_src, child_off, fdt_dst, dst_off)
+        child_off = fdt_src.next_subnode(child_off, QUIET_NOTFOUND)
+
+    return dst_off
+
+
+def _copy_node(fdt: libfdt.Fdt, node_path: str, src_name: str, dst_name: str):
+    log.debug("_copy_node: node_path='%s', src_name='%s', dst_name='%s'",
+              node_path, src_name, dst_name)
+
+    fdt_size_org = fdt.totalsize()
+
+    # We cannot traverse the FDT and change it simultaneously (because the iterators are
+    # invalidated); to solve this we create an auxiliary FDT to hold the to-be-copied node
+    # temporarily.
+    src_off = fdt.path_offset(f"{node_path}/{src_name}")
+    fdt_aux_size = _estimate_node_size(fdt, src_off)
+    log.debug("_copy_node: fdt_aux_size=%d", fdt_aux_size)
+    # Since size is estimated add some extra.
+    fdt_aux_size += (fdt_aux_size // 10) * 12 + 256
+    fdt_aux = libfdt.Fdt.create_empty_tree(fdt_aux_size)
+    dst_aux_off = fdt.path_offset("/")
+    _copy_node_across_fdts(fdt, src_off, fdt_aux, dst_aux_off, new_name=dst_name)
+
+    # Ensure there's enough room for the new node on the destination FDT:
+    fdt.resize(fdt.totalsize() + fdt_aux_size)
+
+    # Copy the auxiliary FDT into a new node:
+    src_off = fdt_aux.path_offset(f"/{dst_name}")
+    dst_off = fdt.path_offset(node_path)
+    _copy_node_across_fdts(fdt_aux, src_off, fdt, dst_off)
+
+    # Determine final size:
+    fdt.pack()
+    fdt_size_new = fdt.totalsize()
+    log.debug("_copy_node: size: %d -> %d", fdt_size_org, fdt_size_new)
+
+
+def _remove_prefix(strval: str, prefix: str, force: bool = True):
+    if strval.startswith(prefix):
+        return strval[len(prefix):]
+    if force:
+        raise KernelFitException(
+            f"String '{strval}' does not have expected prefix '{prefix}'.")
+    return strval
+
+
+class KernelFit:
+    """Class for manipulating a kernel FIT image."""
+
+    def __init__(self, fhandle: BinaryIO = None, *,
+                 conf_prefix: str = "conf-",
+                 dtb_prefix: str = "", dtbimg_prefix: str = "fdt-"):
+        """
+        Class representing a FIT image with methods to manipulate it.
+
+        Args:
+            fhandle (BinaryIO): handle to FIT image file opened in binary mode.
+            conf_prefix (str): prefix used with configuration nodes.
+            dtb_prefix (str): first prefix added to DTB/DTBO files packed inside
+                the FIT image.
+            dtbimg_prefix (str): second prefix added to DTB/DTBO nodes in the
+                image section of the FIT image.
+
+        Example:
+            ```dts
+            images {
+                fdt-freescale_imx8mp-verdin-nonwifi-dahlia.dtb {
+                |__||________|
+                (3)    (2)
+                }
+            }
+            configurations {
+                default = "conf-freescale_imx8mp-verdin-nonwifi-dahlia.dtb";
+                conf-freescale_imx8mp-verdin-nonwifi-dahlia.dtb {
+                |___||________|
+                 (1)    (2)
+                }
+                ...
+            }
+            # Legend:
+            # (1): conf_prefix
+            # (2): dtb_prefix
+            # (3): dtbimg_prefix
+            ```
+        """
+        self.fdt = None
+        self.dtb_prefix = dtb_prefix
+        self.conf_prefix = conf_prefix
+        self.dtbimg_prefix = dtbimg_prefix
+        if fhandle:
+            self._read(fhandle)
+
+    def _read(self, fhandle: BinaryIO = None) -> None:
+        data = fhandle.read(MAX_FIT_IMAGE_SIZE+1)
+        if len(data) > MAX_FIT_IMAGE_SIZE:
+            raise KernelFitException(
+                f"FIT image size exceeds limit of {MAX_FIT_IMAGE_SIZE} bytes.")
+        self.fdt = libfdt.Fdt(data)
+        log.debug("Loaded FIT image; totalsize=%d.", self.fdt.totalsize())
+
+    def read(self, fhandle: BinaryIO = None) -> None:
+        """Load a FIT image from the given file handle.
+
+        Args:
+            fhandle (BinaryIO): handle to file opened for reading in binary mode.
+        """
+        self._read(fhandle)
+
+    def write(self, fhandle: BinaryIO = None) -> None:
+        """Write a FIT image into a file/stream.
+
+        Write the in-memory representation of a FIT image into a file.
+
+        Args:
+            fhandle (BinaryIO): handle to file opened for writing in binary mode.
+        """
+        fhandle.write(self.fdt.as_bytearray())
+
+    def _list_nodes(self, node_path: str, pattern: str) -> List[str]:
+        """List nodes whose name match a given pattern (regex)"""
+        pattern = re.compile(pattern)
+        nodeoff = self.fdt.path_offset(node_path)
+        subnodeoff = self.fdt.first_subnode(nodeoff)
+        nodes = []
+        while subnodeoff >= 0:
+            name = self.fdt.get_name(subnodeoff)
+            if pattern.fullmatch(name):
+                nodes.append(name)
+            subnodeoff = self.fdt.next_subnode(subnodeoff, QUIET_NOTFOUND)
+        return nodes
+
+    def _get_dtb_conf_pref_suf(self, overlay=False):
+        if overlay:
+            pref = self.conf_prefix
+            suf = DTBO_NODE_SUFFIX
+        else:
+            pref = f"{self.conf_prefix}{self.dtb_prefix}"
+            suf = DTB_NODE_SUFFIX
+        return (pref, suf)
+
+    def _get_dtb_image_pref_suf(self, overlay=False):
+        if overlay:
+            pref = self.dtbimg_prefix
+            suf = ".dtbo"
+        else:
+            pref = f"{self.dtbimg_prefix}{self.dtb_prefix}"
+            suf = ".dtb"
+        return (pref, suf)
+
+    # pylint: disable=no-self-use
+    def _get_std_node_path(self, ntype, *args):
+        if ntype == "conf":
+            node_path = "/".join([CONFIG_NODE_PATH, *args])
+        elif ntype == "image":
+            node_path = "/".join([IMAGES_NODE_PATH, *args])
+        else:
+            assert False, f"_get_std_node_path: bad parameter: ntype='{ntype}'"
+        return node_path
+    # pylint: enable=no-self-use
+
+    def _del_node(self, ntype: str, node_name: str) -> None:
+        node_path = self._get_std_node_path(ntype, node_name)
+        siz0 = self.fdt.totalsize()
+        self.fdt.del_node(self.fdt.path_offset(node_path), node_name)
+        self.fdt.pack()
+        siz1 = self.fdt.totalsize()
+        log.debug("Deleted node '%s' (size: %d -> %d).", node_path, siz0, siz1)
+
+    def get_dtb_entries_helper(self, pref: str, suf: str) -> List[Dict[str, str]]:
+        """Get DTB/DTBO configuration entries with a given prefix and suffix.
+
+        Returns:
+           list[dict]: A list of dictionaries, each with the fields:
+               - conf_name (str): Name of the configuration node.
+               - image_name (str): Name of the image referenced by the configuration
+                     node.
+               - file_name (str): This is expected to represent the name of the file
+                     that originated the entry in the FIT image.
+        """
+        sufre = suf.replace('.', '\\.')
+        names = self._list_nodes(CONFIG_NODE_PATH, f"{pref}.*{sufre}")
+        # Go over nodes extracting basic information for an entry:
+        nodes = []
+        for name in names:
+            conf_name = name
+            image_name = _get_prop(
+                self.fdt,
+                self._get_std_node_path("conf", conf_name), DTB_IMAGE_NAME_PROP)
+            image_name = image_name.as_str()
+            file_name = _remove_prefix(conf_name, pref)
+            entry = {
+                "conf_name": conf_name,
+                "image_name": image_name,
+                "file_name": file_name
+            }
+            nodes.append(entry)
+        return nodes
+
+    def get_dtb_list(self, overlay=False) -> List[Dict[str, str]]:
+        """Get DTB/DTBO configuration entries.
+
+        Args:
+            overlay (bool): False selects DTs while True selects DTBOs.
+        See Also:
+            get_dtb_entries_helper(): This generates the actual return value.
+        """
+        return self.get_dtb_entries_helper(*self._get_dtb_conf_pref_suf(overlay))
+
+    def _make_templ_name(self, ntype, overlay):
+        if ntype == "conf":
+            pref, suf = self._get_dtb_conf_pref_suf(overlay)
+        elif ntype == "image":
+            pref, suf = self._get_dtb_image_pref_suf(overlay)
+        else:
+            assert False, f"_make_templ_name: bad parameter: ntype='{ntype}'"
+        return f"_{pref}template{suf}"
+
+    def _dtb_templ_present(self, ntype, overlay):
+        chd_node_name = self._make_templ_name(ntype, overlay)
+        par_node_name = self._get_std_node_path(ntype)
+        res = _node_present(self.fdt, par_node_name, chd_node_name)
+        log.debug("Node '%s' was %s under '%s'.",
+                  chd_node_name, ["not found", "found"][res], par_node_name)
+        return res
+
+    def _copy_dtb(self,
+                  src_conf_name: str, src_image_name: str,
+                  dst_conf_name: str, dst_image_name: str):
+        # Copy configuration:
+        conf_node_path = self._get_std_node_path("conf")
+        _copy_node(self.fdt,
+                   node_path=conf_node_path,
+                   src_name=src_conf_name,
+                   dst_name=dst_conf_name)
+
+        # Copy image:
+        image_node_path = self._get_std_node_path("image")
+        _copy_node(self.fdt,
+                   node_path=image_node_path,
+                   src_name=src_image_name,
+                   dst_name=dst_image_name)
+
+        # Fix the template reference: config -> image:
+        image_name_prop_path = self._get_std_node_path("conf", dst_conf_name)
+        _set_prop(self.fdt, "str",
+                  image_name_prop_path, DTB_IMAGE_NAME_PROP, dst_image_name)
+
+        # Set the "data" prop to avoid taking up space:
+        image_data_prop_path = self._get_std_node_path("image", dst_image_name)
+        _set_prop(self.fdt, "str",
+                  image_data_prop_path, DTB_IMAGE_DATA_PROP, "empty")
+
+        if not DELETE_PROPS_ON_DTB_COPY:
+            return
+
+        # Clean configuration node:
+        for index in range(8):
+            par_node_path = self._get_std_node_path("conf", dst_conf_name)
+            chd_node_name = f"signature-{index}"
+            chd_node_path = self._get_std_node_path("conf", dst_conf_name, chd_node_name)
+            if _node_present(self.fdt, par_node_path, chd_node_name):
+                for prop_name in SIGNATURE_PROPS_TO_DELETE:
+                    _del_prop(self.fdt, chd_node_path, prop_name)
+
+        # Clean image node:
+        for index in range(8):
+            par_node_path = self._get_std_node_path("image", dst_image_name)
+            chd_node_name = f"hash-{index}"
+            chd_node_path = self._get_std_node_path("image", dst_image_name, chd_node_name)
+            if _node_present(self.fdt, par_node_path, chd_node_name):
+                for prop_name in HASH_PROPS_TO_DELETE:
+                    _del_prop(self.fdt, chd_node_path, prop_name)
+
+    def _make_dtb_templ(self, conf_name, overlay):
+        log.debug("Making template from '%s'.", conf_name)
+
+        src_conf_name = conf_name
+        dst_conf_name = self._make_templ_name("conf", overlay)
+
+        image_name_prop_path = self._get_std_node_path("conf", conf_name)
+        src_image_name = _get_prop(self.fdt, image_name_prop_path, DTB_IMAGE_NAME_PROP)
+        src_image_name = src_image_name.as_str()
+        dst_image_name = self._make_templ_name("image", overlay)
+
+        self._copy_dtb(src_conf_name, src_image_name,
+                       dst_conf_name, dst_image_name)
+
+    def del_dtb(self, file_name: str, *, overlay: bool = False) -> bool:
+        """Delete DTB/DTBO entry.
+
+        Delete both the configuration and image nodes related to a given
+        DTB/DTBO file name.
+
+        :param file_name: Name of the DTB/DTBO file associated with the entry;
+            this name will be prefixed appropriately to determine the actual
+            entry names (configuration/image) to be deleted.
+        """
+
+        # Check if the node corresponding to the file is present in the image.
+        dtb_list = self.get_dtb_list(overlay)
+        dtb_list_entry = None
+        for dle in dtb_list:
+            if file_name == dle["file_name"]:
+                dtb_list_entry = dle
+                break
+        if dtb_list_entry is None:
+            log.debug("Configuration node corresponding to '%s' was not "
+                      "found in the FIT image.", file_name)
+            return False
+
+        log.debug("Configuration node corresponding to '%s' was found "
+                  "in the FIT image.", file_name)
+
+        if self._dtb_templ_present("conf", overlay):
+            # If we already have a template it's okay to delete this node.
+            pass
+        elif len(dtb_list) > 1:
+            # If there are other nodes it's okay to delete this node.
+            pass
+        elif len(dtb_list) == 1:
+            # There's only one DTB/DTBO node left; copy it as a template.
+            self._make_dtb_templ(dtb_list_entry["conf_name"], overlay)
+
+        # Delete configuration and corresponding image.
+        self._del_node("image", dtb_list_entry["image_name"])
+        self._del_node("conf", dtb_list_entry["conf_name"])
+
+        return True
+
+    def add_dtb(self,
+                file_name: str,
+                data: Optional[Union[bytes, bytearray]] = None, *,
+                overlay=False, overwrite=True, set_default=True) -> None:
+        """Add DTB/DTBO entry to the FIT image.
+
+        A DTB/DTBO entry inside the FIT image is made up of two nodes:
+
+        One representing a configuration (which combines the kernel, ramdisk,
+        DTB to be selected by the bootloader) and another representing the image,
+        that is, the actual DTB data. Both of them are created by this method.
+
+        :param file_name: Name of the DTB/DTBO file associated with the entry;
+            this name will be prefixed appropriately to determine the actual
+            entry names (configuration/image) to be added.
+        :param data: Data of the DTB/DTBO; this is optional mainly to simplify
+            testing.
+        :param overlay: True to indicate the entries relate to an overlay (DTBO)
+            rather than a plain device-tree.
+        :param overwrite: Whether to overwrite existing entries with the same
+            name; if this is False and an entry exists, an exception will be
+            thrown.
+        :param set_default:" Whether to set the "default" configuration field
+            in the FIT image to the specified DTB.
+        """
+
+        # Check if the node corresponding to the file is present in the image.
+        dtb_list = self.get_dtb_list(overlay)
+        dtb_list_entry = None
+        for dle in dtb_list:
+            if file_name == dle["file_name"]:
+                dtb_list_entry = dle
+                break
+        if dtb_list_entry is not None:
+            if overwrite:
+                log.debug("Configuration node corresponding to '%s' was found "
+                          "in the FIT image and will be overwritten.", file_name)
+                self.del_dtb(file_name, overlay=overlay)
+            else:
+                raise KernelFitException(
+                    f"add_dtb: Configuration node corresponding to '{file_name}' "
+                    f"is already present in the FIT image.")
+
+        # Determine the template to use:
+        dtb_list = self.get_dtb_list(overlay)
+        if dtb_list:
+            # Use existing DTB/DTBO as template:
+            src_conf_name = dtb_list[0]["conf_name"]
+            src_image_name = dtb_list[0]["image_name"]
+        else:
+            # Use previously saved template:
+            src_conf_name = self._make_templ_name("conf", overlay)
+            src_image_name = self._make_templ_name("image", overlay)
+
+        conf_pref_suf = self._get_dtb_conf_pref_suf(overlay)
+        if not file_name.endswith(conf_pref_suf[1]):
+            raise KernelFitException(
+                f"add_dtb: Filename {file_name} does not end with "
+                f"'{conf_pref_suf[1]}'.")
+
+        image_pref_suf = self._get_dtb_image_pref_suf(overlay)
+
+        dst_conf_name = f"{conf_pref_suf[0]}{file_name}"
+        dst_image_name = f"{image_pref_suf[0]}{file_name}"
+
+        self._copy_dtb(src_conf_name, src_image_name,
+                       dst_conf_name, dst_image_name)
+
+        if data is not None:
+            _set_prop(self.fdt, "raw",
+                      self._get_std_node_path("image", dst_image_name),
+                      DTB_IMAGE_DATA_PROP, data)
+
+        if not overlay and set_default:
+            self.set_default_dtb(file_name)
+
+    def set_default_dtb(self, file_name: str, *, check=True) -> None:
+        """Set the default configuration field in the FIT."""
+
+        conf_pref_suf = self._get_dtb_conf_pref_suf()
+        if not file_name.endswith(conf_pref_suf[1]):
+            raise KernelFitException(
+                f"set_default_dtb: Filename {file_name} does not end with "
+                f"'{conf_pref_suf[1]}'.")
+
+        conf_name = f"{conf_pref_suf[0]}{file_name}"
+
+        if not _node_present(self.fdt, CONFIG_NODE_PATH, conf_name):
+            log.debug("Configuration node '%s' does not exist", conf_name)
+            if check:
+                raise KernelFitException(
+                    f"set_default_dtb: Configuration node '{conf_name}'"
+                    " does not exist.")
+
+        conf_node_path = self._get_std_node_path("conf")
+        _set_prop(self.fdt, "str",
+                  conf_node_path, DEFAULT_DTB_PROP, conf_name)
+
+
+# TODO: Consider creating unit tests.
+#
+# if __name__ == "__main__":
+#     logging.basicConfig(level=logging.DEBUG,
+#                         format='%(asctime)s: %(levelname)s: %(message)s')
+
+#     import os
+#     import sys
+#     # Directory containing a "vmlinuz.org" must be passed.
+#     os.chdir(sys.argv[1])
+
+#     FIT_FILE_IN = "vmlinuz.org"
+#     FIT_FILE_OUT = "vmlinuz-out"
+#     with open(FIT_FILE_IN, "rb") as _fhandle:
+#         fit = KernelFit(_fhandle, dtb_prefix="freescale_")
+
+#     print("\nDTBs:")
+#     dtb_nodes = fit.get_dtb_list()
+#     for node in dtb_nodes:
+#         print(node)
+
+#     print("\nDTBOs:")
+#     dto_nodes = fit.get_dtb_list(True)
+#     for node in dto_nodes:
+#         print(node)
+
+#     assert fit.del_dtb("conf-DUMMY1.dtb") is False
+
+#     # import random
+
+#     # Delete all nodes, except one.
+#     print("\nDeleting all DTBs but one.")
+#     dtb_nodes = fit.get_dtb_list()
+#     # random.shuffle(dtb_nodes)
+#     for node in dtb_nodes[:-1]:
+#         assert fit.del_dtb(node["file_name"]) is True
+#     print("DTBs (after deleting all but one):")
+#     dtb_nodes = fit.get_dtb_list()
+#     for node in dtb_nodes:
+#         print(node)
+
+#     # Delete all nodes, except one.
+#     print("\nDeleting all DTBOs but one.")
+#     dtbo_nodes = fit.get_dtb_list(True)
+#     # random.shuffle(dtbo_nodes)
+#     for node in dtbo_nodes[:-1]:
+#         assert fit.del_dtb(node["file_name"], overlay=True) is True
+#     print("DTBOs (after deleting all but one):")
+#     dtbo_nodes = fit.get_dtb_list(True)
+#     for node in dtbo_nodes:
+#         print(node)
+
+#     with open(f"{FIT_FILE_OUT}-onedtbdtbo.fit", "wb") as _fhandle:
+#         fit.write(_fhandle)
+
+#     # # Delete last DTB node.
+#     # print("\nDeleting last DTB node.")
+#     # dtb_nodes = fit.get_dtb_list()
+#     # assert len(dtb_nodes) == 1
+#     # assert fit.del_dtb(dtb_nodes[0]["file_name"]) == True
+#     # assert len(fit.get_dtb_list()) == 0
+#     # assert fit._dtb_templ_present("conf", False) == True
+
+#     # # Delete last DTBO node.
+#     # print("\nDeleting last DTBO node.")
+#     # dtb_nodes = fit.get_dtb_list(True)
+#     # assert len(dtb_nodes) == 1
+#     # assert fit.del_dtb(dtb_nodes[0]["file_name"], overlay=True) == True
+#     # assert len(fit.get_dtb_list(True)) == 0
+#     # assert fit._dtb_templ_present("conf", True) == True
+
+#     with open(f"{FIT_FILE_OUT}-nodtbdtbo.fit", "wb") as _fhandle:
+#         fit.write(_fhandle)
+
+#     fit.set_default_dtb("TEST_DTB.dtb", check=False)
+#     fit.add_dtb("TEST_DTB.dtb", overlay=False)
+#     fit.set_default_dtb("TEST_DTB.dtb")
+#     fit.add_dtb("TEST_DTBO.dtbo", overlay=True)
+
+#     fit.add_dtb("imx8mp-verdin-wifi-yavia.dtb", overlay=False)
+#     fit.add_dtb("verdin-imx8mp_spidev_overlay.dtbo", b"aaaabbbb", overlay=True)
+
+#     with open(f"{FIT_FILE_OUT}-dummyadds.fit", "wb") as _fhandle:
+#         fit.write(_fhandle)

--- a/tcbuilder/backend/secboot.py
+++ b/tcbuilder/backend/secboot.py
@@ -12,7 +12,7 @@ import subprocess
 from tcbuilder.backend.common import \
     (set_output_ownership, get_tar_compress_program_options, is_tcb_container_64bit,
      check_if_file_exists, find_kernel_in_sysroot, get_tezi_image_version, is_file_type_fit,
-     OSTREE_KERNEL_FILENAME)
+     get_kernel_dir, OSTREE_KERNEL_FILENAME)
 from tcbuilder.backend.ubootenv import \
     (get_env_filename, find_board)
 from tcbuilder.backend.platform import \
@@ -663,16 +663,9 @@ def prepare_kernel_for_ostree_commit(storage_dir, kernel_path, kernel_changes_di
     :param kernel_changes_dir: Path to directory with all kernel changes to be commited
     """
 
-    # get kernel path of current deployment inside sysroot
-    # in this path there's a directory named after the kernel version, so we need to get it first
-    src_sysroot_dir = os.path.join(storage_dir, "sysroot")
-    src_sysroot = ostree.load_sysroot(src_sysroot_dir)
-    csum, _ = ostree.get_deployment_info_from_sysroot(src_sysroot)
-
-    kernel_version = ostree.get_kernel_version(src_sysroot.repo(), csum)
-
     # create directory to store the finalized kernel
-    new_kernel_dst = os.path.join(kernel_changes_dir, "usr/lib/modules", kernel_version)
+    kernel_dir = get_kernel_dir(storage_dir)
+    new_kernel_dst = os.path.join(kernel_changes_dir, kernel_dir)
     os.makedirs(new_kernel_dst, exist_ok=True)
 
     shutil.copy2(kernel_path, os.path.join(new_kernel_dst, KERNEL_FIT_FILENAME))

--- a/tcbuilder/backend/secboot.py
+++ b/tcbuilder/backend/secboot.py
@@ -13,11 +13,8 @@ from tcbuilder.backend.common import \
     (set_output_ownership, get_tar_compress_program_options, is_tcb_container_64bit,
      check_if_file_exists, find_kernel_in_sysroot, get_tezi_image_version, is_file_type_fit,
      get_kernel_dir, OSTREE_KERNEL_FILENAME)
-from tcbuilder.backend.ubootenv import \
-    (get_env_filename, find_board)
-from tcbuilder.backend.platform import \
-    (FUSE_HARDWAREIDS)
-from tcbuilder.backend import ostree
+from tcbuilder.backend.ubootenv import (get_env_filename, find_board)
+from tcbuilder.backend.platform import (FUSE_HARDWAREIDS)
 
 from tcbuilder.errors import \
     (TorizonCoreBuilderError, InvalidArgumentError,
@@ -631,44 +628,34 @@ def sign_kernel(storage_dir, kernel_changes_dir, key_dir, key_algo, key_name):
 
     check_unpacked_tezi_kernel_signing_support(storage_dir)
 
-    # Check if secure boot work directory exists, and if so, remove it
-    # so we have a clean work directory
+    # Ensure we have a clean secure boot work directory.
     if os.path.isdir(SECURE_BOOT_WORKDIR):
         shutil.rmtree(SECURE_BOOT_WORKDIR)
-
     os.mkdir(SECURE_BOOT_WORKDIR)
 
-    # Copy kernel FIT in current image deployment to the work directory
-    kernel_deploy_path = find_kernel_in_sysroot(storage_dir)
-    kernel_fitimage_path = os.path.join(SECURE_BOOT_WORKDIR, KERNEL_FIT_FILENAME)
-    shutil.copy2(kernel_deploy_path, kernel_fitimage_path)
+    # Determine final destination of kernel binary.
+    kernel_dst_dir = os.path.join(kernel_changes_dir, get_kernel_dir(storage_dir))
+    kernel_dst_path = os.path.join(kernel_dst_dir, KERNEL_FIT_FILENAME)
 
-    # Before signing, update the expected key name of the fitImage.
-    update_fit_configs_keyname(kernel_fitimage_path, key_name)
+    # Select kernel and copy it to the work directory.
+    kernel_workdir_path = os.path.join(SECURE_BOOT_WORKDIR, KERNEL_FIT_FILENAME)
+    if os.path.exists(kernel_dst_path):
+        kernel_src_path = kernel_dst_path
+        log.debug("Taking customized kernel from '%s' for signing.", kernel_src_path)
+    else:
+        kernel_src_path = find_kernel_in_sysroot(storage_dir)
+        log.debug("Taking original kernel from '%s' for signing.", kernel_src_path)
+    shutil.copy2(kernel_src_path, kernel_workdir_path)
 
-    sign_with_mkimage(kernel_fitimage_path, key_dir, key_algo)
+    # Update key names and re-sign the kernel in the work directory.
+    update_fit_configs_keyname(kernel_workdir_path, key_name)
+    sign_with_mkimage(kernel_workdir_path, key_dir, key_algo)
 
-    prepare_kernel_for_ostree_commit(storage_dir, kernel_fitimage_path, kernel_changes_dir)
+    # Store finalized kernel into the "changes" directory.
+    os.makedirs(kernel_dst_dir, exist_ok=True)
+    shutil.copy2(kernel_workdir_path, kernel_dst_path)
 
     log.info("Kernel in unpacked Torizon OS image signed successfully!")
-
-
-def prepare_kernel_for_ostree_commit(storage_dir, kernel_path, kernel_changes_dir):
-    """
-    Setup a directory tree in kernel_changes_dir with the correct path to update the kernel
-    in an OSTree commit, and copy the file in kernel_path to it.
-
-    :param storage_dir: Path to storage directory, where the image was unpacked
-    :param kernel_path: Path of the kernel file to be committed
-    :param kernel_changes_dir: Path to directory with all kernel changes to be commited
-    """
-
-    # create directory to store the finalized kernel
-    kernel_dir = get_kernel_dir(storage_dir)
-    new_kernel_dst = os.path.join(kernel_changes_dir, kernel_dir)
-    os.makedirs(new_kernel_dst, exist_ok=True)
-
-    shutil.copy2(kernel_path, os.path.join(new_kernel_dst, KERNEL_FIT_FILENAME))
 
 
 def sign_bootloader_hab(storage_dir, kernel_key_dir,

--- a/tcbuilder/cli/dt.py
+++ b/tcbuilder/cli/dt.py
@@ -73,13 +73,56 @@ def do_dt_checkout(args):
             set_output_ownership("device-trees")
 
 
+def _abort_if_overlay(dts_path):
+    '''Abort operation if given device-tree source is an overlay'''
+    with open(dts_path, "r", encoding="utf-8") as fhandle:
+        file_string = fhandle.read()
+    match = re.search(r'^\s*/plugin/\s*;', file_string, re.MULTILINE)
+    if match:
+        raise InvalidArgumentError(
+            f"error: {dts_path} is a device tree overlay and cannot be applied")
+
+
+def _deploy_dtb(*, dtb_src_path, dtb_name, changes_dir, storage_dir):
+    dtb_target_dir = os.path.join(
+        changes_dir, dt.get_dtb_kernel_subdir(storage_dir))
+    os.makedirs(dtb_target_dir, exist_ok=True)
+    dtb_tgt_path = os.path.join(dtb_target_dir, dtb_name)
+    shutil.move(dtb_src_path, dtb_tgt_path)
+
+
+def _deploy_updated_uenv_txt(*, fdtfile, changes_dir, storage_dir):
+    # Deploy the enablement of the device tree blob.
+    uenv_target_dir = os.path.join(changes_dir, "usr", "lib", "ostree-boot")
+    uenv_target_path = os.path.join(uenv_target_dir, "uEnv.txt")
+    os.makedirs(uenv_target_dir, exist_ok=True)
+    with open(uenv_target_path, "w", encoding="utf-8") as fhandle:
+        fhandle.write(f"fdtfile={fdtfile}\n")
+    subprocess.check_call(
+        "set -o pipefail && "
+        f"ostree --repo={shlex.quote(storage_dir)}/ostree-archive "
+        f"cat base /usr/lib/ostree-boot/uEnv.txt | sed /^fdtfile=/d "
+        f">>{shlex.quote(uenv_target_path)}",
+        shell=True)
+
+
+def _deploy_empty_overlays_txt(*, changes_dir, storage_dir):
+    # Deploy an empty overlays config file, so any overlays from the base image are disabled.
+    log.info("warning: removing currently applied device tree overlays")
+    dtb_target_dir = os.path.join(changes_dir, dt.get_dtb_kernel_subdir(storage_dir))
+    overlays_txt_path = os.path.join(dtb_target_dir, "overlays.txt")
+    with open(overlays_txt_path, "w", encoding="utf-8") as fhandle:
+        fhandle.write("fdt_overlays=\n")
+
+
 def dt_apply(dts_path, storage_dir, include_dirs=None):
     '''Perform the work of the 'dt apply' command.'''
 
     images_unpack_executed(storage_dir)
     if unpacked_image_type(storage_dir) == "raw":
-        raise InvalidDataError("Device tree customization is not supported for WIC/raw images. "
-                               "Aborting.")
+        raise InvalidDataError(
+            "Device tree customization is not supported for WIC/raw images. "
+            "Aborting.")
 
     unpacked_kernel_path = find_kernel_in_sysroot(storage_dir)
     if is_file_type_fit(unpacked_kernel_path):
@@ -93,51 +136,37 @@ def dt_apply(dts_path, storage_dir, include_dirs=None):
 
     log.debug(f"dt_apply: include directories: {','.join(include_dirs)}")
 
-    # Check if the device tree blob passed is an overlay
-    with open(dts_path, 'r') as file:
-        file_string = file.read()
-    match = re.search(r'^\s*/plugin/\s*;', file_string, re.MULTILINE)
-    if match:
-        raise InvalidArgumentError(
-            f"error: {dts_path} is a device tree overlay and cannot be applied")
+    # Ensure user is not trying to compile an overlay.
+    _abort_if_overlay(dts_path)
 
-    # Compile the device tree.
-    with tempfile.NamedTemporaryFile(delete=False) as file:
-        dtb_tmp_path = file.name
+    # Compile the device tree into a temporary dtb.
+    dtb_tmp_path = tempfile.mktemp(suffix=".dtb")
     if not dt.build_dts(dts_path, include_dirs, dtb_tmp_path):
         log.error(f"error: cannot apply {dts_path}.")
         sys.exit(1)
 
-    # Deploy the device tree blob.
+    # Compute the final/deployed name of the DTB.
+    dtb_name = os.path.splitext(os.path.basename(dts_path))[0] + ".dtb"
+
+    # Determine the changes directory for DTB-related changes.
     dt_changes_dir = dt.get_dt_changes_dir(storage_dir)
+
     # Erase device tree and overlays of the current session.
     shutil.rmtree(dt_changes_dir, ignore_errors=True)
-    dtb_target_dir = os.path.join(dt_changes_dir, dt.get_dtb_kernel_subdir(storage_dir))
-    os.makedirs(dtb_target_dir, exist_ok=True)
-    dtb_target_basename = os.path.splitext(os.path.basename(dts_path))[0] + ".dtb"
-    dtb_target_path = os.path.join(dtb_target_dir, dtb_target_basename)
-    shutil.move(dtb_tmp_path, dtb_target_path)
 
-    # Deploy the enablement of the device tree blob.
-    uenv_target_dir = os.path.join(dt_changes_dir, "usr", "lib", "ostree-boot")
-    os.makedirs(uenv_target_dir, exist_ok=True)
-    uenv_target_path = os.path.join(uenv_target_dir, "uEnv.txt")
-    with open(uenv_target_path, "w") as file:
-        file.write(f"fdtfile={dtb_target_basename}\n")
-    subprocess.check_call(
-        "set -o pipefail && "
-        f"ostree --repo={shlex.quote(storage_dir)}/ostree-archive "
-        f"cat base /usr/lib/ostree-boot/uEnv.txt | sed /^fdtfile=/d "
-        f">>{shlex.quote(uenv_target_path)}",
-        shell=True)
+    _deploy_dtb(
+        dtb_src_path=dtb_tmp_path, dtb_name=dtb_name,
+        changes_dir=dt_changes_dir, storage_dir=storage_dir)
 
-    # Deploy an empty overlays config file, so any overlays from the base image are disabled.
-    log.info("warning: removing currently applied device tree overlays")
-    with open(os.path.join(dtb_target_dir, "overlays.txt"), "w") as file:
-        file.write("fdt_overlays=\n")
+    _deploy_updated_uenv_txt(
+        fdtfile=dtb_name,
+        changes_dir=dt_changes_dir, storage_dir=storage_dir)
+
+    _deploy_empty_overlays_txt(
+        changes_dir=dt_changes_dir, storage_dir=storage_dir)
 
     # All set.
-    log.info(f"Device tree {dtb_target_basename} successfully applied.")
+    log.info(f"Device tree {dtb_name} successfully applied.")
 
 
 def do_dt_apply(args):

--- a/tcbuilder/cli/dt.py
+++ b/tcbuilder/cli/dt.py
@@ -4,27 +4,27 @@ CLI for the DT (device-tree) command.
 
 import logging
 import os
-import shlex
+import re
 import shutil
-import subprocess
 import sys
 import tempfile
 import traceback
-import re
 
-from tcbuilder.backend import dt
-from tcbuilder.backend.common import (checkout_dt_git_repo,
-                                      set_output_ownership,
-                                      images_unpack_executed,
-                                      update_dt_git_repo,
-                                      unpacked_image_type,
-                                      find_kernel_in_sysroot,
-                                      is_file_type_fit)
-from tcbuilder.errors import (
-    TorizonCoreBuilderError, InvalidArgumentError, InvalidStateError, InvalidDataError,
-    FeatureNotImplementedError)
+from tcbuilder.backend import dt as dt_be
+from tcbuilder.backend import kernel as kernel_be
+from tcbuilder.backend.common import \
+    (checkout_dt_git_repo, set_output_ownership, images_unpack_executed, update_dt_git_repo,
+     unpacked_image_type, find_kernel_in_sysroot, get_kernel_dir, is_file_type_fit,
+     OSTREE_KERNEL_FILENAME)
+from tcbuilder.backend.kernelfit import KernelFit
+from tcbuilder.errors import \
+    (TorizonCoreBuilderError, InvalidArgumentError, InvalidStateError, InvalidDataError)
 
 log = logging.getLogger("torizon." + __name__)
+
+KERNEL_FIT_FILENAME = OSTREE_KERNEL_FILENAME
+MAX_DTB_FILE_SIZE = 1*1024*1024
+DTB_PREFIX_RE = re.compile(r'bootm[^#]*#conf-([^$]*)\$')
 
 
 def do_dt_status(args):
@@ -34,12 +34,7 @@ def do_dt_status(args):
     if unpacked_image_type(args.storage_directory) == "raw":
         raise InvalidDataError("Command not supported for WIC/raw images. Aborting.")
 
-    unpacked_kernel_path = find_kernel_in_sysroot(args.storage_directory)
-    if is_file_type_fit(unpacked_kernel_path):
-        raise FeatureNotImplementedError("Command not supported for kernel in FIT format. "
-                                         "Aborting.")
-
-    dtb_basename = dt.get_current_dtb_basename(args.storage_directory)
+    dtb_basename = dt_be.get_current_dtb_basename(args.storage_directory)
     if not dtb_basename:
         log.error("error: cannot identify the enabled device tree in the image "
                   "because it is dynamically selected at runtime.")
@@ -83,17 +78,75 @@ def _abort_if_overlay(dts_path):
             f"error: {dts_path} is a device tree overlay and cannot be applied")
 
 
-def _deploy_dtb(*, dtb_src_path, dtb_name, changes_dir, storage_dir):
+def _deploy_dtb_nonfit(*, dtb_src_path, dtb_name, changes_dir, storage_dir):
+    '''Deploy the given DTB into a changes directory (non-FIT kernel case)'''
+
     dtb_target_dir = os.path.join(
-        changes_dir, dt.get_dtb_kernel_subdir(storage_dir))
+        changes_dir, dt_be.get_dtb_kernel_subdir(storage_dir))
     os.makedirs(dtb_target_dir, exist_ok=True)
     dtb_tgt_path = os.path.join(dtb_target_dir, dtb_name)
     shutil.move(dtb_src_path, dtb_tgt_path)
 
 
+def _get_dtb_prefix(storage_dir, defval=None):
+    uenv_path = dt_be.get_current_uenv_txt_path(storage_dir)
+    with open(uenv_path, "r", encoding="utf-8") as fhandle:
+        lines = fhandle.readlines()
+    res = None
+    for line in lines:
+        match = DTB_PREFIX_RE.search(line)
+        if match:
+            res = match.group(1)
+            break
+    if res is None and defval is None:
+        raise InvalidDataError(
+            "Cannot determine DTB prefix used inside FIT image from uEnv.txt")
+    if res is None:
+        res = defval
+    log.debug("Determined DTB prefix from uEnv.txt: '%s'", res)
+    return res
+
+
+def _deploy_dtb_fit(*, dtb_src_path, dtb_name, changes_dir, storage_dir):
+    '''Deploy the given DTB into a changes directory (FIT kernel case)'''
+
+    # Copy kernel to changes directory when needed:
+    kernel_tgt_dir = os.path.join(changes_dir, get_kernel_dir(storage_dir))
+    kernel_tgt_path = os.path.join(kernel_tgt_dir, KERNEL_FIT_FILENAME)
+    if not os.path.exists(kernel_tgt_path):
+        log.debug("Kernel does not exist in '%s'", kernel_tgt_path)
+        os.makedirs(kernel_tgt_dir, exist_ok=True)
+        kernel_src_path = find_kernel_in_sysroot(storage_dir)
+        log.debug("Copying '%s' -> '%s'", kernel_src_path, kernel_tgt_path)
+        shutil.copy2(kernel_src_path, kernel_tgt_path)
+    else:
+        log.debug("Kernel already exists in '%s'", kernel_tgt_path)
+
+    dtb_prefix = _get_dtb_prefix(storage_dir)
+
+    # Load kernel FIT into memory:
+    with open(kernel_tgt_path, "rb") as fhandle:
+        fit = KernelFit(fhandle, dtb_prefix=dtb_prefix)
+
+    # Load DTB into memory:
+    with open(dtb_src_path, "rb") as fhandle:
+        dtb_data = fhandle.read(MAX_DTB_FILE_SIZE+1)
+        if len(dtb_data) > MAX_DTB_FILE_SIZE:
+            raise InvalidDataError(
+                f"DTB file size exceeds limit of {MAX_DTB_FILE_SIZE} bytes.")
+
+    # Store into FIT.
+    log.debug("Storing DTB with %d bytes in size into FIT image.", len(dtb_data))
+    fit.add_dtb(dtb_name, dtb_data)
+
+    # Update kernel FIT image on disk.
+    with open(kernel_tgt_path, "wb") as fhandle:
+        fit.write(fhandle)
+
+
 def _deploy_updated_uenv_txt(*, fdtfile, changes_dir, storage_dir):
     # Load original file:
-    uenv_src_path = dt.get_current_uenv_txt_path(storage_dir)
+    uenv_src_path = dt_be.get_current_uenv_txt_path(storage_dir)
     with open(uenv_src_path, "r", encoding="utf-8") as fhandle:
         lines = fhandle.readlines()
     # Drop lines assigning to the desired variable:
@@ -115,8 +168,9 @@ def _deploy_updated_uenv_txt(*, fdtfile, changes_dir, storage_dir):
 def _deploy_empty_overlays_txt(*, changes_dir, storage_dir):
     # Deploy an empty overlays config file, so any overlays from the base image are disabled.
     log.info("warning: removing currently applied device tree overlays")
-    dtb_target_dir = os.path.join(changes_dir, dt.get_dtb_kernel_subdir(storage_dir))
-    overlays_txt_path = os.path.join(dtb_target_dir, "overlays.txt")
+    overlays_txt_dir = os.path.join(changes_dir, dt_be.get_dtb_kernel_subdir(storage_dir))
+    overlays_txt_path = os.path.join(overlays_txt_dir, "overlays.txt")
+    os.makedirs(overlays_txt_dir, exist_ok=True)
     with open(overlays_txt_path, "w", encoding="utf-8") as fhandle:
         fhandle.write("fdt_overlays=\n")
 
@@ -131,9 +185,8 @@ def dt_apply(dts_path, storage_dir, include_dirs=None):
             "Aborting.")
 
     unpacked_kernel_path = find_kernel_in_sysroot(storage_dir)
-    if is_file_type_fit(unpacked_kernel_path):
-        raise FeatureNotImplementedError("Device tree customization is not supported for kernel in "
-                                         "FIT format. Aborting.")
+    kernel_is_fit = is_file_type_fit(unpacked_kernel_path)
+    log.debug(f"dt_apply: kernel_is_fit={kernel_is_fit}")
 
     # Sanity check parameters.
     assert dts_path, "panic: missing device tree source parameter"
@@ -147,29 +200,36 @@ def dt_apply(dts_path, storage_dir, include_dirs=None):
 
     # Compile the device tree into a temporary dtb.
     dtb_tmp_path = tempfile.mktemp(suffix=".dtb")
-    if not dt.build_dts(dts_path, include_dirs, dtb_tmp_path):
+    if not dt_be.build_dts(dts_path, include_dirs, dtb_tmp_path):
         log.error(f"error: cannot apply {dts_path}.")
         sys.exit(1)
 
     # Compute the final/deployed name of the DTB.
     dtb_name = os.path.splitext(os.path.basename(dts_path))[0] + ".dtb"
 
-    # Determine the changes directory for DTB-related changes.
-    dt_changes_dir = dt.get_dt_changes_dir(storage_dir)
-
-    # Erase device tree and overlays of the current session.
-    shutil.rmtree(dt_changes_dir, ignore_errors=True)
-
-    _deploy_dtb(
-        dtb_src_path=dtb_tmp_path, dtb_name=dtb_name,
-        changes_dir=dt_changes_dir, storage_dir=storage_dir)
+    if kernel_is_fit:
+        # FIT case: all changes go to the kernel-changes directory.
+        changes_dir = kernel_be.get_kernel_changes_dir(storage_dir)
+        # Deploy the DTB into the kernel FIT container:
+        _deploy_dtb_fit(
+            dtb_src_path=dtb_tmp_path, dtb_name=dtb_name,
+            changes_dir=changes_dir, storage_dir=storage_dir)
+    else:
+        # non-FIT case: changes go to the DT-changes directory.
+        changes_dir = dt_be.get_dt_changes_dir(storage_dir)
+        # Erase device tree and overlays of the current session.
+        shutil.rmtree(changes_dir, ignore_errors=True)
+        # Deploy the DTB into the appropriate changes directory:
+        _deploy_dtb_nonfit(
+            dtb_src_path=dtb_tmp_path, dtb_name=dtb_name,
+            changes_dir=changes_dir, storage_dir=storage_dir)
 
     _deploy_updated_uenv_txt(
         fdtfile=dtb_name,
-        changes_dir=dt_changes_dir, storage_dir=storage_dir)
+        changes_dir=changes_dir, storage_dir=storage_dir)
 
     _deploy_empty_overlays_txt(
-        changes_dir=dt_changes_dir, storage_dir=storage_dir)
+        changes_dir=changes_dir, storage_dir=storage_dir)
 
     # All set.
     log.info(f"Device tree {dtb_name} successfully applied.")

--- a/tcbuilder/cli/dt.py
+++ b/tcbuilder/cli/dt.py
@@ -92,18 +92,24 @@ def _deploy_dtb(*, dtb_src_path, dtb_name, changes_dir, storage_dir):
 
 
 def _deploy_updated_uenv_txt(*, fdtfile, changes_dir, storage_dir):
-    # Deploy the enablement of the device tree blob.
+    # Load original file:
+    uenv_src_path = dt.get_current_uenv_txt_path(storage_dir)
+    with open(uenv_src_path, "r", encoding="utf-8") as fhandle:
+        lines = fhandle.readlines()
+    # Drop lines assigning to the desired variable:
+    var_name = "fdtfile"
+    new_lines = []
+    for line in lines:
+        if not line.startswith(f"{var_name}="):
+            new_lines.append(line)
+    # Add assignment as the first line.
+    new_lines.insert(0, f"{var_name}={fdtfile}\n")
+    # Save modified version of the file:
     uenv_target_dir = os.path.join(changes_dir, "usr", "lib", "ostree-boot")
     uenv_target_path = os.path.join(uenv_target_dir, "uEnv.txt")
     os.makedirs(uenv_target_dir, exist_ok=True)
     with open(uenv_target_path, "w", encoding="utf-8") as fhandle:
-        fhandle.write(f"fdtfile={fdtfile}\n")
-    subprocess.check_call(
-        "set -o pipefail && "
-        f"ostree --repo={shlex.quote(storage_dir)}/ostree-archive "
-        f"cat base /usr/lib/ostree-boot/uEnv.txt | sed /^fdtfile=/d "
-        f">>{shlex.quote(uenv_target_path)}",
-        shell=True)
+        fhandle.writelines(new_lines)
 
 
 def _deploy_empty_overlays_txt(*, changes_dir, storage_dir):

--- a/tests/integration/samples/dts/small-nodev.dts
+++ b/tests/integration/samples/dts/small-nodev.dts
@@ -1,0 +1,10 @@
+/*
+ * Small Device Tree / not device specific
+ */
+
+/dts-v1/;
+
+/ {
+	model = "Small Device Tree / not device specific";
+	compatible = "unknown,device";
+};

--- a/tests/integration/testcases/dt.bats
+++ b/tests/integration/testcases/dt.bats
@@ -97,8 +97,6 @@ load 'lib/common.bash'
 }
 
 @test "dt: check currently enabled device tree" {
-    requires-non-fit-kernel
-
     torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
 
     run torizoncore-builder dt status
@@ -116,35 +114,51 @@ load 'lib/common.bash'
 }
 
 @test "dt: apply device tree in the image" {
-    requires-non-fit-kernel
-
     torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
     torizoncore-builder-shell "rm -rf device-trees"
 
-    run torizoncore-builder dt checkout --update
-    if is-major-version-greater-than-5; then
-        assert_failure
-        assert_output --partial "dt checkout command is not supported"
-        return 0
-    fi
-    assert_success
-    refute_output --regexp "'device-trees' (is already up to date|successfully updated)"
+    local exp_dts_path="samples/dts/small-nodev.dts"
+    local exp_dts_name=${exp_dts_path##*/}
+    local exp_dtb_name=${exp_dts_name%%.*}.dtb
 
-    run torizoncore-builder-shell "ls /storage/sysroot/boot/ostree/torizon-*/dtb/*.dtb"
-    local DTB=$(basename "${lines[0]}")
-    local DTS="${DTB%.*}.dts"
-
-    run find device-trees/ -name $DTS
-    assert_success
-    local DTS_LOCATION=$output
-
-    run torizoncore-builder dt apply $DTS_LOCATION
+    run torizoncore-builder dt apply "${exp_dts_path}"
     assert_success
     assert_output --regexp "Device tree.*successfully applied"
 
     run torizoncore-builder dt status
     assert_success
     assert_output --partial "$DTB"
+
+    if [ "${IS_DEFAULT_TEZI_IMAGE_FIT}" = "1" ]; then
+        echo "Checking existence of device-tree inside FIT image."
+        run torizoncore-builder-shell \
+            "VMLINUZ=\$(find /storage/kernel -name vmlinuz); echo \${VMLINUZ}; test -n \"\${VMLINUZ}\""
+        assert_success
+        local vmlinuz_path="${output}"
+
+        echo "Checking existence of a new configuration node."
+        run torizoncore-builder-shell \
+            "fdtget ${vmlinuz_path} -l /configurations | grep -F '${exp_dtb_name}'"
+        assert_success
+        local config_node="${output}"
+
+        echo "Checking existence of a new image node."
+        run torizoncore-builder-shell \
+            "fdtget ${vmlinuz_path} -l /images | grep -F '${exp_dtb_name}'"
+        assert_success
+        local image_node="${output}"
+
+        echo "Ensuring config node points to image node."
+        run torizoncore-builder-shell \
+            "test \"\$(fdtget ${vmlinuz_path} /configurations/${config_node} fdt)\" == \"${image_node}\""
+        assert_success
+
+    else
+        echo "Checking existence of device-tree file in kernel dtb directory."
+        run torizoncore-builder-shell \
+            "DTB=\$(find /storage/dt/ -wholename '*/usr/lib/modules/*/dtb/${exp_dtb_name}'); echo \${DTB}; test -n \"\${DTB}\""
+        assert_success
+    fi
 }
 
 # bats test_tags=requires-device
@@ -205,17 +219,4 @@ load 'lib/common.bash'
     run device-shell "cat /proc/device-tree/model"
     assert_success
     assert_output --partial "$MODEL"
-}
-
-@test "dt: throw error on kernel FIT format" {
-    requires-fit-kernel
-
-    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
-    run torizoncore-builder dt status
-    assert_failure
-    assert_output --partial "not supported for kernel in FIT format"
-
-    run torizoncore-builder dt apply foo.dtb
-    assert_failure
-    assert_output --partial "not supported for kernel in FIT format"
 }


### PR DESCRIPTION
Summary:

- Make some refactoring to allow reuse in the code being introduced.
- Introduce the infrastructure required for querying and manipulating a kernel FIT image.
- Use that infrastructure to implement the DT (Device Tree) operations (`dt status`, `dt apply`.
- Adapt the secboot sign-kernel command to allow re-signing a kernel image whose DT has been modified.
- Modify tests to perform more detailed checks on the DT application.

Please check the individual commit messages for details.
