### PR TITLE
Introduce support for kernel bootargs customization (set, get, clear) when the kernel is in the FIT format

### DIFF
--- a/requirements_debian.txt
+++ b/requirements_debian.txt
@@ -6,4 +6,4 @@ pyyaml==5.3.1
 requests-oauthlib==1.3.0
 debugpy==1.8.7
 fabric==3.2.2
-pylibfdt==1.7.2
+pylibfdt==1.7.2.post1

--- a/tcbuilder/backend/common.py
+++ b/tcbuilder/backend/common.py
@@ -754,6 +754,16 @@ def unpacked_image_type(storage_dir):
     return "raw"
 
 
+def fail_on_raw_image(storage_dir, message):
+    """Throw error if the unpacked image is of type WIC/raw.
+
+    :param storage_dir: Path to storage directory.
+    :param message: Message string for exception to be thrown.
+    """
+    if unpacked_image_type(storage_dir) == "raw":
+        raise InvalidDataError(message)
+
+
 def get_own_network():
     """ Determine Network mode of current tcb container
     Given the host `docker_client`. This function returns

--- a/tcbuilder/backend/dt.py
+++ b/tcbuilder/backend/dt.py
@@ -18,12 +18,15 @@ log = logging.getLogger("torizon." + __name__)
 
 DTB_PREFIX_RE = re.compile(r'bootm[^#]*#conf-([^$]*)\$')
 
+BACKSLASH_SPC_RE = re.compile(r"\\\s*$")
+
 
 def get_dt_changes_dir(storage_dir):
     """Returns the directory that contains external device tree related changes."""
     return os.path.join(storage_dir, "dt")
 
 
+# TODO: Consider moving the various "uenv" functions to a separate module (other than common).
 def get_current_uenv_txt_path(storage_dir):
     """Get the path to the currently applied uEnv.txt, the bootloader environment file."""
 
@@ -55,6 +58,118 @@ def get_current_uenv_txt_path(storage_dir):
     log.debug(f"Found uEnv.txt in deployment: '{dpath}'")
 
     return dpath
+
+
+def set_uenv_txt_variable(var_name, var_value, *,
+                          changes_dir, storage_dir, append=False):
+    """Set/clear a variable in uEnv.txt storing the modified file in the changes directory.
+
+    :param var_name: Name of the variable.
+    :param var_value: Value of the variable; if None is passed, the variable
+        will be cleared (removed from the file).
+    :param changes_dir: Path to changes directory.
+    :param storage_dir: Path to storage directory.
+    :param append: If False (default), the new variable assignment is added at
+        the beginning of the uEnv.txt file; otherwise, it's added at its end.
+    :returns: True if the variable existed in uEnv.txt; False, otherwise."""
+
+    # Load original file:
+    uenv_src_path = get_current_uenv_txt_path(storage_dir)
+    with open(uenv_src_path, "r", encoding="utf-8") as fhandle:
+        lines = fhandle.readlines()
+
+    # Status indicates that the variable was set before.
+    status = False
+
+    # Drop lines assigning to the desired variable (lines may be continued by
+    # a backslash at the end):
+    ign_cont = False
+    new_lines = []
+    for line in lines:
+        if ign_cont:
+            if not BACKSLASH_SPC_RE.search(line):
+                ign_cont = False
+        elif line.startswith(f"{var_name}="):
+            status = True
+            if BACKSLASH_SPC_RE.search(line):
+                ign_cont = True
+        else:
+            new_lines.append(line)
+
+    if var_value is None:
+        # Variable is being deleted.
+        pass
+    elif append:
+        # Add assignment as the last line.
+        assgn_str = f"{var_name}={var_value}\n"
+        new_lines.append(assgn_str)
+    else:
+        # Add assignment as the first line.
+        assgn_str = f"{var_name}={var_value}\n"
+        new_lines.insert(0, assgn_str)
+
+    # Save modified version of the file:
+    uenv_target_dir = os.path.join(changes_dir, "usr", "lib", "ostree-boot")
+    uenv_target_path = os.path.join(uenv_target_dir, "uEnv.txt")
+    os.makedirs(uenv_target_dir, exist_ok=True)
+    with open(uenv_target_path, "w", encoding="utf-8") as fhandle:
+        fhandle.writelines(new_lines)
+
+    return status
+
+
+def get_uenv_txt_variable(var_name, *, storage_dir, drop_cont=False):
+    """Get a variable from the current uEnv.txt.
+
+    By default, if the variable setting in uEnv.txt was split into multiple-lines
+    in the source file, the returned value will be a string with embedded new-line
+    characters including the backslash at end of each line indicating the line
+    continuation. This behavior can be changed by 'drop_cont'.
+
+    :param var_name: Name of the variable.
+    :param storage_dir: Path to the storage directory.
+    :param drop_cont: Drop the continuaton string at the end of the lines
+        effectively joining all lines together.
+
+    """
+
+    # Load original file:
+    uenv_src_path = get_current_uenv_txt_path(storage_dir)
+    with open(uenv_src_path, "r", encoding="utf-8") as fhandle:
+        lines = fhandle.readlines()
+
+    assgn_str = f"{var_name}="
+    var_value = None
+
+    # Find the assignment (handling the multi-line case); in case of multiple
+    # assignments get the value of the last one:
+    cont = False
+    for line in lines:
+        if cont:
+            var_value.append(line)
+            if not BACKSLASH_SPC_RE.search(line):
+                cont = False
+        elif line.startswith(assgn_str):
+            var_value = []
+            var_value.append(line[len(assgn_str):])
+            if BACKSLASH_SPC_RE.search(line):
+                cont = True
+
+    # Drop the continuation string from all intermediate lines:
+    if var_value and drop_cont:
+        for _idx, _val in enumerate(var_value[:-1]):
+            var_value[_idx] = _val[:_val.rindex("\\")]
+
+    # Drop the newline character of the last line:
+    if var_value:
+        if "\n" in var_value[-1]:
+            _val = var_value[-1]
+            var_value[-1] = _val[:_val.rindex("\n")]
+
+    if var_value is not None:
+        var_value = "".join(var_value)
+
+    return var_value
 
 
 def get_uboot_initial_env_path(storage_dir):

--- a/tcbuilder/backend/kernel.py
+++ b/tcbuilder/backend/kernel.py
@@ -10,7 +10,7 @@ import shutil
 import logging
 import urllib.request
 
-from tcbuilder.backend import ostree
+from tcbuilder.backend import ostree, dt
 from tcbuilder.backend.common import \
     (get_tar_compress_program_options, progress, set_output_ownership)
 from tcbuilder.errors import \
@@ -27,6 +27,14 @@ IMAGE_MAJOR_TO_GCC_MAP = {
 OSTREE_KERNEL_FILENAME = "vmlinuz"
 OSTREE_KERNEL_DEPLOY_PATH = "ostree/deploy/torizon/deploy/{csum}/usr/lib/modules/{kver}/"
 KERNEL_FIT_FILENAME = OSTREE_KERNEL_FILENAME
+
+# Name of the "function" in uEnv.txt responsible for handling boot arguments
+# passed by means of an overlay.
+SET_BOOTARGS_CUSTOM_RE = r'^\s*set_bootargs_custom='
+
+# Name of the "function" in uEnv.txt responsible for handling boot arguments
+# passed as variables in uEnv.txt.
+SET_BOOTARGS_TORIZON_RE = r'^\s*set_bootargs_torizon='
 
 
 def get_kernel_changes_dir(storage_dir):
@@ -235,7 +243,9 @@ def find_kernel_in_sysroot(storage_dir):
     kernel_path = OSTREE_KERNEL_DEPLOY_PATH.format(csum=csum, kver=kernel_version)
     kernel_path = os.path.join(sysroot_path, kernel_path, OSTREE_KERNEL_FILENAME)
 
-    if not os.path.isfile(kernel_path):
+    if os.path.isfile(kernel_path):
+        log.debug("Kernel found at '%s'", kernel_path)
+    else:
         raise PathNotExistError("Kernel not found in unpacked rootfs. Aborting.")
 
     return kernel_path
@@ -261,7 +271,7 @@ def find_kernel_in_changes_dir(changes_dir, storage_dir, basename=None):
     kernel_subdir = get_kernel_subdir(storage_dir)
     kernel_src_dir = os.path.join(changes_dir, kernel_subdir)
     kernel_src_path = os.path.join(kernel_src_dir, basename or OSTREE_KERNEL_FILENAME)
-    if os.path.exists(kernel_src_path):
+    if os.path.isfile(kernel_src_path):
         log.debug("Kernel found at '%s'", kernel_src_path)
     else:
         log.debug("Kernel not found at '%s'", kernel_src_path)
@@ -281,7 +291,7 @@ def copy_kernel_to_changes_dir(changes_dir, storage_dir, basename=None):
     kernel_subdir = get_kernel_subdir(storage_dir)
     kernel_tgt_dir = os.path.join(changes_dir, kernel_subdir)
     kernel_tgt_path = os.path.join(kernel_tgt_dir, basename or OSTREE_KERNEL_FILENAME)
-    if not os.path.exists(kernel_tgt_path):
+    if not os.path.isfile(kernel_tgt_path):
         log.debug("Kernel does not exist in '%s'", kernel_tgt_path)
         os.makedirs(kernel_tgt_dir, exist_ok=True)
         kernel_src_path = find_kernel_in_sysroot(storage_dir)
@@ -291,3 +301,21 @@ def copy_kernel_to_changes_dir(changes_dir, storage_dir, basename=None):
         log.debug("Kernel already exists in '%s'", kernel_tgt_path)
 
     return kernel_tgt_path
+
+
+def get_supported_bootargs_methods(storage_dir):
+    """Determine the set of bootargs passing methods supported by the current image."""
+
+    uenv_txt_path = dt.get_current_uenv_txt_path(storage_dir)
+    method_re = {
+        "overlay": re.compile(SET_BOOTARGS_CUSTOM_RE),
+        "uenv": re.compile(SET_BOOTARGS_TORIZON_RE)
+    }
+    found_methods = set()
+    with open(uenv_txt_path, "r") as fhandle:
+        for line in fhandle:
+            for meth, regex in method_re.items():
+                if regex.match(line):
+                    found_methods.add(meth)
+    log.debug("Supported bootargs passing methods: %s", str(found_methods))
+    return found_methods

--- a/tcbuilder/cli/dt.py
+++ b/tcbuilder/cli/dt.py
@@ -119,24 +119,9 @@ def _deploy_dtb_fit(*, dtb_src_path, dtb_name, changes_dir, storage_dir):
 
 
 def _deploy_updated_uenv_txt(*, fdtfile, changes_dir, storage_dir):
-    # Load original file:
-    uenv_src_path = dt_be.get_current_uenv_txt_path(storage_dir)
-    with open(uenv_src_path, "r", encoding="utf-8") as fhandle:
-        lines = fhandle.readlines()
-    # Drop lines assigning to the desired variable:
-    var_name = "fdtfile"
-    new_lines = []
-    for line in lines:
-        if not line.startswith(f"{var_name}="):
-            new_lines.append(line)
-    # Add assignment as the first line.
-    new_lines.insert(0, f"{var_name}={fdtfile}\n")
-    # Save modified version of the file:
-    uenv_target_dir = os.path.join(changes_dir, "usr", "lib", "ostree-boot")
-    uenv_target_path = os.path.join(uenv_target_dir, "uEnv.txt")
-    os.makedirs(uenv_target_dir, exist_ok=True)
-    with open(uenv_target_path, "w", encoding="utf-8") as fhandle:
-        fhandle.writelines(new_lines)
+    dt_be.set_uenv_txt_variable(
+        "fdtfile", fdtfile,
+        changes_dir=changes_dir, storage_dir=storage_dir)
 
 
 def _deploy_empty_overlays_txt(*, changes_dir, storage_dir):

--- a/tcbuilder/cli/kernel.py
+++ b/tcbuilder/cli/kernel.py
@@ -9,12 +9,15 @@ import logging
 import tempfile
 import subprocess
 
+import libfdt
 from tcbuilder.errors import \
-    (PathNotExistError, FileContentMissing, InvalidDataError, FeatureNotImplementedError)
+    (FileContentMissing, FeatureNotImplementedError, InvalidDataError,
+     PathNotExistError, UnsupportedImageFeature)
 from tcbuilder.backend.common import \
-    (get_tar_compress_program_options, images_unpack_executed, unpacked_image_type,
-     get_branch_and_major_from_metadata, is_file_type_fit)
+    (fail_on_raw_image, is_file_type_fit, get_branch_and_major_from_metadata,
+     get_tar_compress_program_options, images_unpack_executed)
 from tcbuilder.backend import kernel, dt, dto
+from tcbuilder.backend.kernelfit import KernelFit
 from tcbuilder.cli import dto as dto_cli
 
 log = logging.getLogger("torizon." + __name__)
@@ -41,9 +44,28 @@ KERNEL_SET_CUSTOM_ARGS_DTS = """
 # XXX: Always keep in sync with uEnv.txt.in in recipe `u-boot-distro-boot`.
 KERNEL_SET_CUSTOM_ARGS_PROPERTY = 'bootargs_custom'
 
