### PR TITLE
kernel: Prepend custom kargs with secboot images

### DIFF
--- a/tcbuilder/backend/kernel.py
+++ b/tcbuilder/backend/kernel.py
@@ -33,7 +33,7 @@ SET_BOOTARGS_CUSTOM_RE = r'^\s*set_bootargs_custom='
 
 # Name of the "function" in uEnv.txt responsible for handling boot arguments
 # passed as variables in uEnv.txt.
-SET_BOOTARGS_TORIZON_RE = r'^\s*set_bootargs_torizon='
+SET_BOOTARGS_CUSTOM2_RE = r'^\s*set_bootargs_custom2='
 
 # List of files/directories under usr/lib/modules/<kver>/ which should not be
 # copied from sysroot to the changes directory when preparing the latter for
@@ -354,7 +354,7 @@ def get_supported_bootargs_methods(storage_dir):
     uenv_txt_path = dt.get_current_uenv_txt_path(storage_dir)
     method_re = {
         "overlay": re.compile(SET_BOOTARGS_CUSTOM_RE),
-        "uenv": re.compile(SET_BOOTARGS_TORIZON_RE)
+        "uenv": re.compile(SET_BOOTARGS_CUSTOM2_RE)
     }
     found_methods = set()
     with open(uenv_txt_path, "r") as fhandle:

