### PR TITLE
Create new "splash-config" command

### DIFF
--- a/tcbuilder/backend/splashconfig.py
+++ b/tcbuilder/backend/splashconfig.py
@@ -1,0 +1,35 @@
+"""
+Backend functions and functionality for all splash-config commands
+"""
+
+import os
+import subprocess
+
+from tcbuilder.backend.common import get_storage_dir
+from tcbuilder.backend.splash import add_plymouth_theme_file
+from tcbuilder.errors import PathNotExistError
+
+PLYMOUTH_CONFIG = "spinner.plymouth"
+
+
+def get_default_config():
+    """Returns path to the default spinner.plymouth file
+       found in the unpacked image.
+    """
+
+    storage_dir = get_storage_dir()
+
+    default_config = subprocess.check_output(
+        ["find", os.path.join(storage_dir, "sysroot/ostree/deploy"),
+         "-type", "f", "-name", PLYMOUTH_CONFIG, "-print", "-quit"], text=True)
+
+    if not default_config:
+        raise PathNotExistError("Could not find default Plymouth configuration file.")
+
+    return default_config.rstrip()
+
+
+def add_plymouth_splash_config(root_dir, config):
+    """Add splash config in the Plymouth theme directory tree relative to root_dir"""
+
+    add_plymouth_theme_file(root_dir, config, PLYMOUTH_CONFIG)

--- a/tcbuilder/backend/tcbuild.schema.yaml
+++ b/tcbuilder/backend/tcbuild.schema.yaml
@@ -167,6 +167,10 @@ properties:
         type: string
         description: "local file path of a PNG file used to generate the splash screen image"
         tdxMeta: "file;png"
+      splash-config:
+        type: string
+        description: "local file path of a configuration file for the splash screen"
+        tdxMeta: "file"
       filesystem:
         type: array
         description: "directory trees to be applied on top of the ones in the input image"

--- a/tcbuilder/cli/build.py
+++ b/tcbuilder/cli/build.py
@@ -31,6 +31,7 @@ from tcbuilder.cli import dto as dto_cli
 from tcbuilder.cli import kernel as kernel_cli
 from tcbuilder.cli import images as images_cli
 from tcbuilder.cli import splash as splash_cli
+from tcbuilder.cli import splashconfig as splashconfig_cli
 from tcbuilder.cli import union as union_cli
 from tcbuilder.cli import secboot as secboot_cli
 
@@ -177,8 +178,12 @@ def handle_customization_section(props):
         log.info(l1_pref("Handling customization section"))
 
     if "splash-screen" in props:
-        log.info(l2_pref("Setting splash screen"))
+        log.info(l2_pref("Setting splash screen image"))
         splash_cli.splash(props["splash-screen"])
+
+    if "splash-config" in props:
+        log.info(l2_pref("Setting splash screen configuration"))
+        splashconfig_cli.splash_config_set(props["splash-config"])
 
     if "device-tree" in props:
         handle_dt_customization(props["device-tree"])