-# Regex to find the "function" responsible for handling the bootargs in uEnv.txt.
+# Name of the property defining the kernel args in uEnv.txt.
 # XXX: Always keep in sync with uEnv.txt.in in recipe `u-boot-distro-boot`.
-UENV_SET_CUSTOM_ARGS_FUNCTION_RE = r'^\s*set_bootargs_custom='
+UENV_CUSTOM_BOOTARGS_VAR = "torizon_boot_args"
+
+# Error messages:
+MSG_CUSTOMIZATION_NOT_SUPPORTED_FOR_WIC = \
+    "Kernel customization is not supported for WIC/raw images. Aborting."
+MSG_COMMAND_NOT_SUPPORTED_FOR_WIC = \
+    "Command not supported for WIC/raw images. Aborting."
+
+# Regexp to match the name of the secure boot kernel bootargs overlay.
+SECBOOT_KARGS_OVL_RE = re.compile(r"^conf-.*secboot-kargs_overlay\.dtbo$")
+
+SECBOOT_NODE_PATH = "/fragment@0/__overlay__/chosen/toradex,secure-boot"
+SECBOOT_REQ_BOOTARGS_PROPNAME = "required-bootargs"
+SECBOOT_REQ_BOOTARGS_ORG_PROPNAME = "required-bootargs-org"
+
+
+def _on_custom_kargs_not_supported():
+    raise UnsupportedImageFeature(
+        "Error: the Torizon OS image you are customizing does not support "
+        "custom kernel arguments; please upgrade to a newer OS image version.")
 
 
 # pylint: disable=too-many-locals
