### PR TITLE
Fix DTO test on TCB images with 'early-access' tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,9 @@ variables:
   ENABLE_XRAY:
     value: "false"
     description: "Whether to send test results to JIRA using XRay"
+  COMMON_TORIZON_ALLOW_FAILURE:
+    value: "false"
+    description: "Whether to allow the pipeline to continue upon failures in Common Torizon tests."
 
   DEBIAN_RELEASE: "bullseye-slim"
   # Pipeline Settings
@@ -372,10 +375,33 @@ test-host-tos7-64bit-signed-nightly:
     - ./run_all.sh --machine $TCB_MACHINE --report --testcase "$TCB_HOST_TESTS"
       --tcb-custom-image "${TCB_IMAGE_UNDER_TEST}"
 
-test-torizoncore-common-intel:
+.test-base-common-torizon:
   variables:
     IS_WIC: 1
+    IMAGE_NAME: torizoncore-builder-amd64
   extends: .test-base
+  rules:
+    # Following condition is needed to avoid the execution of merge-request pipelines.
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    # Following condition prevents execution with custom Torizon OS images (triggered by Jenkins).
+    - if: $BUILD_MACHINE
+      when: never
+    # The following condition allows the pipeline to continue even if tests fail.
+    # In such cases, subsequent steps let the developer decide, at their discretion,
+    # whether to proceed with the release.
+    - if: '$COMMON_TORIZON_ALLOW_FAILURE =~ /^true$/i'
+      when: on_success
+      allow_failure: true
+    - if: '$RELEASE_TYPE == "official"'
+      when: on_success
+      allow_failure: true
+    # In all other cases the pipeline continues only if there no failures.
+    - when: on_success
+      allow_failure: false
+
+test-common-torizon-intel:
+  extends: .test-base-common-torizon
   script:
     - TCB_SKIP_PULL=1 source ./setup.sh
     # TODO: Switch to Bash and use tcb-env-setup.sh script later
@@ -392,10 +418,8 @@ test-torizoncore-common-intel:
     - TCB_REPORT=1 TCB_UNDER_CI=1 TCB_MACHINE=${TCB_MACHINE} ${T} ./run.sh
     - echo -e "\e[0Ksection_end:$(date +%s):test_intel64_section\r\e[0K"
 
-test-torizoncore-common-rasp4:
-  variables:
-    IS_WIC: 1
-  extends: .test-base
+test-common-torizon-rasp4:
+  extends: .test-base-common-torizon
   script:
     # TODO: Since this creates a sub-shell, the environment variables created in setup.sh aren't persisting, because of this 'export TCBCMD' is required
     - TCB_SKIP_PULL=1 source ./setup.sh

--- a/tests/integration/testcases/dto.bats
+++ b/tests/integration/testcases/dto.bats
@@ -192,9 +192,11 @@ bats_load_library 'bats/bats-file/load.bash'
 
     run torizoncore-builder dt apply "${SAMPLES_DIR}/dts/small-nodev.dts"
     run torizoncore-builder dto status
+    # Print command output for debugging purposes
+    echo "${output}"
     assert_success
     assert_output --partial "Enabled overlays over device tree small-nodev.dtb"
-    assert [ "$(echo "${output}" | wc -l)" == 1 ]
+    assert [ "$(echo "${output}" | grep -c -e '^- ')" == 0 ]
 
     run torizoncore-builder dto apply "${SAMPLES_DIR}/dts/sample_overlay.dts" --force
     run torizoncore-builder dto status

--- a/tests/integration/testcases/wic/build.bats
+++ b/tests/integration/testcases/wic/build.bats
@@ -171,7 +171,7 @@ teardown_file() {
 
     ## Bundle with a docker-compose.yml file
     local OUTFILE='bundled_image.wic'
-    run torizoncore-builder build \
+    run torizoncore-builder --log-level debug build \
         --file "$SAMPLES_DIR/config/wic-tcbuild-bundle-compose-customization.yaml" \
         --set INPUT_IMAGE="$DEFAULT_WIC_IMAGE" \
         --set OUTPUT_FILE="$OUTFILE" --force


### PR DESCRIPTION
Fix a test that only fails when running a TorizonCore Builder image with the 'early-access' tag.

This specific tag causes an additional message to be printed to `stderr` when running every command informing that the image is an early-access version. This extra message made the test fail as it only expected the one line of output from the 'dto status' command itself.

Also increase the verbosity level for a WIC build test to facilitate debugging, and add a new `COMMON_TORIZON_ALLOW_FAILURE` boolean variable (`false` by default) that allows the pipeline to continue even if Common Torizon tests fail.