--- a/tcbuilder/cli/splashconfig.py
+++ b/tcbuilder/cli/splashconfig.py
@@ -1,0 +1,164 @@
+"""
+CLI for the splash-config command
+"""
+
+import logging
+import os
+import shutil
+
+from tcbuilder.backend import splashconfig as splashconfig_be
+
+from tcbuilder.backend.common import \
+    (images_unpack_executed, set_output_ownership,
+     is_file_type_fit)
+from tcbuilder.errors import \
+    (InvalidStateError, PathNotExistError)
+from tcbuilder.backend.initramfs import UnpackedInitramfs
+from tcbuilder.backend.kernel import \
+    (find_kernel_in_sysroot, get_kernel_changes_dir)
+from tcbuilder.backend.splash import \
+    (get_splash_changes_dir, PLYMOUTH_THEME_PATH)
+from tcbuilder.backend.splashconfig import PLYMOUTH_CONFIG
+
+log = logging.getLogger("torizon." + __name__)
+
+
+def splash_config_set(config):
+    """Main handler for 'splash-config set' command.
+
+    :param config: Path to provided configuration file.
+    """
+
+    config_file = os.path.abspath(config)
+    if not os.path.exists(config_file):
+        raise PathNotExistError(f"Unable to find configuration file {config}.")
+
+    with UnpackedInitramfs(source="auto") as rdm:
+        splashconfig_be.add_plymouth_splash_config(rdm.get_path(), config_file)
+
+    unpacked_kernel_path = find_kernel_in_sysroot()
+    kernel_is_fit = is_file_type_fit(unpacked_kernel_path)
+    log.debug(f"splash: kernel_is_fit={kernel_is_fit}")
+
+    if kernel_is_fit:
+        # FIT case: all changes go to the kernel-changes directory.
+        changes_dir = get_kernel_changes_dir()
+    else:
+        # non-FIT case: changes go to the splash-changes directory.
+        changes_dir = get_splash_changes_dir()
+
+    splashconfig_be.add_plymouth_splash_config(changes_dir, config_file)
+
+    log.info("Splash screen configuration updated")
+
+
+def do_splash_config_set(args):
+    """Run 'splash-config set' command."""
+
+    images_unpack_executed()
+
+    splash_config_set(args.splash_config)
+
+
+def create_config(output_file, config, force):
+    """Prints or writes the current active Plymouth Configuration file.
+
+    :param output_file: Filename for where to write the conent. If 'None'
+                        then prints the content to console instead.
+    :param config: Path to currently active config file.
+    :param force: Whether to overwrite output_file if it arleady exists.
+    """
+
+    # Dump to stdout
+    if not output_file:
+        print()
+        with open(config, 'r') as file:
+            for line in file:
+                print(line, end='')
+    else:
+        if os.path.exists(output_file) and not force:
+            raise InvalidStateError(f"File '{output_file}' already exists; aborting.")
+
+        log.info(f"Creating configuration file '{output_file}'")
+        shutil.copy(config, output_file)
+        set_output_ownership(output_file)
+
+
+def splash_config_dump(output_file, force):
+    """Main handler for splash-config dump.
+
+    :param output_file: Filename to write splash config content to.
+    :param force: Whether to overwrite output_file if it already exists.
+    """
+
+    unpacked_kernel_path = find_kernel_in_sysroot()
+    kernel_is_fit = is_file_type_fit(unpacked_kernel_path)
+    log.debug(f"splash: kernel_is_fit={kernel_is_fit}")
+
+    if kernel_is_fit:
+        # FIT case: all changes go to the kernel-changes directory.
+        changes_dir = get_kernel_changes_dir()
+    else:
+        # non-FIT case: changes go to the splash-changes directory.
+        changes_dir = get_splash_changes_dir()
+
+    config_custom = os.path.join(changes_dir, PLYMOUTH_THEME_PATH, PLYMOUTH_CONFIG)
+
+    # First determine whether a customized config is present,
+    # otherwise we use the one from the unpacked image.
+    if os.path.exists(config_custom):
+        config_current = config_custom
+        log.info("Found customized configuration file.")
+    else:
+        config_current = splashconfig_be.get_default_config()
+        log.info("Found default configuration file.")
+
+    create_config(output_file, config_current, force)
+
+
+def do_splash_config_dump(args):
+    """Run 'splash-config dump' command."""
+
+    images_unpack_executed()
+
+    splash_config_dump(args.output_file, args.force)
+
+
+def init_parser(subparsers):
+    """Initialize 'splash-config' subcommands command line interface."""
+
+    parser = subparsers.add_parser(
+        "splash-config",
+        help=("Perform customizations that affect the configuration of the splash "
+              "screen."),
+        allow_abbrev=False)
+    subparsers = parser.add_subparsers(title='Commands', required=True, dest='cmd')
+
+    # splash-config set
+    subparser = subparsers.add_parser(
+        "set",
+        help=("Sets a new Plymouth configuration file as the new configuration."),
+        allow_abbrev=False)
+    subparser.add_argument(
+        dest="splash_config",
+        metavar="SPLASH_CONFIG",
+        help=("File path to the new configuration file."))
+    subparser.set_defaults(func=do_splash_config_set)
+
+    # splash-config dump
+    subparser = subparsers.add_parser(
+        "dump",
+        help=("Prints the current Plymouth configuration."),
+        allow_abbrev=False)
+    subparser.add_argument(
+        "--file",
+        dest="output_file",
+        help=("Writes current Plymouth configuration to the provided file name."),
+        required=False,
+        default=None)
+    subparser.add_argument(
+        "--force",
+        dest="force",
+        default=False, action="store_true",
+        help="Overwrite file designated by '--file' (if it exists).")
+    subparser.set_defaults(func=do_splash_config_dump)

--- a/tcbuilder/cli/tcbuild.template.yaml
+++ b/tcbuilder/cli/tcbuild.template.yaml
@@ -40,8 +40,10 @@ input:
 # >> The customization section defines the modifications to be applied to get
 # >> the desired output image.
 # customization:
