### PR TITLE
Introduce support for kernel module building when the kernel is in the FIT format

### DIFF
--- a/tcbuilder/backend/kernel.py
+++ b/tcbuilder/backend/kernel.py
@@ -38,11 +38,11 @@ SET_BOOTARGS_TORIZON_RE = r'^\s*set_bootargs_torizon='
 
 
 def get_kernel_changes_dir(storage_dir):
-    """Return directory containing kernel related changes"""
+    """Return directory containing kernel related changes."""
     return os.path.join(storage_dir, "kernel")
 
 
-def get_kernel_version(linux_src):
+def _kernel_version_from_source(linux_src):
     """Return dictionary with kernel major, minor and revision from source."""
 
     kernel_release_file = os.path.join(linux_src, "include/config/kernel.release")
@@ -57,12 +57,9 @@ def get_kernel_version(linux_src):
     return None
 
 
-# pylint: disable=too-many-locals
-def build_module(src_dir, linux_src, src_mod_dir, image_major_version,
-                 src_ostree_archive_dir, mod_path, kernel_changes_dir):
-    """Build kernel module from source"""
+def _kernel_arch_from_source(linux_src):
+    """Determine ARCH based on linux source."""
 
-    # Figure out ARCH based on linux source
     config = os.path.join(linux_src, ".config")
     with open(config, 'r') as file:
         config_lines = file.read()