@@ -51,9 +73,7 @@ def kernel_build_module(source_dir, storage_dir, autoload):
     """"Main handler of the 'kernel build_module' subcommand"""
 
     images_unpack_executed(storage_dir)
-    if unpacked_image_type(storage_dir) == "raw":
-        raise InvalidDataError("Kernel customization is not supported for WIC/raw images. "
-                               "Aborting.")
+    fail_on_raw_image(storage_dir, MSG_CUSTOMIZATION_NOT_SUPPORTED_FOR_WIC)
 
     unpacked_kernel_path = kernel.find_kernel_in_sysroot(storage_dir)
     if is_file_type_fit(unpacked_kernel_path):
@@ -134,31 +154,10 @@ def do_kernel_build_module(args):
                         autoload=args.autoload)
 
 
-def kernel_set_custom_args(kernel_args, storage_dir):
-    """Main handler of the 'kernel set_custom_args" subcommand
+def _set_custom_kargs_ovl(kargs, storage_dir):
+    """Set the custom bootargs using the (old) overlay method."""
 
-    :param kernel_args: List of strings with the kernel arguments.
-    :param storage_dir: Path of the storage directory to be used on the
-                        operations.
-    """
-
-    images_unpack_executed(storage_dir)
-    if unpacked_image_type(storage_dir) == "raw":
-        raise InvalidDataError("Kernel customization is not supported for WIC/raw images. "
-                               "Aborting.")
-
-    unpacked_kernel_path = kernel.find_kernel_in_sysroot(storage_dir)
-    if is_file_type_fit(unpacked_kernel_path):
-        raise FeatureNotImplementedError("Kernel customization is not supported for FIT format. "
-                                         "Aborting.")
-
-    kargs = " ".join(kernel_args)
-    if not kargs.rstrip():
-        log.error('error: please pass a valid string for the custom kernel arguments.')
-        sys.exit(1)
-
-    # Make sure image can handle kernel arguments.
-    assert_custom_kargs_compat_image(storage_dir)
+    log.debug("Setting bootargs (overlay method).")
 
     # Format string to become file contents.
     dts_contents = KERNEL_SET_CUSTOM_ARGS_DTS.format(kernel_args=kargs)
@@ -169,120 +168,394 @@ def kernel_set_custom_args(kernel_args, storage_dir):
         with open(dtos_path, 'w') as file:
             file.write(dts_contents)
 