-  # >> Splash screen:
+  # >> Splash screen image:
   # splash-screen: custom-splash-screen.png
+  # >> Splash screen configuration:
+  # splash-config: spinner.plymouth
   # >> Directories overlayed to the base OSTree
   # filesystem:
      # - changes/

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -30,6 +30,7 @@ $TESTCASES_DIR/ostree.bats \
 $TESTCASES_DIR/platform.bats \
 $TESTCASES_DIR/push.bats \
 $TESTCASES_DIR/splash.bats \
+$TESTCASES_DIR/splashconfig.bats \
 $TESTCASES_DIR/ubootenv.bats \
 "
 
@@ -40,6 +41,7 @@ $TESTCASES_DIR/wic/images-unpack.bats \
 $TESTCASES_DIR/wic/union.bats \
 $TESTCASES_DIR/wic/deploy.bats \
 $TESTCASES_DIR/wic/splash.bats \
+$TESTCASES_DIR/wic/splashconfig.bats \
 $TESTCASES_DIR/wic/combine.bats \
 $TESTCASES_DIR/wic/build.bats \
 "

--- a/tests/integration/samples/splashconfig/test.plymouth
+++ b/tests/integration/samples/splashconfig/test.plymouth
@@ -1,0 +1,46 @@
+[Plymouth Theme]
+Name=Spinner
+Description=Spinner theme config file for TCB CI/CD.
+ModuleName=two-step
+
+[two-step]
+Font=Cantarell 12
+TitleFont=Cantarell Light 30
+ImageDir=/usr/share/plymouth/themes/spinner
+DialogHorizontalAlignment=.5
+DialogVerticalAlignment=.382
+TitleHorizontalAlignment=.5
+TitleVerticalAlignment=.382
+HorizontalAlignment=0.2
+VerticalAlignment=0.2
+WatermarkHorizontalAlignment=.5
+WatermarkVerticalAlignment=.45
+Transition=none
+TransitionDuration=0.0
+BackgroundStartColor=0x000000
+BackgroundEndColor=0x000000
+ProgressBarBackgroundColor=0x606060
+ProgressBarForegroundColor=0xffffff
+MessageBelowAnimation=true
+
+[updates]
+SuppressMessages=true
+ProgressBarShowPercentComplete=true
+UseProgressBar=true
+_Title=Installing Updates...
+_SubTitle=Do not turn off your computer
+
+[system-upgrade]
+SuppressMessages=true
+ProgressBarShowPercentComplete=true
+UseProgressBar=true
+_Title=Upgrading System...
+_SubTitle=Do not turn off your computer
+
+[firmware-upgrade]
+SuppressMessages=true
+ProgressBarShowPercentComplete=true
+UseProgressBar=true
+UseFirmwareBackground=true
+_Title=Upgrading Firmware...
+_SubTitle=Do not turn off your computer