@@ -74,27 +71,13 @@ def build_module(src_dir, linux_src, src_mod_dir, image_major_version,
     else:
         assert False, "Architecture could not be determined from .config"
 
-    version_gcc = IMAGE_MAJOR_TO_GCC_MAP.get(image_major_version)
+    return arch
 
-    assert version_gcc, "Unable to determine the GCC toolchain version"
 
-    # Set CROSS_COMPILE and toolchain based on ARCH
-    toolchain_path = os.path.join(os.path.dirname(linux_src), "toolchain")
-    if arch == "arm":
-        c_c = "arm-none-linux-gnueabihf-"
-        toolchain = os.path.join(toolchain_path,
-                                 f"{version_gcc}-x86_64-arm-none-linux-gnueabihf/bin")
-    if arch == "arm64":
-        c_c = "aarch64-none-linux-gnu-"
-        toolchain = os.path.join(toolchain_path,
-                                 f"{version_gcc}-x86_64-aarch64-none-linux-gnu/bin")
+def _amend_makefile(linux_src):
+    """Amend the Linux kernel Makefile to allow building out-of-tree."""
 
-    # Download toolchain if needed
-    if not os.path.exists(toolchain):
-        download_toolchain(c_c, toolchain_path, version_gcc)
-
-    kversion = get_kernel_version(linux_src)
-
+    kversion = _kernel_version_from_source(linux_src)
     if kversion is None:
         raise TorizonCoreBuilderError(
             "Could not determine kernel version of unpacked image. Aborting.")
@@ -106,73 +89,101 @@ def build_module(src_dir, linux_src, src_mod_dir, image_major_version,
             ["sed", "-i", _pattern, f"{linux_src}/Makefile"],
             stderr=subprocess.STDOUT)
 
-    env_path = {
+
+def _get_toolchain(image_major_version, linux_src):
+    arch = _kernel_arch_from_source(linux_src)
+    version_gcc = IMAGE_MAJOR_TO_GCC_MAP.get(image_major_version)
+    assert version_gcc, "Unable to determine the GCC toolchain version"
+
+    # Set CROSS_COMPILE and toolchain based on ARCH
+    toolchain_path = os.path.join(os.path.dirname(linux_src), "toolchain")
+    if arch == "arm":
+        c_c = "arm-none-linux-gnueabihf-"
+        toolchain = os.path.join(
+            toolchain_path, f"{version_gcc}-x86_64-arm-none-linux-gnueabihf/bin")
+    elif arch == "arm64":
+        c_c = "aarch64-none-linux-gnu-"
+        toolchain = os.path.join(
+            toolchain_path, f"{version_gcc}-x86_64-aarch64-none-linux-gnu/bin")
+    else:
+        assert False, "build_module: Unhandled architecture"
+
+    # Download toolchain if needed
+    if not os.path.exists(toolchain):
+        download_toolchain(c_c, toolchain_path, version_gcc)
+
+    return (toolchain, arch, c_c)
+
+
+def _prep_linux_src_for_modules_install(src_ostree_archive_dir, linux_src):
+    """Prepare linux source for modules_install."""
+
+    # TODO: Consider not relying on OSTree / get the version from the map file itself.
+    # Get kernel version for future operations
+    repo = ostree.open_ostree(src_ostree_archive_dir)
+    kernel_version = ostree.get_kernel_version(repo, ostree.OSTREE_BASE_REF)
+    shutil.copyfile(
+        os.path.join(linux_src, f"System.map-{kernel_version}"),
+        os.path.join(linux_src, "System.map"))
+    release_file = os.path.join(linux_src, "include/config/kernel.release")
+    with open(release_file, "w") as file:
+        file.write(kernel_version)
+
+
+def _copy_mod_dir_to_mod_path(src_mod_dir, mod_path):
+    subprocess.check_output(
+        ["cp", "-r", *glob.glob(f"{src_mod_dir}/*"), mod_path],
+        stderr=subprocess.STDOUT)
+    shutil.rmtree(os.path.join(mod_path, "dtb"))
+
+
+def build_module(src_dir, linux_src, src_mod_dir, image_major_version,
+                 src_ostree_archive_dir, mod_path, kernel_changes_dir):
+    """Build kernel module from source."""
+
+    (toolchain, arch, c_c) = _get_toolchain(image_major_version, linux_src)
+    _amend_makefile(linux_src)
+
+    env_vars = {
         **os.environ.copy(),
         "PATH": f"{os.environ['PATH']}:{toolchain}",
+        "KERNEL_SRC": linux_src,
+        "KDIR": linux_src
     }
 
     # Run modules_prepare on kernel source
-    cmd = [
-        "make", "-C", linux_src,
-        f"ARCH={arch}",
-        f"CROSS_COMPILE={c_c}",
-        "modules_prepare",
-    ]
-    subprocess.check_output(cmd, stdin=subprocess.DEVNULL, stderr=subprocess.STDOUT, env=env_path)
+    subprocess.check_output(
+        ["make", "-C", linux_src, f"ARCH={arch}", f"CROSS_COMPILE={c_c}", "modules_prepare"],
+        env=env_vars, stdin=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 
-    # Build kernel module source
+    # Build kernel module in the source directory
     try:
-        extra_env = {
-            **env_path,
-            "KERNEL_SRC": linux_src,
-            "KDIR": linux_src,
-        }
-        cmd = [
-            "make", "-C", src_dir,
-            f"CROSS_COMPILE={c_c}",
-            f"ARCH={arch}",
-        ]
-        subprocess.run(cmd, stderr=subprocess.STDOUT, check=True, env=extra_env)
+        subprocess.run(
+            ["make", "-C", src_dir, f"CROSS_COMPILE={c_c}", f"ARCH={arch}"],
+            env=env_vars, stderr=subprocess.STDOUT, check=True)
         print()
     except subprocess.CalledProcessError as exc:
         raise TorizonCoreBuilderError(f"Error building kernel module(s): {exc}") from exc
     finally:
         set_output_ownership(src_dir)
 
-    # Get kernel version for future operations
-    repo = ostree.open_ostree(src_ostree_archive_dir)
-    kernel_version = ostree.get_kernel_version(repo, ostree.OSTREE_BASE_REF)
-
-    # Prepare linux source for modules_install
-    map_file = os.path.join(linux_src, f"System.map-{kernel_version}")
-    dest = os.path.join(linux_src, "System.map")
-    shutil.copyfile(map_file, dest)
-    release_file = os.path.join(linux_src, "include/config/kernel.release")
-    with open(release_file, 'w') as file:
-        file.write(kernel_version)
+    # Amend some files to allow proper installation
+    _prep_linux_src_for_modules_install(src_ostree_archive_dir, linux_src)
 
     # Copy source module directory to changes directory
-    install_path = os.path.join(kernel_changes_dir, "usr")
-    subprocess.check_output(["cp", "-r", *glob.glob(f"{src_mod_dir}/*"), mod_path],
-                            stderr=subprocess.STDOUT)
-    shutil.rmtree(os.path.join(mod_path, "dtb"))
+    _copy_mod_dir_to_mod_path(src_mod_dir, mod_path)
 
     # Install modules with modules_install
-    cmd = [
-        "make", "-C", linux_src,
-        f"ARCH={arch}",
-        f"CROSS_COMPILE={c_c}",
-        f"M={src_dir}",
-        f"INSTALL_MOD_PATH={install_path}",
-        "INSTALL_MOD_DIR=updates",
-        "modules_install",
-    ]
-    subprocess.check_output(cmd, stderr=subprocess.STDOUT, env=env_path)
+    install_path = os.path.join(kernel_changes_dir, "usr")
+    subprocess.check_output(
+        ["make", "-C", linux_src,
+         f"ARCH={arch}", f"CROSS_COMPILE={c_c}",
+         f"M={src_dir}", f"INSTALL_MOD_PATH={install_path}",
+         "INSTALL_MOD_DIR=updates", "modules_install"],
+        env=env_vars, stderr=subprocess.STDOUT)
 
     # Cleanup kernel source
     shutil.rmtree(linux_src)
-
-# pylint: enable=too-many-locals
 
 
 def autoload_module(module, kernel_changes_dir):

--- a/tcbuilder/backend/kernel.py
+++ b/tcbuilder/backend/kernel.py
@@ -215,9 +215,21 @@ def autoload_module(module, kernel_changes_dir):
     os.makedirs(conf_dir, exist_ok=True)
     module_name = os.path.splitext(os.path.basename(os.path.normpath(module)))[0]
 
+    # Load the modules-load configuration file if one already exists and drop
+    # lines listing the module being added.
     conf_file = os.path.join(conf_dir, "tcb.conf")
-    with open(conf_file, 'a') as file:
-        file.write(f"{module_name} \n")
+    conf_lines = []
+    if os.path.isfile(conf_file):
+        with open(conf_file, "r", encoding="utf-8") as cnfh:
+            conf_lines_ = cnfh.readlines()
+            conf_lines = [
+                _line for _line in conf_lines_ if _line.strip() != module_name
+            ]
+
+    # Add the new module line at the end:
+    conf_lines.append(f"{module_name}\n")
+    with open(conf_file, "w", encoding="utf-8") as cnfh:
+        cnfh.writelines(conf_lines)
 
 
 def download_toolchain(toolchain, toolchain_path, version_gcc):

--- a/tcbuilder/backend/kernel.py
+++ b/tcbuilder/backend/kernel.py
@@ -2,12 +2,11 @@
 Backend functions and functionality for all kernel commands
 """
 
-import glob
-import subprocess
+import logging
 import os
 import re
 import shutil
-import logging
+import subprocess
 import urllib.request
 
 from tcbuilder.backend import ostree, dt
@@ -35,6 +34,11 @@ SET_BOOTARGS_CUSTOM_RE = r'^\s*set_bootargs_custom='
 # Name of the "function" in uEnv.txt responsible for handling boot arguments
 # passed as variables in uEnv.txt.
 SET_BOOTARGS_TORIZON_RE = r'^\s*set_bootargs_torizon='
+
+# List of files/directories under usr/lib/modules/<kver>/ which should not be
+# copied from sysroot to the changes directory when preparing the latter for
+# building modules.
+MOD_DIR_COPY_EXCLUDE_SET = {"dtb"}
 
 
 def get_kernel_changes_dir(storage_dir):
@@ -131,10 +135,28 @@ def _prep_linux_src_for_modules_install(src_ostree_archive_dir, linux_src):
 
 
 def _copy_mod_dir_to_mod_path(src_mod_dir, mod_path):
+    """Copy modules directory to modules path.
+
+    The source directory is supposed to be in the sysroot and, the target, in a
+    "changes" directory. The entries listed in MOD_DIR_COPY_EXCLUDE_SET will be
+    excluded from the copy. Also, files already in the destination, will not be
+    replaced.
+    """
+
+    all_entries = os.listdir(src_mod_dir)
+    flt_entries = [
+        _entry for _entry in all_entries if _entry not in MOD_DIR_COPY_EXCLUDE_SET
+    ]
+    flt_entries_with_path = [
+        os.path.join(src_mod_dir, _entry) for _entry in flt_entries
+    ]
+
+    # Copy files to MOD_PATH; notice the "-n" flag that prevents the overwriting of
+    # files; this is important to keep any other files that might be present at the
+    # destination due to previous customizations.
     subprocess.check_output(
-        ["cp", "-r", *glob.glob(f"{src_mod_dir}/*"), mod_path],
+        ["cp", "-r", "-n", *flt_entries_with_path, mod_path],
         stderr=subprocess.STDOUT)
-    shutil.rmtree(os.path.join(mod_path, "dtb"))
 
 
 def build_module(src_dir, linux_src, src_mod_dir, image_major_version,

--- a/tcbuilder/cli/build.py
+++ b/tcbuilder/cli/build.py
@@ -810,7 +810,8 @@ def do_build(args):
         sys.exit(3)
 
     except (TorizonCoreBuilderError, TeziError) as exc:
-        exc.msg = "Error: " + exc.msg
+        if exc.msg and not exc.msg.lower().startswith("error:"):
+            exc.msg = "Error: " + exc.msg
         raise exc
 
 

--- a/tcbuilder/cli/build.py
+++ b/tcbuilder/cli/build.py
@@ -190,9 +190,6 @@ def handle_customization_section(props, storage_dir=None):
 
     assert storage_dir is not None, "Parameter `storage_dir` must be passed"
 
-    if "secboot" in props:
-        handle_secboot_customization(props["secboot"], storage_dir=storage_dir)
-
     if "splash-screen" in props:
         log.info(l2_pref("Setting splash screen"))
         splash_cli.splash(props["splash-screen"], storage_dir=storage_dir)
@@ -202,6 +199,9 @@ def handle_customization_section(props, storage_dir=None):
 
     if "kernel" in props:
         handle_kernel_customization(props["kernel"], storage_dir=storage_dir)
+
+    if "secboot" in props:
+        handle_secboot_customization(props["secboot"], storage_dir=storage_dir)
 
     # Filesystem changes are actually handled as part of the output processing.
     fs_changes = props.get("filesystem")

--- a/tcbuilder/cli/kernel.py
+++ b/tcbuilder/cli/kernel.py
@@ -11,8 +11,7 @@ import subprocess
 
 import libfdt
 from tcbuilder.errors import \
-    (FileContentMissing, FeatureNotImplementedError, InvalidDataError,
-     PathNotExistError, UnsupportedImageFeature)
+    (FileContentMissing, InvalidDataError, PathNotExistError, UnsupportedImageFeature)
 from tcbuilder.backend.common import \
     (fail_on_raw_image, is_file_type_fit, get_branch_and_major_from_metadata,
      get_tar_compress_program_options, images_unpack_executed)
@@ -124,11 +123,6 @@ def kernel_build_module(source_dir, storage_dir, autoload):
 
     images_unpack_executed(storage_dir)
     fail_on_raw_image(storage_dir, MSG_CUSTOMIZATION_NOT_SUPPORTED_FOR_WIC)
-
-    unpacked_kernel_path = kernel.find_kernel_in_sysroot(storage_dir)
-    if is_file_type_fit(unpacked_kernel_path):
-        raise FeatureNotImplementedError("Kernel customization is not supported for FIT format. "
-                                         "Aborting.")
 
     # Check for valid Makefile
     if not os.path.isdir(source_dir):

--- a/tcbuilder/cli/kernel.py
+++ b/tcbuilder/cli/kernel.py
@@ -68,7 +68,57 @@ def _on_custom_kargs_not_supported():
         "custom kernel arguments; please upgrade to a newer OS image version.")
 
 
-# pylint: disable=too-many-locals
+def _check_makefile(source_dir):
+    """Ensure the Makefile in the module source dir has the required variables."""
+
+    makefile = os.path.join(source_dir, "Makefile")
+    if not os.path.exists(makefile):
+        raise PathNotExistError(f'Makefile "{makefile}" does not exist')
+
+    log.debug("Checking presence of KERNEL_SRC/KDIR in '%s'.", makefile)
+    with open(makefile, "r", encoding="utf-8") as mkfile:
+        lines = mkfile.readlines()
+        kernel_check = None
+        for line in lines:
+            if kernel_check is None:
+                kernel_check = re.search("KERNEL_SRC", line)
+            if kernel_check is None:
+                kernel_check = re.search("KDIR", line)
+            if kernel_check is not None:
+                break
+    if kernel_check is None:
+        raise FileContentMissing(f'KERNEL_SRC not found in "{makefile}"')
+
+
+def _extract_kernel_source(storage_dir):
+    """Find the kernel source tarball in the present image and unpack it.
+
+    The tarball will be unpacked into the storage directory whose path will be
+    returned by the function.
+    """
+
+    # Determine location of linux source tarball.
+    linux_src = subprocess.check_output(
+        ["find", os.path.join(storage_dir, "sysroot/ostree/deploy"),
+         "-type", "f", "-name", "linux.tar.bz2", "-print", "-quit"], text=True)
+    assert linux_src, "panic: missing Linux kernel source!"
+    linux_src = linux_src.rstrip()
+
+    # Unpack the linux source tarball into the storage.
+    log.debug("Unpacking '%s' into storage '%s'", linux_src, storage_dir)
+    tarcmd = [
+        "tar",
+        "-xf", linux_src,
+        "-C", storage_dir,
+    ] + get_tar_compress_program_options(linux_src)
+    subprocess.check_output(tarcmd, stderr=subprocess.STDOUT)
+    extracted_src = os.path.join(storage_dir, "linux")
+    assert os.path.isdir(extracted_src), \
+        "panic: linux source tarball does not contain 'linux/' directory"
+
+    return extracted_src
+
+
 def kernel_build_module(source_dir, storage_dir, autoload):
     """"Main handler of the 'kernel build_module' subcommand"""
 
@@ -81,41 +131,17 @@ def kernel_build_module(source_dir, storage_dir, autoload):
                                          "Aborting.")
 
     # Check for valid Makefile
-    if not os.path.exists(source_dir):
+    if not os.path.isdir(source_dir):
         raise PathNotExistError(f'Source directory "{source_dir}" does not exist')
-
-    makefile = os.path.join(source_dir, "Makefile")
-    if not os.path.exists(makefile):
-        raise PathNotExistError(f'Makefile "{makefile}" does not exist')
-    file = open(makefile, 'r')
-    lines = file.readlines()
-    kernel_check = None
-    for line in lines:
-        if kernel_check is None:
-            kernel_check = re.search("KERNEL_SRC", line)
-        if kernel_check is None:
-            kernel_check = re.search("KDIR", line)
-    if kernel_check is None:
-        raise FileContentMissing(f'KERNEL_SRC not found in "{makefile}"')
+    _check_makefile(source_dir)
 
     # Find and unpack linux source
-    linux_src = subprocess.check_output(
-        ["find", os.path.join(storage_dir, "sysroot/ostree/deploy"),
-         "-type", "f", "-name", "linux.tar.bz2", "-print", "-quit"], text=True)
-    assert linux_src, "panic: missing Linux kernel source!"
-    linux_src = linux_src.rstrip()
-    tarcmd = [
-        "tar",
-        "-xf", linux_src,
-        "-C", storage_dir,
-    ] + get_tar_compress_program_options(linux_src)
-    subprocess.check_output(tarcmd, stderr=subprocess.STDOUT)
-    extracted_src = os.path.join(storage_dir, "linux")
+    extracted_src = _extract_kernel_source(storage_dir)
 
     # Build and install Kernel module
-    kernel_changes_dir = kernel.get_kernel_changes_dir(storage_dir)
-    kernel_subdir = os.path.dirname(dt.get_dtb_kernel_subdir(storage_dir))
-    mod_path = os.path.join(kernel_changes_dir, kernel_subdir)
+    changes_dir = kernel.get_kernel_changes_dir(storage_dir)
+    kernel_subdir = kernel.get_kernel_subdir(storage_dir)
+    mod_path = os.path.join(changes_dir, kernel_subdir)
     os.makedirs(mod_path, exist_ok=True)
     usr_dir = subprocess.check_output(
         ["find", os.path.join(storage_dir, "sysroot/ostree/deploy"),
@@ -123,13 +149,12 @@ def kernel_build_module(source_dir, storage_dir, autoload):
         text=True).rstrip()
     src_mod_dir = os.path.join(os.path.dirname(usr_dir), kernel_subdir)
     src_ostree_archive_dir = os.path.join(storage_dir, "ostree-archive")
-
     _, image_major_version = get_branch_and_major_from_metadata(storage_dir)
 
     src_dir = os.path.abspath(source_dir)
     kernel.build_module(
         src_dir, extracted_src, src_mod_dir, image_major_version,
-        src_ostree_archive_dir, mod_path, kernel_changes_dir)
+        src_ostree_archive_dir, mod_path, changes_dir)
     log.info("Kernel module(s) successfully built and ready to deploy.")
 
     # Set built kernel modules to be autoloaded on boot
@@ -138,17 +163,14 @@ def kernel_build_module(source_dir, storage_dir, autoload):
             ["find", source_dir, "-name", "*.ko", "-print"],
             text=True).splitlines()
         for module in built_modules:
-            kernel.autoload_module(module, kernel_changes_dir)
+            kernel.autoload_module(module, changes_dir)
             log.info(f"{module} is set to be autoloaded on boot.")
 
     log.info("All kernel module(s) have been built and prepared.")
 
-# pylint: enable=too-many-locals
-
 
 def do_kernel_build_module(args):
     """"Run 'kernel build_module' subcommand"""
-
     kernel_build_module(source_dir=args.source_directory,
                         storage_dir=args.storage_directory,
                         autoload=args.autoload)
@@ -572,7 +594,7 @@ def init_parser(subparsers):
         "build_module",
         help="Build the kernel module at the provided source directory.",
         allow_abbrev=False)