--- a/tcbuilder/cli/kernel.py
+++ b/tcbuilder/cli/kernel.py
@@ -43,9 +43,12 @@ KERNEL_SET_CUSTOM_ARGS_DTS = """
 # XXX: Always keep in sync with uEnv.txt.in in recipe `u-boot-distro-boot`.
 KERNEL_SET_CUSTOM_ARGS_PROPERTY = 'bootargs_custom'
 
-# Name of the property defining the kernel args in uEnv.txt.
+# Name of the variables in uEnv.txt defining the kernel args; one variable
+# is added to the left (prepended) and the other to the right (appended) of
+# the original bootargs string.
 # XXX: Always keep in sync with uEnv.txt.in in recipe `u-boot-distro-boot`.
-UENV_CUSTOM_BOOTARGS_VAR = "torizon_boot_args"
+UENV_CUSTOM_BOOTARGS_L_VAR = "torizon_bootargs_l"
+UENV_CUSTOM_BOOTARGS_R_VAR = "torizon_bootargs_r"
 
 # Error messages:
 MSG_CUSTOMIZATION_NOT_SUPPORTED_FOR_WIC = \
@@ -194,13 +197,26 @@ def _set_custom_kargs_ovl(kargs, storage_dir):
             storage_dir=storage_dir, allow_reapply=True, test_apply=False)
 
 
-def _set_custom_kargs_uenv(kargs, changes_dir, storage_dir):
+def _set_custom_kargs_uenv(kargs, changes_dir, storage_dir, *, prepend=False):
     """Set the custom bootargs using the (new) uenv method."""
 
     log.debug("Setting bootargs (uenv method).")
-    dt.set_uenv_txt_variable(
-        UENV_CUSTOM_BOOTARGS_VAR, kargs,
-        changes_dir=changes_dir, storage_dir=storage_dir)
+    if prepend:
+        log.debug("Passed string will be prepended to the original bootargs.")
+        dt.set_uenv_txt_variable(
+            UENV_CUSTOM_BOOTARGS_L_VAR, kargs,
+            changes_dir=changes_dir, storage_dir=storage_dir)
+        dt.set_uenv_txt_variable(
+            UENV_CUSTOM_BOOTARGS_R_VAR, None,
+            changes_dir=changes_dir, storage_dir=storage_dir)
+    else:
+        log.debug("Passed string will be appended to the original bootargs.")
+        dt.set_uenv_txt_variable(
+            UENV_CUSTOM_BOOTARGS_L_VAR, None,
+            changes_dir=changes_dir, storage_dir=storage_dir)
+        dt.set_uenv_txt_variable(
+            UENV_CUSTOM_BOOTARGS_R_VAR, kargs,
+            changes_dir=changes_dir, storage_dir=storage_dir)
 
 
 def _secboot_kargs_ovl_present(storage_dir):
@@ -264,7 +280,11 @@ def _get_secboot_required_bootargs_fdt(ovl):
 
 
 def _set_secboot_required_bootargs(kargs, changes_dir, storage_dir):
-    """Set/clear the required-bootargs data inside the kernel FIT image."""
+    """Set/clear the required-bootargs data inside the kernel FIT image.
+
+    The passed kernel bootargs will be prepended to the existing required-bootargs
+    in the secboot overlay.
+    """
 
     log.debug("Trying to %s secboot required-bootargs.",
               ["clear", "set"][kargs is None])
@@ -306,10 +326,10 @@ def _set_secboot_required_bootargs(kargs, changes_dir, storage_dir):
             ovl.resize(ovl.totalsize() + len(req_bootargs_cur) + 128)
             ovl.setprop_str(nodoff, SECBOOT_REQ_BOOTARGS_ORG_PROPNAME, req_bootargs_cur)
             # Define new value (string):
-            req_bootargs_new = req_bootargs_cur + " " + kargs
+            req_bootargs_new = kargs + " " + req_bootargs_cur
         else:
             # Define new value (string) based on the original bootargs:
-            req_bootargs_new = req_bootargs_org + " " + kargs
+            req_bootargs_new = kargs + " " + req_bootargs_org
 
     log.debug("req_bootargs_new='%s'", req_bootargs_new)
 
@@ -370,8 +390,21 @@ def kernel_set_custom_args(kernel_args, storage_dir):
     else:
         changes_dir = dt.get_dt_changes_dir(storage_dir)
 
+    # Determine if the *secboot* kargs overlay is present (not to be confused with
+    # the "custom kargs overlay" which is the old method for passing bootargs). We
+    # use the presence of the overlay to decide whether the passed bootargs should
+    # be prepended or appended to the original secboot bootargs string.
+    sb_kargs_ovl_pres = False
+    if kernel_is_fit:
+        sb_kargs_ovl_pres, _ = _secboot_kargs_ovl_present(storage_dir)
+
     if "uenv" in kargs_methods:
-        _set_custom_kargs_uenv(kargs, changes_dir, storage_dir)
+        if sb_kargs_ovl_pres:
+            log.info(
+                "Warning: because you are customizing a Secure Boot image, the custom "
+                "kernel arguments will be prepended rather than appended to the "
+                "original ones from the base image.")
+        _set_custom_kargs_uenv(kargs, changes_dir, storage_dir, prepend=sb_kargs_ovl_pres)
         _clr_custom_kargs_ovl(storage_dir)
     elif "overlay" in kargs_methods:
         _set_custom_kargs_ovl(kargs, storage_dir)
@@ -380,7 +413,7 @@ def kernel_set_custom_args(kernel_args, storage_dir):
 
     # Secure boot images also keep a "required-bootargs" string inside the kernel
     # which need to be updated; handle this case here.
-    if kernel_is_fit:
+    if kernel_is_fit and sb_kargs_ovl_pres:
         _set_secboot_required_bootargs(kargs, changes_dir, storage_dir)
 
     # Confirm application of arguments.
@@ -420,8 +453,18 @@ def _get_custom_kargs_uenv(storage_dir):
     """Get the custom bootargs using the (new) uenv method."""
 
     log.debug("Getting bootargs (uenv method).")
-    kargs = dt.get_uenv_txt_variable(UENV_CUSTOM_BOOTARGS_VAR, storage_dir=storage_dir)
-    return kargs
+    kargs_l = dt.get_uenv_txt_variable(
+        UENV_CUSTOM_BOOTARGS_L_VAR, storage_dir=storage_dir)
+    kargs_r = dt.get_uenv_txt_variable(
+        UENV_CUSTOM_BOOTARGS_R_VAR, storage_dir=storage_dir)
+    if kargs_l and kargs_r:
+        raise InvalidDataError(
+            "Error: the Torizon OS image you are customizing has both "
+            "'%s' and '%s' set in uEnv.txt which is a case currently not "
+            "supported by TorizonCore Builder." %
+            (UENV_CUSTOM_BOOTARGS_L_VAR, UENV_CUSTOM_BOOTARGS_R_VAR))
+
+    return kargs_l or kargs_r
 
 
 def _get_secboot_required_bootargs(changes_dir, storage_dir):
@@ -470,7 +513,7 @@ def kernel_get_custom_args(storage_dir):
     # +----------+----------+------+
     #
     if kernel_is_fit and "uenv" not in kargs_methods:
-        log.info(
+        log.warning(
             "Notice: this image has a kernel in FIT format but it does not support "
             "the uEnv method for passing kernel arguments; this means you will not "
             "be able to set its custom kernel arguments. This can be solved by "
@@ -518,10 +561,13 @@ def _clr_custom_kargs_uenv(changes_dir, storage_dir):
     """Clear the custom bootargs set using the new method (variables in uEnv.txt)."""
 
     log.debug("Clearing bootargs (uenv method).")
-    status = dt.set_uenv_txt_variable(
-        UENV_CUSTOM_BOOTARGS_VAR, None,
+    status_l = dt.set_uenv_txt_variable(
+        UENV_CUSTOM_BOOTARGS_L_VAR, None,
         changes_dir=changes_dir, storage_dir=storage_dir)
-    return status
+    status_r = dt.set_uenv_txt_variable(
+        UENV_CUSTOM_BOOTARGS_R_VAR, None,
+        changes_dir=changes_dir, storage_dir=storage_dir)
+    return status_l or status_r
 
 
 def kernel_clear_custom_args(storage_dir):

--- a/tests/integration/testcases/kernel.bats
+++ b/tests/integration/testcases/kernel.bats
@@ -35,7 +35,7 @@ is_ovl_kargs_passing_supported() {
 
 is_uenv_kargs_passing_supported() {
     local uenv_path="${1?uEnv.txt path required}"
-    torizoncore-builder-shell "grep -q '^set_bootargs_torizon=' ${uenv_path}"
+    torizoncore-builder-shell "grep -q '^set_bootargs_custom2=' ${uenv_path}"
 }
 
 @test "kernel: run without parameters" {
@@ -214,7 +214,7 @@ is_uenv_kargs_passing_supported() {
     # Change uEnv.txt to pretend that the new bootargs passing method is not supported.
     if [ "${uenv_kargs_supported}" = "1" ]; then
         echo "Removing uenv-based bootargs setting method from uEnv.txt"
-        run torizoncore-builder-shell "sed -i -e '/^set_bootargs_torizon=/d' ${uenv_path}"
+        run torizoncore-builder-shell "sed -i -e '/^set_bootargs_custom2=/d' ${uenv_path}"
         assert_success
     fi
 
@@ -303,30 +303,64 @@ is_uenv_kargs_passing_supported() {
         assert_output --partial "Clearing bootargs (overlay method)"
 
         # Check uEnv.txt to see if the arguments were actually set.
-        local uenv_path_chgsdir
+        local uenv_path_chgsdir check_append
         uenv_path_chgsdir=$(find_uenv_txt_in_chgsdir)
-        echo "Checking contents of '${uenv_path_chgsdir}'."
-        run torizoncore-builder-shell "grep -e '^torizon_boot_args=arg1=val1 arg2=val2' ${uenv_path_chgsdir}"
-        assert_success
+        check_append="1"
 
         if [ "${IS_DEFAULT_TEZI_IMAGE_FIT}" = "1" ]; then
+            echo "Run extra checks for FIT case."
             if echo "${output}" | \
                grep -q "Overlay with secboot required-bootargs found in the kernel"; then
                 # Check if the overlay keeping the required-bootargs was updated.
                 assert_output --regexp "req_bootargs_cur='.*'"
                 refute_output --partial "req_bootargs_cur='None'"
                 assert_output --partial "req_bootargs_org='None'"
-                assert_output --regexp "req_bootargs_new='.* arg1=val1 arg2=val2'"
+                assert_output --regexp "req_bootargs_new='arg1=val1 arg2=val2 .*'"
                 assert_output --partial "Storing updated required-bootargs into the overlay"
                 assert_output --partial "Storing updated overlay into the kernel FIT"
+                assert_output --partial "Passed string will be prepended to the original bootargs"
+                assert_output --regexp "Warning: .*the custom kernel arguments will be prepended"
+                check_append="0"
+            else
+                assert_output --partial "Passed string will be appended to the original bootargs"
             fi
         fi
+
+        if [ "${check_append}" = "1" ]; then
+            echo "Ensure new bootargs were appended to the existing ones."
+            if ! torizoncore-builder-shell \
+                 "grep -e '^torizon_bootargs_r=arg1=val1 arg2=val2' ${uenv_path_chgsdir}"; then
+                fail "New bootargs aren't present in 'torizon_bootargs_r'."
+            fi
+            if torizoncore-builder-shell \
+                   "grep -e '^torizon_bootargs_l=' ${uenv_path_chgsdir}"; then
+                fail "Variable 'torizon_bootargs_l' shouldn't be present in uEnv.txt."
+            fi
+        else
+            echo "Ensure new bootargs were prepended to the existing ones."
+            if ! torizoncore-builder-shell \
+                 "grep -e '^torizon_bootargs_l=arg1=val1 arg2=val2' ${uenv_path_chgsdir}"; then
+                fail "New bootargs aren't present in 'torizon_bootargs_l'."
+            fi
+            if torizoncore-builder-shell \
+                   "grep -e '^torizon_bootargs_r=' ${uenv_path_chgsdir}"; then
+                fail "Variable 'torizon_bootargs_r' shouldn't be present in uEnv.txt."
+            fi
+        fi
+
     elif [ "${ovl_kargs_supported}" = "1" ]; then
-        echo "Checking output of setting custom kernel arguments via overlay method."
-        assert_success
-        assert_output --partial 'Kernel custom arguments successfully configured with "arg1=val1 arg2=val2"'
-        assert_output --partial "Setting bootargs (overlay method)"
-        assert_output --partial "Overlay custom-kargs_overlay.dtbo successfully applied"
+        if [ "${IS_DEFAULT_TEZI_IMAGE_FIT}" = "1" ]; then
+            # Testing with deprecated secboot image (rare).
+            assert_failure
+            assert_output --regexp 'Error: the Torizon OS image you are customizing has a kernel in FIT format but it does not support the uEnv method for passing kernel arguments'
+            return
+        else
+            echo "Checking output of setting custom kernel arguments via overlay method."
+            assert_success
+            assert_output --partial 'Kernel custom arguments successfully configured with "arg1=val1 arg2=val2"'
+            assert_output --partial "Setting bootargs (overlay method)"
+            assert_output --partial "Overlay custom-kargs_overlay.dtbo successfully applied"
+        fi
     else
         # Images without support for custom bootargs should no longer be available;
         # but handle them anyway.
@@ -349,7 +383,7 @@ is_uenv_kargs_passing_supported() {
         if echo "${output}" | \
            grep -q "Overlay with secboot required-bootargs found in the kernel"; then
             # Check if the overlay keeping the required-bootargs was updated.
-            assert_output --regexp "req_bootargs_cur='.* arg1=val1 arg2=val2'"
+            assert_output --regexp "req_bootargs_cur='arg1=val1 arg2=val2 .*'"
             assert_output --regexp "req_bootargs_org='.*'"
             refute_output --regexp "req_bootargs_org='None'"
         fi
@@ -367,13 +401,6 @@ is_uenv_kargs_passing_supported() {
         assert_output --partial 'Custom kernel arguments successfully cleared'
         assert_output --partial "Clearing bootargs (uenv method)"
 
-        # Check uEnv.txt to see if the arguments variable was removed.
-        local uenv_path_chgsdir
-        uenv_path_chgsdir=$(find_uenv_txt_in_chgsdir)
-        echo "Checking contents of '${uenv_path_chgsdir}'."
-        run torizoncore-builder-shell "grep -e '^torizon_boot_args=' ${uenv_path_chgsdir}"
-        assert_failure
-
         if [ "${IS_DEFAULT_TEZI_IMAGE_FIT}" = "1" ]; then
             if echo "${output}" | \
                     grep -q "Overlay with secboot required-bootargs found in the kernel"; then
@@ -387,6 +414,18 @@ is_uenv_kargs_passing_supported() {
                 assert_output --partial "Storing updated overlay into the kernel FIT"
             fi
         fi
+
+        # Check uEnv.txt to see if the arguments variables are gone.
+        local uenv_path_chgsdir
+        uenv_path_chgsdir=$(find_uenv_txt_in_chgsdir)
+        echo "Ensure bootargs variables are not present in '${uenv_path_chgsdir}'."
+        if torizoncore-builder-shell "grep -e '^torizon_bootargs_l=' ${uenv_path_chgsdir}"; then
+            fail "Variable 'torizon_bootargs_l' is present in uEnv.txt after clearing."
+        fi
+        if torizoncore-builder-shell "grep -e '^torizon_bootargs_r=' ${uenv_path_chgsdir}"; then
+            fail "Variable 'torizon_bootargs_r' is present in uEnv.txt after clearing."
+        fi
+
     elif [ "${ovl_kargs_supported}" = "1" ]; then
         echo "Checking output of clearing custom kernel arguments via overlay method."
         assert_success


### PR DESCRIPTION
When detecting that the image has secboot features, we now prepend (rather than append) the custom kargs string to the existing bootargs. This creates a limitation in that users won't be able to override bootargs explicitly set in the base image, but it makes the change in bootargs compatible with the kernel command-line protection feature (which is part of the Toradex hardening features in U-Boot). This relies on the new variables torizon_bootargs_{l,r} provided by the latest boot script (uEnv.txt).

If the image is not a secboot one, the kargs are still appended as usual. This is to keep the behavior exactly as before for non-secboot users, avoiding a breaking change from their perspective.

NOTES:

1. This will need to be rebased after the following PR is merged (DONE):
   * https://github.com/torizon/torizoncore-builder/pull/110
2. The changes will work with secure boot images built after the following PR is merged (DONE):
   * https://github.com/torizon/meta-toradex-torizon/pull/408

~(leaving as draft until the above happens)~