--- a/tests/integration/testcases/splashconfig.bats
+++ b/tests/integration/testcases/splashconfig.bats
@@ -1,0 +1,119 @@
+bats_load_library 'bats/bats-support/load.bash'
+bats_load_library 'bats/bats-assert/load.bash'
+bats_load_library 'bats/bats-file/load.bash'
+
+@test "splash-config: run without parameters" {
+    run torizoncore-builder splash-config
+    assert_failure
+    assert_output --partial "the following arguments are required"
+}
+
+@test "splash-config: check help output" {
+    run torizoncore-builder splash-config --help
+    assert_success
+    assert_output --partial "Sets a new Plymouth configuration"
+}
+
+@test "splash-config set: without parameters" {
+    run torizoncore-builder splash-config set
+    assert_failure
+    assert_output --partial "the following arguments are required: SPLASH_CONFIG"
+}
+
+@test "splash-config set: check help output" {
+    run torizoncore-builder splash-config set --help
+    assert_success
+    assert_output --partial "File path to the new configuration file"
+}
+
+@test "splash-config set: without images unpack" {
+    torizoncore-builder-clean-storage
+
+    run torizoncore-builder splash-config set foo
+    assert_failure
+    assert_output --partial "Error: could not find an Easy Installer or WIC image in the storage."
+    assert_output --partial "Please use the 'images' command to unpack an image before running this command."
+}
+
+@test "splash-config set: file not found" {
+    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+
+    run torizoncore-builder splash-config set foo
+    assert_failure
+    assert_output --partial "Unable to find configuration file"
+}
+
+@test "splash-config set: standard success case" {
+    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+
+    run torizoncore-builder splash-config set $SAMPLES_DIR/splashconfig/test.plymouth
+    assert_success
+    assert_output --partial "Splash screen configuration updated"
+
+    local STORAGE_DIR="/storage/splash"
+    if [ "${IS_DEFAULT_TEZI_IMAGE_FIT}" != "1" ]; then
+        run torizoncore-builder-shell "ls -l ${STORAGE_DIR}/usr/lib/modules/*/initramfs.img"
+        assert_success
+    else
+        STORAGE_DIR="/storage/kernel"
+        run torizoncore-builder-shell "ls -l ${STORAGE_DIR}/usr/lib/modules/*/vmlinuz"
+        assert_success
+    fi
+
+    run torizoncore-builder-shell "ls -l ${STORAGE_DIR}/usr/share/plymouth/themes/spinner/spinner.plymouth"
+
+    assert_success
+}
+
+@test "splash-config dump: check help output" {
+    run torizoncore-builder splash-config dump --help
+    assert_success
+    assert_output --partial "Writes current Plymouth configuration"
+}
+
+@test "splash-config dump: without images unpack" {
+    torizoncore-builder-clean-storage
+
+    run torizoncore-builder splash-config dump
+    assert_failure
+    assert_output --partial "Error: could not find an Easy Installer or WIC image in the storage."
+    assert_output --partial "Please use the 'images' command to unpack an image before running this command."
+}
+
+@test "splash-config dump: success case default configuration" {
+    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+
+    run torizoncore-builder splash-config dump    
+    assert_success
+    assert_output --partial "Found default configuration file."
+    assert_output --partial "Adoption of official Spinner Theme for"
+}
+
+@test "splash-config dump: success case custom configuration" {
+    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+
+    run torizoncore-builder splash-config set $SAMPLES_DIR/splashconfig/test.plymouth
+    assert_success
+
+    run torizoncore-builder splash-config dump
+    assert_success
+    assert_output --partial "Found customized configuration file."
+    assert_output --partial "Spinner theme config file for TCB"
+}
+
+@test "splash-config dump: success case output to file" {
+    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+
+    run torizoncore-builder splash-config set $SAMPLES_DIR/splashconfig/test.plymouth
+    assert_success
+
+    run torizoncore-builder splash-config dump --file $SAMPLES_DIR/splashconfig/out.plymouth
+    assert_success
+    assert_output --partial "Found customized configuration file."
+    assert_output --partial "Creating configuration file"
+
+    grep "Spinner theme config file for TCB" $SAMPLES_DIR/splashconfig/out.plymouth
+    assert_success
+
+    rm -f $SAMPLES_DIR/splashconfig/out.plymouth
+}

--- a/tests/integration/testcases/torizoncore-builder.bats
+++ b/tests/integration/testcases/torizoncore-builder.bats
@@ -6,7 +6,7 @@ bats_load_library 'bats/bats-file/load.bash'
     run torizoncore-builder
     assert_failure 2
     assert_output --partial 'error: the following arguments are required: '