-        # The present command is simply a wrapper around `dto apply` - since we are setting
-        # test_apply as False the parameters `dtb_path` is not required as the function being
-        # invoked will not try to apply the overlay for assurance purposes. Also, the include
-        # directory is not needed either because we know the file being compiled includes no
-        # other files.
-        dto_cli.dto_apply(dtos_path=dtos_path,
-                          dtb_path=None, include_dirs=[],
-                          storage_dir=storage_dir,
-                          allow_reapply=True, test_apply=False)
+        # The present command is simply a wrapper around `dto apply` - since we are
+        # setting test_apply as False the parameters `dtb_path` is not required as
+        # the function being invoked will not try to apply the overlay for assurance
+        # purposes. Also, the include directory is not needed either because we know
+        # the file being compiled includes no other files.
+        dto_cli.dto_apply(
+            dtos_path=dtos_path, dtb_path=None, include_dirs=[],
+            storage_dir=storage_dir, allow_reapply=True, test_apply=False)
+
+
+def _set_custom_kargs_uenv(kargs, changes_dir, storage_dir):
+    """Set the custom bootargs using the (new) uenv method."""
+
+    log.debug("Setting bootargs (uenv method).")
+    dt.set_uenv_txt_variable(
+        UENV_CUSTOM_BOOTARGS_VAR, kargs,
+        changes_dir=changes_dir, storage_dir=storage_dir)
+
+
+def _secboot_kargs_ovl_present(storage_dir):
+    """Check if the base image kernel has a secboot kargs overlay.
+
+    :returns: A pair where first element is a boolean indicating the presence of
+        overlay, and the second element is the corresponding file name inside the
+        kernel FIT image.
+    """
+
+    kernel_path = kernel.find_kernel_in_sysroot(storage_dir)
+    dtb_prefix = dt.get_kernelfit_dtb_prefix(storage_dir)
+    with open(kernel_path, "rb") as fhandle:
+        fit = KernelFit(fhandle, dtb_prefix=dtb_prefix)
+
+    # Find the configuration node corresponding to the secboot kargs overlay
+    # and determine its related file name.
+    dtbo_list = fit.get_dtb_list(overlay=True)
+    dtbo_fname = None
+    for _dtbo in dtbo_list:
+        if SECBOOT_KARGS_OVL_RE.match(_dtbo["conf_name"]):
+            dtbo_fname = _dtbo["file_name"]
+            break
+
+    if not dtbo_fname:
+        log.debug("Overlay with secboot required-bootargs is not present in the kernel.")
+        return False, None
+
+    log.debug("Overlay with secboot required-bootargs found in the kernel.")
+    return True, dtbo_fname
+
+
+def _get_secboot_required_bootargs_fdt(ovl):
+    """Get the required-bootargs string from the given overlay libfdt.Fdt."""
+
+    # Determine current value of required-bootargs:
+    try:
+        nodoff = ovl.path_offset(SECBOOT_NODE_PATH)
+        req_bootargs_cur = ovl.getprop(nodoff, SECBOOT_REQ_BOOTARGS_PROPNAME)
+        req_bootargs_cur = req_bootargs_cur.as_str()
+    except libfdt.FdtException as exc:
+        raise InvalidDataError(
+            f"Required property {SECBOOT_NODE_PATH}/{SECBOOT_REQ_BOOTARGS_PROPNAME}"
+            " not found in secboot overlay.") \
+            from exc
+    log.debug("req_bootargs_cur='%s'", req_bootargs_cur)
+
+    # Determine original value of required-bootargs:
+    try:
+        nodoff = ovl.path_offset(SECBOOT_NODE_PATH)
+        req_bootargs_org = ovl.getprop(nodoff, SECBOOT_REQ_BOOTARGS_ORG_PROPNAME)
+        req_bootargs_org = req_bootargs_org.as_str()
+    except libfdt.FdtException as exc:
+        req_bootargs_org = None
+        log.debug(
+            f"Property {SECBOOT_NODE_PATH}/{SECBOOT_REQ_BOOTARGS_ORG_PROPNAME}"
+            " not found in secboot overlay.")
+    log.debug("req_bootargs_org='%s'", req_bootargs_org)
+
+    return req_bootargs_cur, req_bootargs_org
+
+
+def _set_secboot_required_bootargs(kargs, changes_dir, storage_dir):
+    """Set/clear the required-bootargs data inside the kernel FIT image."""
+
+    log.debug("Trying to %s secboot required-bootargs.",
+              ["clear", "set"][kargs is None])
+    dtbo_pres, dtbo_fname = _secboot_kargs_ovl_present(storage_dir)
+    if not dtbo_pres:
+        return
+
+    # Copy kernel to changes directory and load it.
+    kernel_path = kernel.copy_kernel_to_changes_dir(changes_dir, storage_dir)
+    with open(kernel_path, "rb") as fhandle:
+        fit = KernelFit(
+            fhandle, dtb_prefix=dt.get_kernelfit_dtb_prefix(storage_dir))
+
+    # Extract/parse the overlay from the kernel.
+    ovl = libfdt.Fdt(fit.extract_dtb(dtbo_fname, overlay=True))
+
+    # Determine current and original required-bootargs strings.
+    req_bootargs_cur, req_bootargs_org = _get_secboot_required_bootargs_fdt(ovl)
+
+    if kargs is None:
+        # Handle the "clear" operation:
+        if req_bootargs_org is None:
+            # Original was not set; by setting the new value to None we avoid
+            # updating the overlay inside the FIT (as an optimization).
+            req_bootargs_new = None
+        else:
+            # Clear original bootargs:
+            log.debug("Clearing original required-bootargs in the overlay.")
+            nodoff = ovl.path_offset(SECBOOT_NODE_PATH)
+            ovl.delprop(nodoff, SECBOOT_REQ_BOOTARGS_ORG_PROPNAME)
+            # Copy original value into new (undoing the set operation).
+            req_bootargs_new = req_bootargs_org
+    else:
+        # Handle the "set" operation:
+        if req_bootargs_org is None:
+            # Save original bootargs:
+            log.debug("Storing original required-bootargs into the overlay.")
+            nodoff = ovl.path_offset(SECBOOT_NODE_PATH)
+            ovl.resize(ovl.totalsize() + len(req_bootargs_cur) + 128)
+            ovl.setprop_str(nodoff, SECBOOT_REQ_BOOTARGS_ORG_PROPNAME, req_bootargs_cur)
+            # Define new value (string):
+            req_bootargs_new = req_bootargs_cur + " " + kargs
+        else:
+            # Define new value (string) based on the original bootargs:
+            req_bootargs_new = req_bootargs_org + " " + kargs
+
+    log.debug("req_bootargs_new='%s'", req_bootargs_new)
+
+    if req_bootargs_new is None:
+        log.debug("Overlay with required-bootargs needs no update.")
+        return
+
+    # Save new bootargs:
+    log.debug("Storing updated required-bootargs into the overlay.")
+    nodoff = ovl.path_offset(SECBOOT_NODE_PATH)
+    ovl.resize(ovl.totalsize() + len(req_bootargs_new) + 128)
+    ovl.setprop_str(nodoff, SECBOOT_REQ_BOOTARGS_PROPNAME, req_bootargs_new)
+    ovl.pack()
+
+    # Update the DTBO inside the kernel.
+    log.debug("Storing updated overlay into the kernel FIT.")
+    fit.add_dtb(dtbo_fname, bytes(ovl.as_bytearray()), overlay=True, overwrite=True)
+
+    # Update kernel FIT image on disk.
+    with open(kernel_path, "wb") as fhandle:
+        fit.write(fhandle)
+
+
+def kernel_set_custom_args(kernel_args, storage_dir):
+    """Main handler of the 'kernel set_custom_args" subcommand
+
+    :param kernel_args: List of strings with the kernel arguments.
+    :param storage_dir: Path of the storage directory to be used on the
+                        operations.
+    """
+
+    images_unpack_executed(storage_dir)
+    fail_on_raw_image(storage_dir, MSG_CUSTOMIZATION_NOT_SUPPORTED_FOR_WIC)
+
+    kernel_path = kernel.find_kernel_in_sysroot(storage_dir)
+    kernel_is_fit = is_file_type_fit(kernel_path)
+    log.debug(f"kernel_set_custom_args: kernel_is_fit={kernel_is_fit}")
+
+    # Ensure a non-empty string arguments string is being passed (to clear the
+    # string users should use the "clear" sub-command).
+    kargs = " ".join(kernel_args)
+    if not kargs.rstrip():
+        log.error('Error: please pass a valid string for the custom kernel arguments.')
+        sys.exit(1)
+
+    kargs_methods = kernel.get_supported_bootargs_methods(storage_dir)
+
+    # Check image requirements:
+    if kernel_is_fit and "uenv" not in kargs_methods:
+        raise UnsupportedImageFeature(
+            "Error: the Torizon OS image you are customizing has a kernel in FIT "
+            "format but it does not support the uEnv method for passing kernel "
+            "arguments; please upgrade to Torizon OS version 7.5.0 or newer.")
+
+    # Determine the target changes directory.
+    if kernel_is_fit:
+        changes_dir = kernel.get_kernel_changes_dir(storage_dir)
+    else:
+        changes_dir = dt.get_dt_changes_dir(storage_dir)
+
+    if "uenv" in kargs_methods:
+        _set_custom_kargs_uenv(kargs, changes_dir, storage_dir)
+        _clr_custom_kargs_ovl(storage_dir)
+    elif "overlay" in kargs_methods:
+        _set_custom_kargs_ovl(kargs, storage_dir)
+    else:
+        _on_custom_kargs_not_supported()
+
+    # Secure boot images also keep a "required-bootargs" string inside the kernel
+    # which need to be updated; handle this case here.
+    if kernel_is_fit:
+        _set_secboot_required_bootargs(kargs, changes_dir, storage_dir)
 
     # Confirm application of arguments.
-    print(f"Kernel custom arguments successfully configured with \"{kargs}\".")
+    print(f'Kernel custom arguments successfully configured with "{kargs}".')
 
 
 def do_kernel_set_custom_args(args):
     """Run 'kernel set_custom_args" subcommand"""
+    kernel_set_custom_args(
+        kernel_args=args.kernel_args,
+        storage_dir=args.storage_directory)
 
-    kernel_set_custom_args(kernel_args=args.kernel_args,
-                           storage_dir=args.storage_directory)
 