-    subparser.add_argument(metavar="SRC_DIR", dest="source_directory", nargs='?',
+    subparser.add_argument(metavar="SRC_DIR", dest="source_directory",
                            help="Path to directory with kernel module source code.")
     subparser.add_argument("--autoload", dest="autoload", action="store_true",
                            help="Configure kernel module to be loaded on startup.")

--- a/tests/integration/testcases/kernel.bats
+++ b/tests/integration/testcases/kernel.bats
@@ -52,41 +52,6 @@ is_uenv_kargs_passing_supported() {
     assert_output --partial "{build_module,set_custom_args,get_custom_args,clear_custom_args}"
 }
 
-@test "kernel build_module: check ownership of output files" {
-    requires-non-fit-kernel
-
-    local MOD_FILE="hello"
-    local MAKEFILE="Makefile"
-    local README="README.md"
-    local SRC_DIR="source_dir"
-
-    mkdir -p "${SRC_DIR}"
-    cp "${SAMPLES_DIR}/kernel/${MOD_FILE}.c" "${SRC_DIR}"
-    cp "${SAMPLES_DIR}/kernel/${MAKEFILE}" "${SRC_DIR}"
-    cp "${SAMPLES_DIR}/kernel/${README}" "${SRC_DIR}"
-
-    torizoncore-builder-shell "chown 10:20 ${SRC_DIR}/${README}"
-    torizoncore-builder images --remove-storage unpack "${DEFAULT_TEZI_IMAGE}"
-
-    run torizoncore-builder kernel build_module "${SRC_DIR}"
-    assert_success
-
-    run ls -ld "${SRC_DIR}/${MOD_FILE}.ko"
-    assert_success
-
-    # Check files ownership as work dir
-    check-file-ownership-as-workdir "${SRC_DIR}/${MOD_FILE}.c"
-    check-file-ownership-as-workdir "${SRC_DIR}/${MOD_FILE}.o"
-    check-file-ownership-as-workdir "${SRC_DIR}/${MOD_FILE}.ko"
-    check-file-ownership-as-workdir "${SRC_DIR}/${MAKEFILE}"
-
-    # Check file with ownership not as "root:root"
-    run ls -dln "${SRC_DIR}/${README}"
-    assert_output --regexp '[ \t]+1[ \t]+10[ \t]+20[ \t]+0'
-
-    torizoncore-builder-shell "rm -rf ${SRC_DIR}"
-}
-
 @test "kernel build_module: run without images unpack" {
     torizoncore-builder-clean-storage
 
@@ -98,17 +63,109 @@ is_uenv_kargs_passing_supported() {
     assert_output --partial "Error: could not find an Easy Installer or WIC image in the storage."
     assert_output --partial "Please use the 'images' command to unpack an image before running this command."
 
-    torizoncore-builder-shell "rm -rf $SRC_DIR"
+    torizoncore-builder-shell "rm -rf ${SRC_DIR}"
 }
 
-@test "kernel build_module: throw error on kernel FIT format" {
-    requires-fit-kernel
+@test "kernel build_module: check success cases" {
+    torizoncore-builder images --remove-storage unpack "${DEFAULT_TEZI_IMAGE}"
 
-    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+    local idx
+    local BLD_MOD_ARGS=("" "--autoload" "" "--autoload")
 
-    run torizoncore-builder kernel build_module $SRC_DIR
-    assert_failure
-    assert_output --partial "not supported for FIT format"
+    # Initial cleanup:
+    for ((idx=0; idx<${#BLD_MOD_ARGS[@]}; idx++)); do
+        local SRC_DIR="source_dir${idx}"
+        torizoncore-builder-shell "rm -rf ${SRC_DIR}"
+    done
+
+    # Build a few versions of the same module:
+    for ((idx=0; idx<${#BLD_MOD_ARGS[@]}; idx++)); do
+        local SRC_DIR="source_dir${idx}"
+
+        # Prepare source directory:
+        mkdir -p "${SRC_DIR}"
+        cp "${SAMPLES_DIR}/kernel/hello.c" "${SRC_DIR}/hello${idx}.c"
+        cp "${SAMPLES_DIR}/kernel/Makefile" "${SRC_DIR}/Makefile"
+        cp "${SAMPLES_DIR}/kernel/README.md" "${SRC_DIR}/README.md"
+        sed -i -e "s#hello\\.o#hello${idx}.o#" "${SRC_DIR}/Makefile"
+
+        torizoncore-builder-shell "chown 10:20 ${SRC_DIR}/README.md"
+
+        echo "Building kernel module in '${SRC_DIR}' with args '${BLD_MOD_ARGS[idx]}'."
+        # shellcheck disable=SC2086
+        run torizoncore-builder kernel build_module ${BLD_MOD_ARGS[idx]} "${SRC_DIR}"
+        assert_success
+
+        run ls -ld "${SRC_DIR}/hello${idx}.ko"
+        assert_success
+
+        # Check files ownership as work dir
+        check-file-ownership-as-workdir "${SRC_DIR}/hello${idx}.c"
+        check-file-ownership-as-workdir "${SRC_DIR}/hello${idx}.o"
+        check-file-ownership-as-workdir "${SRC_DIR}/hello${idx}.ko"
+        check-file-ownership-as-workdir "${SRC_DIR}/Makefile"
+
+        # Check file with ownership not as "root:root"
+        run ls -dln "${SRC_DIR}/README.md"
+        assert_output --regexp '[ \t]+1[ \t]+10[ \t]+20[ \t]+0'
+    done
+
+    # Ensure --autoload flag was honored:
+    echo "Check etc/modules-load.d/tcb.conf contents."
+    run torizoncore-builder-shell \
+        "echo \$(cat /storage/kernel/usr/etc/modules-load.d/tcb.conf)"
+    assert_success
+    assert_output 'hello1 hello3'
+
+    # Determine the kernel/modules directory (relative to the deployment):
+    # shellcheck disable=SC2016
+    run torizoncore-builder-shell \
+        'dpldir=$(cd /storage/sysroot/ostree/deploy/torizon/deploy/*/usr/.. && pwd) && ' \
+        'moddir=$(cd ${dpldir}/usr/lib/modules/* && pwd) && ' \
+        'moddirrel=$(realpath --relative-to="${dpldir}" "${moddir}") && ' \
+        'echo ${moddirrel}'
+    assert_success
+    local moddirrel="${output}"
+
+    # Ensure that the modules have been installed:
+    echo "Check installation of kernel modules."
+    run torizoncore-builder-shell \
+        "echo \$(cd /storage/kernel/${moddirrel}/updates && ls -1 hello*.ko)"
+    assert_success
+    assert_output 'hello0.ko hello1.ko hello2.ko hello3.ko'
+
+    # Check if the same module can be built/installed more than once; here we re-build a
+    # module which was previously built with --autoload and check to see if that switch
+    # was handled correctly (the last auto-loaded module should be listed at the end of
+    # etc/modules-load.d/tcb.conf):
+    local SRC_DIR="source_dir1"
+    echo "Re-building kernel module in '${SRC_DIR}' with args '${BLD_MOD_ARGS[1]}'."
+    # shellcheck disable=SC2086
+    run torizoncore-builder kernel build_module ${BLD_MOD_ARGS[1]} "${SRC_DIR}"
+    assert_success
+    echo "Check etc/modules-load.d/tcb.conf contents again."
+    run torizoncore-builder-shell \
+        "echo \$(cat /storage/kernel/usr/etc/modules-load.d/tcb.conf)"
+    assert_success
+    assert_output 'hello3 hello1'
+
+    # Ensure that files "vmlinuz" (kernel binary) and "overlays.txt" do not get touched
+    # by the command; if they were, then other commands (e.g. "dt", "dto", "splash")
+    # would likely be broken by "kernel build_module".
+    run torizoncore-builder-shell \
+        "echo 'DUMMY_KERNEL' > /storage/kernel/${moddirrel}/vmlinuz && " \
+        "mkdir -p /storage/kernel/${moddirrel}/dtb && " \
+        "echo 'DUMMY_OVERLAYS' > /storage/kernel/${moddirrel}/dtb/overlays.txt"
+    assert_success
+    local SRC_DIR="source_dir0"
+    echo "Re-building kernel module in '${SRC_DIR}' with args '${BLD_MOD_ARGS[0]}'."
+    # shellcheck disable=SC2086
+    run torizoncore-builder kernel build_module ${BLD_MOD_ARGS[0]} "${SRC_DIR}"
+    assert_success
+    run torizoncore-builder-shell \
+        "[ \"\$(cat /storage/kernel/${moddirrel}/vmlinuz)\" = 'DUMMY_KERNEL' ] && " \
+        "[ \"\$(cat /storage/kernel/${moddirrel}/dtb/overlays.txt)\" = 'DUMMY_OVERLAYS' ]"
+    assert_success
 }
 
 @test "kernel {set,get,clear}_custom_args: check basic errors" {

--- a/tests/integration/testcases/kernel.bats
+++ b/tests/integration/testcases/kernel.bats
@@ -60,40 +60,40 @@ is_uenv_kargs_passing_supported() {
     local README="README.md"
     local SRC_DIR="source_dir"
 
-    mkdir -p $SRC_DIR
-    cp $SAMPLES_DIR/kernel/$MOD_FILE.c $SRC_DIR
-    cp $SAMPLES_DIR/kernel/$MAKEFILE $SRC_DIR
-    cp $SAMPLES_DIR/kernel/$README $SRC_DIR
+    mkdir -p "${SRC_DIR}"
+    cp "${SAMPLES_DIR}/kernel/${MOD_FILE}.c" "${SRC_DIR}"
+    cp "${SAMPLES_DIR}/kernel/${MAKEFILE}" "${SRC_DIR}"
+    cp "${SAMPLES_DIR}/kernel/${README}" "${SRC_DIR}"
 
-    torizoncore-builder-shell "chown 10:20 $SRC_DIR/$README"
-    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+    torizoncore-builder-shell "chown 10:20 ${SRC_DIR}/${README}"
+    torizoncore-builder images --remove-storage unpack "${DEFAULT_TEZI_IMAGE}"
 
-    run torizoncore-builder kernel build_module $SRC_DIR
+    run torizoncore-builder kernel build_module "${SRC_DIR}"
     assert_success
 
-    run ls -ld $SRC_DIR/$MOD_FILE.ko
+    run ls -ld "${SRC_DIR}/${MOD_FILE}.ko"
     assert_success
 
     # Check files ownership as work dir
-    check-file-ownership-as-workdir $SRC_DIR/$MOD_FILE.c
-    check-file-ownership-as-workdir $SRC_DIR/$MOD_FILE.o
-    check-file-ownership-as-workdir $SRC_DIR/$MOD_FILE.ko
-    check-file-ownership-as-workdir $SRC_DIR/$MAKEFILE
+    check-file-ownership-as-workdir "${SRC_DIR}/${MOD_FILE}.c"
+    check-file-ownership-as-workdir "${SRC_DIR}/${MOD_FILE}.o"
+    check-file-ownership-as-workdir "${SRC_DIR}/${MOD_FILE}.ko"
+    check-file-ownership-as-workdir "${SRC_DIR}/${MAKEFILE}"
 
     # Check file with ownership not as "root:root"
-    run ls -dln $SRC_DIR/$README
+    run ls -dln "${SRC_DIR}/${README}"
     assert_output --regexp '[ \t]+1[ \t]+10[ \t]+20[ \t]+0'
 
-    torizoncore-builder-shell "rm -rf $SRC_DIR"
+    torizoncore-builder-shell "rm -rf ${SRC_DIR}"
 }
 
 @test "kernel build_module: run without images unpack" {
     torizoncore-builder-clean-storage
 
     local SRC_DIR="source_dir"
-    mkdir -p $SRC_DIR
+    mkdir -p "${SRC_DIR}"
 
-    run torizoncore-builder kernel build_module $SRC_DIR
+    run torizoncore-builder kernel build_module "${SRC_DIR}"
     assert_failure
     assert_output --partial "Error: could not find an Easy Installer or WIC image in the storage."
     assert_output --partial "Please use the 'images' command to unpack an image before running this command."
@@ -129,7 +129,7 @@ is_uenv_kargs_passing_supported() {
     assert_output --partial "Error: could not find an Easy Installer or WIC image in the storage"
     assert_output --partial "Please use the 'images' command to unpack an image before running this command"
 
-    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+    torizoncore-builder images --remove-storage unpack "${DEFAULT_TEZI_IMAGE}"
 
     run torizoncore-builder kernel set_custom_args ""
     assert_failure
@@ -137,15 +137,19 @@ is_uenv_kargs_passing_supported() {
 }
 
 @test "kernel {set,get,clear}_custom_args: check unsupported bootargs passing" {
-    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+    torizoncore-builder images --remove-storage unpack "${DEFAULT_TEZI_IMAGE}"
+
+    local uenv_path
+    local ovl_kargs_supported
+    local uenv_kargs_supported
 
     # Find uEnv.txt in storage:
-    local uenv_path=$(find_uenv_txt_in_sysroot)
+    uenv_path=$(find_uenv_txt_in_sysroot)
     # Determine the supported bootargs passing methods:
-    local ovl_kargs_supported=$(is_ovl_kargs_passing_supported "${uenv_path}" \
-                                && echo "1" || echo "0")
-    local uenv_kargs_supported=$(is_uenv_kargs_passing_supported "${uenv_path}" \
-                                 && echo "1" || echo "0")
+    ovl_kargs_supported=$(is_ovl_kargs_passing_supported "${uenv_path}" \
+                          && echo "1" || echo "0")
+    uenv_kargs_supported=$(is_uenv_kargs_passing_supported "${uenv_path}" \
+                           && echo "1" || echo "0")
     # Show result (for debug):
     echo "ovl_kargs_supported=${ovl_kargs_supported}"
     echo "uenv_kargs_supported=${uenv_kargs_supported}"
@@ -211,15 +215,19 @@ is_uenv_kargs_passing_supported() {
 }
 
 @test "kernel {set,get,clear}_custom_args: check success cases" {
-    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
+    torizoncore-builder images --remove-storage unpack "${DEFAULT_TEZI_IMAGE}"
+
+    local uenv_path
+    local ovl_kargs_supported
+    local uenv_kargs_supported
 
     # Find uEnv.txt in storage:
-    local uenv_path=$(find_uenv_txt_in_sysroot)
+    uenv_path=$(find_uenv_txt_in_sysroot)
     # Determine the supported bootargs passing methods:
-    local ovl_kargs_supported=$(is_ovl_kargs_passing_supported "${uenv_path}" \
-                                && echo "1" || echo "0")
-    local uenv_kargs_supported=$(is_uenv_kargs_passing_supported "${uenv_path}" \
-                                 && echo "1" || echo "0")
+    ovl_kargs_supported=$(is_ovl_kargs_passing_supported "${uenv_path}" \
+                          && echo "1" || echo "0")
+    uenv_kargs_supported=$(is_uenv_kargs_passing_supported "${uenv_path}" \
+                           && echo "1" || echo "0")
     # Show result (for debug):
     echo "ovl_kargs_supported=${ovl_kargs_supported}"
     echo "uenv_kargs_supported=${uenv_kargs_supported}"
@@ -238,7 +246,8 @@ is_uenv_kargs_passing_supported() {
         assert_output --partial "Clearing bootargs (overlay method)"
 
         # Check uEnv.txt to see if the arguments were actually set.
-        local uenv_path_chgsdir=$(find_uenv_txt_in_chgsdir)
+        local uenv_path_chgsdir
+        uenv_path_chgsdir=$(find_uenv_txt_in_chgsdir)
         echo "Checking contents of '${uenv_path_chgsdir}'."
         run torizoncore-builder-shell "grep -e '^torizon_boot_args=arg1=val1 arg2=val2' ${uenv_path_chgsdir}"
         assert_success
@@ -302,7 +311,8 @@ is_uenv_kargs_passing_supported() {
         assert_output --partial "Clearing bootargs (uenv method)"
 
         # Check uEnv.txt to see if the arguments variable was removed.
-        local uenv_path_chgsdir=$(find_uenv_txt_in_chgsdir)
+        local uenv_path_chgsdir
+        uenv_path_chgsdir=$(find_uenv_txt_in_chgsdir)
         echo "Checking contents of '${uenv_path_chgsdir}'."
         run torizoncore-builder-shell "grep -e '^torizon_boot_args=' ${uenv_path_chgsdir}"
         assert_failure


### PR DESCRIPTION
Add support for building kernel modules via `kernel build_module` when kernel is in the FIT format. Besides that, solve some relate bugs found when making the implementation, namely:

- When a module was auto-loaded (via switch --autoload passed to `kernel build_module`) the various module names were accumulating into the `tcb.conf` file.
- The prefix to some error messages were duplicated when running the build command because the command itself added the prefix in some cases.
- The build command was signing the kernel before other customization was performed which resulted in a kernel with not all required nodes being signed (ultimately preventing the boot of a device).

Please check the individual commit messages for details.

Related-to: TCB-763