-    assert_output --partial '{build,bundle,combine,deploy,dt,dto,images,isolate,kernel,ostree,platform,push,secboot,splash,ubootenv,union}'
+    assert_output --partial '{build,bundle,combine,deploy,dt,dto,images,isolate,kernel,ostree,platform,push,secboot,splash,splash-config,ubootenv,union}'
 }
 
 @test "torizoncore-builder: get software version" {

--- a/tests/integration/testcases/wic/splashconfig.bats
+++ b/tests/integration/testcases/wic/splashconfig.bats
@@ -1,0 +1,108 @@
+bats_load_library 'bats/bats-support/load.bash'
+bats_load_library 'bats/bats-assert/load.bash'
+bats_load_library 'bats/bats-file/load.bash'
+
+@test "splash-config: run without parameters" {
+    run torizoncore-builder splash-config
+    assert_failure
+    assert_output --partial "the following arguments are required"
+}
+
+@test "splash-config: check help output" {
+    run torizoncore-builder splash-config --help
+    assert_success
+    assert_output --partial "Sets a new Plymouth configuration"
+}
+
+@test "splash-config set: without parameters" {
+    run torizoncore-builder splash-config set
+    assert_failure
+    assert_output --partial "the following arguments are required: SPLASH_CONFIG"
+}
+
+@test "splash-config set: check help output" {
+    run torizoncore-builder splash-config set --help
+    assert_success
+    assert_output --partial "File path to the new configuration file"
+}
+
+@test "splash-config set: without images unpack" {
+    torizoncore-builder-clean-storage
+
+    run torizoncore-builder splash-config set foo
+    assert_failure
+    assert_output --partial "Error: could not find an Easy Installer or WIC image in the storage."
+    assert_output --partial "Please use the 'images' command to unpack an image before running this command."
+}
+
+@test "splash-config set: file not found" {
+    torizoncore-builder images --remove-storage unpack $DEFAULT_WIC_IMAGE
+
+    run torizoncore-builder splash-config set foo
+    assert_failure
+    assert_output --partial "Unable to find configuration file"
+}
+
+@test "splash-config set: standard success case" {
+    torizoncore-builder images --remove-storage unpack $DEFAULT_WIC_IMAGE
+
+    run torizoncore-builder splash-config set $SAMPLES_DIR/splashconfig/test.plymouth
+    assert_success
+    assert_output --partial "Splash screen configuration updated"
+
+    run torizoncore-builder-shell "ls -l /storage/splash/usr/share/plymouth/themes/spinner/spinner.plymouth"
+    assert_success
+}
+
+@test "splash-config dump: check help output" {
+    run torizoncore-builder splash-config dump --help
+    assert_success
+    assert_output --partial "Writes current Plymouth configuration"
+}
+
+@test "splash-config dump: without images unpack" {
+    torizoncore-builder-clean-storage
+
+    run torizoncore-builder splash-config dump
+    assert_failure
+    assert_output --partial "Error: could not find an Easy Installer or WIC image in the storage."
+    assert_output --partial "Please use the 'images' command to unpack an image before running this command."
+}
+
+@test "splash-config dump: success case default configuration" {
+    torizoncore-builder images --remove-storage unpack $DEFAULT_WIC_IMAGE
+
+    run torizoncore-builder splash-config dump    
+    assert_success
+    assert_output --partial "Found default configuration file."
+    assert_output --partial "Adoption of official Spinner Theme for"
+}
+
+@test "splash-config dump: success case custom configuration" {
+    torizoncore-builder images --remove-storage unpack $DEFAULT_WIC_IMAGE
+
+    run torizoncore-builder splash-config set $SAMPLES_DIR/splashconfig/test.plymouth
+    assert_success
+
+    run torizoncore-builder splash-config dump
+    assert_success
+    assert_output --partial "Found customized configuration file."
+    assert_output --partial "Spinner theme config file for TCB"
+}
+
+@test "splash-config dump: success case output to file" {
+    torizoncore-builder images --remove-storage unpack $DEFAULT_WIC_IMAGE
+
+    run torizoncore-builder splash-config set $SAMPLES_DIR/splashconfig/test.plymouth
+    assert_success
+
+    run torizoncore-builder splash-config dump --file $SAMPLES_DIR/splashconfig/out.plymouth
+    assert_success
+    assert_output --partial "Found customized configuration file."
+    assert_output --partial "Creating configuration file"
+
+    grep "Spinner theme config file for TCB" $SAMPLES_DIR/splashconfig/out.plymouth
+    assert_success
+
+    rm -f $SAMPLES_DIR/splashconfig/out.plymouth
+}

--- a/torizoncore-builder.py
+++ b/torizoncore-builder.py
@@ -26,7 +26,7 @@ import traceback
 
 from tcbuilder.cli import \
     (bundle, build, combine, deploy, dt, dto, images, isolate, kernel, ostree,
-     platform, push, secboot, splash, ubootenv, union)
+     platform, push, secboot, splash, splashconfig, ubootenv, union)
 from tcbuilder.backend.common import set_storage_dir
 
 from tcbuilder.errors import TorizonCoreBuilderError, InvalidArgumentError
@@ -151,6 +151,7 @@ platform.init_parser(subparsers)
 push.init_parser(subparsers)
 secboot.init_parser(subparsers)
 splash.init_parser(subparsers)
+splashconfig.init_parser(subparsers)
 ubootenv.init_parser(subparsers)
 union.init_parser(subparsers)
 


### PR DESCRIPTION
Create new `splash-config` command that can customize the Plymouth configuration file for our splash screen on Torizon OS. Also did some refactoring on the `splash` command so that it can work more smoothly with `splash-config` and any future features that are also related to splash-screen configuration.