-
-def do_kernel_get_custom_args(args):
-    """Run 'kernel get_custom_args" subcommand"""
-
-    images_unpack_executed(args.storage_directory)
-    if unpacked_image_type(args.storage_directory) == "raw":
-        raise InvalidDataError("Command not supported for WIC/raw images. Aborting.")
-
-    unpacked_kernel_path = kernel.find_kernel_in_sysroot(args.storage_directory)
-    if is_file_type_fit(unpacked_kernel_path):
-        raise FeatureNotImplementedError("Command not supported for kernel in FIT format. "
-                                         "Aborting.")
-
-    # Make sure image can handle kernel arguments.
-    assert_custom_kargs_compat_image(args.storage_directory)
-
+def _get_custom_kargs_ovl(storage_dir):
     # Check if the custom kernel args overlays is being applied.
-    applied_overlay_basenames = dto.get_applied_overlay_names(args.storage_directory)
+    overlay_basenames = dto.get_applied_overlay_names(storage_dir)
     dtob_basename = os.path.splitext(KERNEL_SET_CUSTOM_ARGS_DTS_NAME)[0] + ".dtbo"
-    if dtob_basename not in applied_overlay_basenames:
+    if dtob_basename not in overlay_basenames:
         # No arguments set: nothing wrong with that.
-        log.info("No custom kernel arguments configured.")
-        return
+        return None
 
     # Determine full path of the overlay of interest only.
-    applied_overlay_paths = \
-        dto.get_applied_overlay_paths(args.storage_directory, base_names=[dtob_basename])
+    overlay_paths = dto.get_applied_overlay_paths(storage_dir, base_names=[dtob_basename])
+    dtob_path = overlay_paths[0]
+    log.debug(f"Custom arguments overlay is applied: path='{dtob_path}'")
 
-    log.debug(f"Custom arguments overlay is applied: path='{applied_overlay_paths[0]}'")
-
-    dtob_path = applied_overlay_paths[0]
-
-    # XXX: Following command might break if DTC command changes in the future.
-    # Run external program from 'device-tree-compiler' package.
+    # Read overlay property holding custom bootargs.
     fdtget_output = \
         subprocess.check_output(
             ["fdtget", dtob_path, "/fragment@0/__overlay__/",
              KERNEL_SET_CUSTOM_ARGS_PROPERTY], text=True).rstrip()
 
-    # Send output to stdout always.
-    print(f"Currently configured custom kernel arguments: \"{fdtget_output}\".")
+    return fdtget_output
 
 
-def do_kernel_clear_custom_args(args):
+def _get_custom_kargs_uenv(storage_dir):
+    """Get the custom bootargs using the (new) uenv method."""
+
+    log.debug("Getting bootargs (uenv method).")
+    kargs = dt.get_uenv_txt_variable(UENV_CUSTOM_BOOTARGS_VAR, storage_dir=storage_dir)
+    return kargs
+
+
+def _get_secboot_required_bootargs(changes_dir, storage_dir):
+    """Get the (current, original) required-bootargs strings from the kernel FIT."""
+
+    log.debug("Trying to get secboot required-bootargs.")
+    dtbo_pres, dtbo_fname = _secboot_kargs_ovl_present(storage_dir)
+    if not dtbo_pres:
+        return None, None
+
+    # Load customized or original kernel.
+    kernel_path = \
+        (kernel.find_kernel_in_changes_dir(changes_dir, storage_dir) or
+         kernel.find_kernel_in_sysroot(storage_dir))
+    with open(kernel_path, "rb") as fhandle:
+        fit = KernelFit(
+            fhandle, dtb_prefix=dt.get_kernelfit_dtb_prefix(storage_dir))
+
+    # Extract/parse the overlay from the kernel.
+    ovl = libfdt.Fdt(fit.extract_dtb(dtbo_fname, overlay=True))
+
+    return _get_secboot_required_bootargs_fdt(ovl)
+
+
+def kernel_get_custom_args(storage_dir):
+    """Run 'kernel get_custom_args" subcommand"""
+
+    images_unpack_executed(storage_dir)
+    fail_on_raw_image(storage_dir, MSG_COMMAND_NOT_SUPPORTED_FOR_WIC)
+
+    kernel_path = kernel.find_kernel_in_sysroot(storage_dir)
+    kernel_is_fit = is_file_type_fit(kernel_path)
+    log.debug(f"kernel_get_custom_args: kernel_is_fit={kernel_is_fit}")
+
+    kargs_methods = kernel.get_supported_bootargs_methods(storage_dir)
+
+    # Supported cases are shown in the table below:
+    #            +-----------------+
+    #            |   Kernel type   |
+    # +----------+-----------------+
+    # | Method   | non-FIT  | FIT  |
+    # +----------+----------+------+
+    # | Overlay  | Yes      | No   |
+    # +----------+----------+------+
+    # | uEnv.txt | Yes      | Yes  |
+    # +----------+----------+------+
+    #
+    if kernel_is_fit and "uenv" not in kargs_methods:
+        log.info(
+            "Notice: this image has a kernel in FIT format but it does not support "
+            "the uEnv method for passing kernel arguments; this means you will not "
+            "be able to set its custom kernel arguments. This can be solved by "
+            "upgrading to Torizon OS version 7.5.0 or newer.")
+
+    kargs = None
+    if "uenv" in kargs_methods:
+        kargs = _get_custom_kargs_uenv(storage_dir)
+    elif "overlay" in kargs_methods:
+        kargs = _get_custom_kargs_ovl(storage_dir)
+    else:
+        _on_custom_kargs_not_supported()
+
+    if kargs is None:
+        print("No custom kernel arguments configured.")
+    else:
+        # Send output to stdout always.
+        print(f'Currently configured custom kernel arguments: "{kargs}".')
+
+    if kernel_is_fit:
+        # Show a debug message with the final secure boot kernel arguments (which
+        # include the custom arguments set by the user and the original "required"
+        # arguments set when the image was built).
+        changes_dir = kernel.get_kernel_changes_dir(storage_dir)
+        # At the moment, we don't handle the output of the below function because
+        # we are only showing the required-bootargs string as debug messages.
+        _get_secboot_required_bootargs(changes_dir, storage_dir)
+
+
+def do_kernel_get_custom_args(args):
+    """Run 'kernel get_custom_args" subcommand"""
+    kernel_get_custom_args(args.storage_directory)
+
+
+def _clr_custom_kargs_ovl(storage_dir):
+    """Clear the custom bootargs set using the old method (overlay)."""
+
+    log.debug("Clearing bootargs (overlay method).")
+    dtob_basename = os.path.splitext(KERNEL_SET_CUSTOM_ARGS_DTS_NAME)[0] + ".dtbo"
+    res = dto_cli.dto_remove_single(dtob_basename, storage_dir, presence_required=False)
+    return res
+
+
+def _clr_custom_kargs_uenv(changes_dir, storage_dir):
+    """Clear the custom bootargs set using the new method (variables in uEnv.txt)."""
+
+    log.debug("Clearing bootargs (uenv method).")
+    status = dt.set_uenv_txt_variable(
+        UENV_CUSTOM_BOOTARGS_VAR, None,
+        changes_dir=changes_dir, storage_dir=storage_dir)
+    return status
+
+
+def kernel_clear_custom_args(storage_dir):
     """Run 'kernel clear_custom_args" subcommand"""
 
-    images_unpack_executed(args.storage_directory)
-    if unpacked_image_type(args.storage_directory) == "raw":
-        raise InvalidDataError("Kernel customization is not supported for WIC/raw images. "
-                               "Aborting.")
+    images_unpack_executed(storage_dir)
+    fail_on_raw_image(storage_dir, MSG_CUSTOMIZATION_NOT_SUPPORTED_FOR_WIC)
 
-    unpacked_kernel_path = kernel.find_kernel_in_sysroot(args.storage_directory)
-    if is_file_type_fit(unpacked_kernel_path):
-        raise FeatureNotImplementedError("Kernel customization is not supported for FIT format. "
-                                         "Aborting.")
+    kernel_path = kernel.find_kernel_in_sysroot(storage_dir)
+    kernel_is_fit = is_file_type_fit(kernel_path)
+    log.debug(f"kernel_clear_custom_args: kernel_is_fit={kernel_is_fit}")
 
-    # Make sure image can handle kernel arguments.
-    assert_custom_kargs_compat_image(args.storage_directory)
+    kargs_methods = kernel.get_supported_bootargs_methods(storage_dir)
 
-    dtob_basename = os.path.splitext(KERNEL_SET_CUSTOM_ARGS_DTS_NAME)[0] + ".dtbo"
+    # Check image requirements:
+    if kernel_is_fit and "uenv" not in kargs_methods:
+        raise UnsupportedImageFeature(
+            "Error: the Torizon OS image you are customizing has a kernel in FIT "
+            "format but it does not support the uEnv method for passing kernel "
+            "arguments; please upgrade to Torizon OS version 7.5.0 or newer.")
 
-    res = dto_cli.dto_remove_single(
-        dtob_basename, args.storage_directory, presence_required=False)
-    if res:
+    # Determine the target changes directory.
+    if kernel_is_fit:
+        changes_dir = kernel.get_kernel_changes_dir(storage_dir)
+    else:
+        changes_dir = dt.get_dt_changes_dir(storage_dir)
+
+    status = False
+    if "uenv" in kargs_methods:
+        status = _clr_custom_kargs_uenv(changes_dir, storage_dir)
+    elif "overlay" in kargs_methods:
+        status = _clr_custom_kargs_ovl(storage_dir)
+    else:
+        _on_custom_kargs_not_supported()
+
+    # Secure boot images also keep a "required-bootargs" string inside the kernel
+    # which need to be updated; handle this case here.
+    if kernel_is_fit:
+        _set_secboot_required_bootargs(None, changes_dir, storage_dir)
+
+    if status:
         print("Custom kernel arguments successfully cleared.")
     else:
         # No arguments set: nothing wrong with that.
         log.info("No custom kernel arguments configured.")
-        return
 
 
-def assert_custom_kargs_compat_image(storage_dir):
-    """Ensure image is capable of handling custom kernel argument.
-
-    On return, caller can assume reference image does contain the code to handle
-    custom kernel argument. If it does not, the program will exit.
-    """
-
-    uenv_txt_path = dt.get_current_uenv_txt_path(storage_dir)
-    handling_code_found = False
-
-    re_searched = re.compile(UENV_SET_CUSTOM_ARGS_FUNCTION_RE)
-
-    with open(uenv_txt_path, 'r') as file:
-        for line in file:
-            if re_searched.match(line):
-                handling_code_found = True
-                break
-
-    if not handling_code_found:
-        log.error("The TorizonCore image you are customizing doesn't support "
-                  "custom kernel arguments. Please update it to the latest "
-                  "TorizonCore version.")
-        sys.exit(1)
+def do_kernel_clear_custom_args(args):
+    """Run 'kernel clear_custom_args" subcommand"""
+    kernel_clear_custom_args(args.storage_directory)
 
 
 def init_parser(subparsers):

--- a/tcbuilder/errors.py
+++ b/tcbuilder/errors.py
@@ -110,3 +110,6 @@ class LicenceAcceptanceError(TorizonCoreBuilderError):
 
 class InvalidStorageDriverError(TorizonCoreBuilderError):
     pass
+
+class UnsupportedImageFeature(TorizonCoreBuilderError):
+    pass

--- a/tests/integration/functions.sh
+++ b/tests/integration/functions.sh
@@ -70,7 +70,7 @@ export -f stop-torizoncore-builder-bg
 # $@ = command to be executed
 torizoncore-builder-shell() {
     local TCB=$(echo ${TCBCMD##* })
-    docker run --rm -v $(pwd):/workdir -v storage:/storage --net=host --entrypoint /bin/bash $TCB -c "$@"
+    docker run --rm -v $(pwd):/workdir -v storage:/storage --net=host --entrypoint /bin/bash $TCB -c "$*"
 }
 export -f torizoncore-builder-shell
 

--- a/tests/integration/testcases/kernel.bats
+++ b/tests/integration/testcases/kernel.bats
@@ -3,6 +3,40 @@ bats_load_library 'bats/bats-assert/load.bash'
 bats_load_library 'bats/bats-file/load.bash'
 load 'lib/common.bash'
 
+# Local helpers:
+find_uenv_txt_in_sysroot() {
+    # Get path:
+    run torizoncore-builder-shell "find /storage/sysroot/ostree/deploy/ -name uEnv.txt"
+    assert_success
+    local uenv_path="${output}"
+    # Sanity check:
+    run torizoncore-builder-shell "[ -f '${uenv_path}' ]"
+    assert_success
+    echo "${uenv_path}"
+}
+
+find_uenv_txt_in_chgsdir() {
+    # Get path:
+    run torizoncore-builder-shell \
+        "{ [ -d /storage/dt ] && find /storage/dt/ -name uEnv.txt; } ||" \
+        "{ [ -d /storage/kernel ] && find /storage/kernel/ -name uEnv.txt; }"
+    assert_success
+    local uenv_path="${output}"
+    # Sanity check:
+    run torizoncore-builder-shell "[ -f '${uenv_path}' ]"
+    assert_success
+    echo "${uenv_path}"
+}
+
+is_ovl_kargs_passing_supported() {
+    local uenv_path="${1?uEnv.txt path required}"
+    torizoncore-builder-shell "grep -q '^set_bootargs_custom=' ${uenv_path}"
+}
+
+is_uenv_kargs_passing_supported() {
+    local uenv_path="${1?uEnv.txt path required}"
+    torizoncore-builder-shell "grep -q '^set_bootargs_torizon=' ${uenv_path}"
+}
 
 @test "kernel: run without parameters" {
     run torizoncore-builder kernel
@@ -18,7 +52,7 @@ load 'lib/common.bash'
     assert_output --partial "{build_module,set_custom_args,get_custom_args,clear_custom_args}"
 }
 
-@test "kernel: check build_module ownership for output files" {
+@test "kernel build_module: check ownership of output files" {
     requires-non-fit-kernel
 
     local MOD_FILE="hello"
@@ -53,7 +87,7 @@ load 'lib/common.bash'
     torizoncore-builder-shell "rm -rf $SRC_DIR"
 }
 
-@test "kernel: run build_module without images unpack" {
+@test "kernel build_module: run without images unpack" {
     torizoncore-builder-clean-storage
 
     local SRC_DIR="source_dir"
@@ -67,7 +101,7 @@ load 'lib/common.bash'
     torizoncore-builder-shell "rm -rf $SRC_DIR"
 }
 
-@test "kernel: throw error on kernel FIT format" {
+@test "kernel build_module: throw error on kernel FIT format" {
     requires-fit-kernel
 
     torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
@@ -75,16 +109,263 @@ load 'lib/common.bash'
     run torizoncore-builder kernel build_module $SRC_DIR
     assert_failure
     assert_output --partial "not supported for FIT format"
+}
 
-    run torizoncore-builder kernel set_custom_args "foo=bar"
+@test "kernel {set,get,clear}_custom_args: check basic errors" {
+    torizoncore-builder-clean-storage
+
+    run torizoncore-builder kernel set_custom_args "arg1=val1" "arg2=val2"
     assert_failure
-    assert_output --partial "not supported for FIT format"
+    assert_output --partial "Error: could not find an Easy Installer or WIC image in the storage"
+    assert_output --partial "Please use the 'images' command to unpack an image before running this command"
 
     run torizoncore-builder kernel get_custom_args
     assert_failure
-    assert_output --partial "not supported for kernel in FIT format"
+    assert_output --partial "Error: could not find an Easy Installer or WIC image in the storage"
+    assert_output --partial "Please use the 'images' command to unpack an image before running this command"
 
     run torizoncore-builder kernel clear_custom_args
     assert_failure
-    assert_output --partial "not supported for FIT format"
+    assert_output --partial "Error: could not find an Easy Installer or WIC image in the storage"
+    assert_output --partial "Please use the 'images' command to unpack an image before running this command"
+
+    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+
+    run torizoncore-builder kernel set_custom_args ""
+    assert_failure
+    assert_output --partial "Error: please pass a valid string for the custom kernel arguments"
+}
+
+@test "kernel {set,get,clear}_custom_args: check unsupported bootargs passing" {
+    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+
+    # Find uEnv.txt in storage:
+    local uenv_path=$(find_uenv_txt_in_sysroot)
+    # Determine the supported bootargs passing methods:
+    local ovl_kargs_supported=$(is_ovl_kargs_passing_supported "${uenv_path}" \
+                                && echo "1" || echo "0")
+    local uenv_kargs_supported=$(is_uenv_kargs_passing_supported "${uenv_path}" \
+                                 && echo "1" || echo "0")
+    # Show result (for debug):
+    echo "ovl_kargs_supported=${ovl_kargs_supported}"
+    echo "uenv_kargs_supported=${uenv_kargs_supported}"
+
+    # Change uEnv.txt to pretend that the new bootargs passing method is not supported.
+    if [ "${uenv_kargs_supported}" = "1" ]; then
+        echo "Removing uenv-based bootargs setting method from uEnv.txt"
+        run torizoncore-builder-shell "sed -i -e '/^set_bootargs_torizon=/d' ${uenv_path}"
+        assert_success
+    fi
+
+    if [ "${IS_DEFAULT_TEZI_IMAGE_FIT}" = "1" ]; then
+        # In case of FIT images, the new passing method is strictly needed for
+        # setting/clearing (not for getting); check that:
+        echo "Performing basic set/get/clear checks for FIT-kernel case"
+        run torizoncore-builder kernel set_custom_args "arg1=val1" "arg2=val2"
+        assert_failure
+        assert_output --partial "Error: the Torizon OS image you are customizing has a kernel in FIT format but it does not support the uEnv method"
+
+        run torizoncore-builder kernel get_custom_args
+        assert_success
+        assert_output --partial "Notice: this image has a kernel in FIT format but it does not support the uEnv method for passing kernel arguments"
+
+        run torizoncore-builder kernel clear_custom_args
+        assert_failure
+        assert_output --partial "Error: the Torizon OS image you are customizing has a kernel in FIT format but it does not support the uEnv method"
+    fi
+
+    # Change uEnv.txt to pretend that the old bootargs passing method is also
+    # not supported; now not setting methods are available.
+    if [ "${ovl_kargs_supported}" = "1" ]; then
+        echo "Removing overlay-based bootargs setting method from uEnv.txt"
+        run torizoncore-builder-shell "sed -i -e '/^set_bootargs_custom=/d' ${uenv_path}"
+        assert_success
+    fi
+
+    # At this point, no bootargs setting method is available; check that:
+    echo "Run kernel set_custom_args with no bootargs setting method available"
+    run torizoncore-builder kernel set_custom_args "arg1=val1" "arg2=val2"
+    assert_failure
+    if [ "${IS_DEFAULT_TEZI_IMAGE_FIT}" = "1" ]; then
+        assert_output --partial "Error: the Torizon OS image you are customizing has a kernel in FIT format but it does not support the uEnv method"
+    else
+        assert_output --partial "Error: the Torizon OS image you are customizing does not support custom kernel arguments"
+    fi
+
+    echo "Run kernel get_custom_args with no bootargs setting method available"
+    run torizoncore-builder kernel get_custom_args
+    assert_failure
+    if [ "${IS_DEFAULT_TEZI_IMAGE_FIT}" = "1" ]; then
+        assert_output --partial "Notice: this image has a kernel in FIT format but it does not support the uEnv method for passing kernel arguments"
+    fi
+    assert_output --partial "Error: the Torizon OS image you are customizing does not support custom kernel arguments"
+
+    echo "Run kernel clear_custom_args with no bootargs setting method available"
+    run torizoncore-builder kernel clear_custom_args
+    assert_failure
+    if [ "${IS_DEFAULT_TEZI_IMAGE_FIT}" = "1" ]; then
+        assert_output --partial "Error: the Torizon OS image you are customizing has a kernel in FIT format but it does not support the uEnv method"
+    else
+        assert_output --partial "Error: the Torizon OS image you are customizing does not support custom kernel arguments"
+    fi
+}
+
+@test "kernel {set,get,clear}_custom_args: check success cases" {
+    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+
+    # Find uEnv.txt in storage:
+    local uenv_path=$(find_uenv_txt_in_sysroot)
+    # Determine the supported bootargs passing methods:
+    local ovl_kargs_supported=$(is_ovl_kargs_passing_supported "${uenv_path}" \
+                                && echo "1" || echo "0")
+    local uenv_kargs_supported=$(is_uenv_kargs_passing_supported "${uenv_path}" \
+                                 && echo "1" || echo "0")
+    # Show result (for debug):
+    echo "ovl_kargs_supported=${ovl_kargs_supported}"
+    echo "uenv_kargs_supported=${uenv_kargs_supported}"
+
+    # ---
+    # Test the "set" command:
+    # ---
+    echo "Try setting custom bootargs."
+    run torizoncore-builder --log-level debug kernel set_custom_args "arg1=val1" "arg2=val2"
+
+    if [ "${uenv_kargs_supported}" = "1" ]; then
+        echo "Checking output of setting custom kernel arguments via uenv method."
+        assert_success
+        assert_output --partial 'Kernel custom arguments successfully configured with "arg1=val1 arg2=val2"'
+        assert_output --partial "Setting bootargs (uenv method)"
+        assert_output --partial "Clearing bootargs (overlay method)"
+
+        # Check uEnv.txt to see if the arguments were actually set.
+        local uenv_path_chgsdir=$(find_uenv_txt_in_chgsdir)
+        echo "Checking contents of '${uenv_path_chgsdir}'."
+        run torizoncore-builder-shell "grep -e '^torizon_boot_args=arg1=val1 arg2=val2' ${uenv_path_chgsdir}"
+        assert_success
+
+        if [ "${IS_DEFAULT_TEZI_IMAGE_FIT}" = "1" ]; then
+            if echo "${output}" | \
+               grep -q "Overlay with secboot required-bootargs found in the kernel"; then
+                # Check if the overlay keeping the required-bootargs was updated.
+                assert_output --regexp "req_bootargs_cur='.*'"
+                refute_output --partial "req_bootargs_cur='None'"
+                assert_output --partial "req_bootargs_org='None'"
+                assert_output --regexp "req_bootargs_new='.* arg1=val1 arg2=val2'"
+                assert_output --partial "Storing updated required-bootargs into the overlay"
+                assert_output --partial "Storing updated overlay into the kernel FIT"
+            fi
+        fi
+    elif [ "${ovl_kargs_supported}" = "1" ]; then
+        echo "Checking output of setting custom kernel arguments via overlay method."
+        assert_success
+        assert_output --partial 'Kernel custom arguments successfully configured with "arg1=val1 arg2=val2"'
+        assert_output --partial "Setting bootargs (overlay method)"
+        assert_output --partial "Overlay custom-kargs_overlay.dtbo successfully applied"
+    else
+        # Images without support for custom bootargs should no longer be available;
+        # but handle them anyway.
+        assert_failure
+        assert_output --partial "Error: the Torizon OS image you are customizing does not support custom kernel arguments"
+        return
+    fi
+
+    # ---
+    # Test the "get" command:
+    # ---
+    echo "Try getting custom bootargs."
+    run torizoncore-builder --log-level debug kernel get_custom_args
+    echo "Checking output of getting custom kernel arguments."
+    assert_success
+    assert_output --partial 'Currently configured custom kernel arguments: "arg1=val1 arg2=val2"'
+
+    if [ "${uenv_kargs_supported}" = "1" ] && \
+       [ "${IS_DEFAULT_TEZI_IMAGE_FIT}" = "1" ]; then
+        if echo "${output}" | \
+           grep -q "Overlay with secboot required-bootargs found in the kernel"; then
+            # Check if the overlay keeping the required-bootargs was updated.
+            assert_output --regexp "req_bootargs_cur='.* arg1=val1 arg2=val2'"
+            assert_output --regexp "req_bootargs_org='.*'"
+            refute_output --regexp "req_bootargs_org='None'"
+        fi
+    fi
+
+    # ---
+    # Test the "clear" command:
+    # ---
+    echo "Try clearing custom bootargs."
+    run torizoncore-builder --log-level debug kernel clear_custom_args
+
+    if [ "${uenv_kargs_supported}" = "1" ]; then
+        echo "Checking output of clearing custom kernel arguments via uenv method."
+        assert_success
+        assert_output --partial 'Custom kernel arguments successfully cleared'
+        assert_output --partial "Clearing bootargs (uenv method)"
+
+        # Check uEnv.txt to see if the arguments variable was removed.
+        local uenv_path_chgsdir=$(find_uenv_txt_in_chgsdir)
+        echo "Checking contents of '${uenv_path_chgsdir}'."
+        run torizoncore-builder-shell "grep -e '^torizon_boot_args=' ${uenv_path_chgsdir}"
+        assert_failure
+
+        if [ "${IS_DEFAULT_TEZI_IMAGE_FIT}" = "1" ]; then
+            if echo "${output}" | \
+                    grep -q "Overlay with secboot required-bootargs found in the kernel"; then
+                # Check if the required-bootargs was cleared (based on logs).
+                assert_output --regexp "req_bootargs_cur='.*'"
+                assert_output --regexp "req_bootargs_org='.*'"
+                refute_output --regexp "req_bootargs_cur='None'"
+                refute_output --regexp "req_bootargs_org='None'"
+                assert_output --partial "Clearing original required-bootargs in the overlay"
+                assert_output --partial "Storing updated required-bootargs into the overlay"
+                assert_output --partial "Storing updated overlay into the kernel FIT"
+            fi
+        fi
+    elif [ "${ovl_kargs_supported}" = "1" ]; then
+        echo "Checking output of clearing custom kernel arguments via overlay method."
+        assert_success
+        assert_output --partial 'Custom kernel arguments successfully cleared'
+        assert_output --partial "Clearing bootargs (overlay method)"
+    else
+        # Images without support for custom bootargs should no longer be available;
+        # but handle them anyway.
+        assert_failure
+        assert_output --partial "Error: the Torizon OS image you are customizing does not support custom kernel arguments"
+        return
+    fi
+
+    # ---
+    # Check the "get" command after clearing:
+    # ---
+    echo "Try getting custom bootargs after clearing."
+    run torizoncore-builder --log-level debug kernel get_custom_args
+    echo "Checking output of getting custom kernel arguments after clearing."
+    assert_success
+    assert_output --partial 'No custom kernel arguments configured'
+
+    # ---
+    # Test the "clear" command again after clearing:
+    # ---
+    echo "Try clearing custom bootargs after clearing."
+    run torizoncore-builder --log-level debug kernel clear_custom_args
+    echo "Checking output of clearing custom kernel arguments after clearing."
+    assert_success
+    assert_output --partial 'No custom kernel arguments configured'
+
+    if [ "${uenv_kargs_supported}" = "1" ]; then
+        echo "Checking output of clearing custom kernel arguments again."
+        assert_success
+        assert_output --partial "Clearing bootargs (uenv method)"
+
+        if [ "${IS_DEFAULT_TEZI_IMAGE_FIT}" = "1" ]; then
+            if echo "${output}" | \
+               grep -q "Overlay with secboot required-bootargs found in the kernel"; then
+                # Check if the required-bootargs was cleared (based on logs).
+                assert_output --regexp "req_bootargs_cur='.*'"
+                refute_output --regexp "req_bootargs_cur='None'"
+                assert_output --regexp "req_bootargs_org='None'"
+                assert_output --regexp "req_bootargs_new='None'"
+                assert_output --partial "Overlay with required-bootargs needs no update"
+            fi
+        fi
+    fi
 }


### PR DESCRIPTION
Add support for setting/getting/clearing custom kernel bootargs when the kernel is in the FIT format. This includes handling the **custom-kargs** overlay inside the FIT image, when present; this is the case with Secure Boot where the full kernel command line (not only the user supplied additions) must be statically defined to satisfy the hardening feature known as the kernel command-line protection.

Please check the individual commit messages for details.

Related-to: TCB-763
