### PR TITLE
 Introduce support for changing the splash screen when the kernel is in the FIT format

### DIFF
--- a/tcbuilder/backend/common.py
+++ b/tcbuilder/backend/common.py
@@ -71,6 +71,8 @@ REMOTE_CMD_TIMEOUT = 90
 
 SECBOOT_ARTIFACTS_DIR = "/storage/secboot_tracked_artifacts"
 
+OSTREE_ROOT_DEPLOY_PATH = "ostree/deploy/torizon/deploy/{csum}"
+
 
 def get_storage_dir():
     """Get the absolute path of the "storage" directory."""

--- a/tcbuilder/backend/initramfs.py
+++ b/tcbuilder/backend/initramfs.py
@@ -1,0 +1,348 @@
+"""
+This module offers the `UnpackedInitramfs` class to manipulate an unpacked initramfs file.
+"""
+
+import logging
+import os
+import subprocess
+import shutil
+import shlex
+
+from tcbuilder.errors import \
+    (InvalidArgumentError, InvalidDataError, PathNotExistError, TorizonCoreBuilderError)
+from tcbuilder.backend.common import \
+    (get_storage_dir, is_file_type_fit, OSTREE_ROOT_DEPLOY_PATH)
+from tcbuilder.backend import kernel as kernel_be
+from tcbuilder.backend import splash as splash_be
+from tcbuilder.backend import ostree
+from tcbuilder.backend.kernelfit import KernelFit
+
+log = logging.getLogger("torizon." + __name__)
+
+MAX_INITRAMFS_FILE_SIZE = 64*1024*1024
+# Initramfs binary has the same root subdir path as the kernel
+OSTREE_INITRAMFS_SUBDIR_PATH = kernel_be.OSTREE_KERNEL_SUBDIR_PATH
+OSTREE_INITRAMFS_FILENAME = "initramfs.img"
+
+UNPACKED_INITRAMFS_DIR = "initramfs_{suffix}"
+
+
+def check_initramfs_data_size(data):
+    """Check if data is above the maximum defined initramfs file size."""
+
+    if len(data) > MAX_INITRAMFS_FILE_SIZE:
+        raise InvalidDataError(
+            f"New initramfs file size of {data/1024:.2f} kiB would exceed "
+            f"limit of {MAX_INITRAMFS_FILE_SIZE/1024:.2f} kiB. Aborting.")
+
+
+def get_initramfs_subdir():
+    """Get the versioned initramfs path."""
+
+    storage_dir = get_storage_dir()
+    src_sysroot_dir = os.path.join(storage_dir, "sysroot")
+    src_sysroot = ostree.load_sysroot(src_sysroot_dir)
+    csum, _ = ostree.get_deployment_info_from_sysroot(src_sysroot)
+    kernel_version = ostree.get_kernel_version(src_sysroot.repo(), csum)
+    return OSTREE_INITRAMFS_SUBDIR_PATH.format(kver=kernel_version)
+
+
+def find_initramfs_in_sysroot():
+    """
+    Find initramfs binary path in the unpacked image sysroot. Raises an error if
+    it cannot find it.
+
+    :returns: String with absolute path of the initramfs binary inside sysroot.
+    """
+
+    storage_dir = get_storage_dir()
+    sysroot_path = os.path.join(storage_dir, "sysroot")
+
+    # As the initramfs path is composed of directories named after the deployment commit and the
+    # kernel version, get them via OSTree metadata.
+    sysroot_obj = ostree.load_sysroot(sysroot_path)
+    csum, _ = ostree.get_deployment_info_from_sysroot(sysroot_obj)
+    kernel_version = ostree.get_kernel_version(sysroot_obj.repo(), csum)
+    # Add deployment index part to checksum string, which is 0 for a new deployment
+    csum += ".0"
+
+    initramfs_path = os.path.join(
+        OSTREE_ROOT_DEPLOY_PATH.format(csum=csum),
+        OSTREE_INITRAMFS_SUBDIR_PATH.format(kver=kernel_version)
+    )
+    initramfs_path = os.path.join(sysroot_path, initramfs_path, OSTREE_INITRAMFS_FILENAME)
+
+    if os.path.isfile(initramfs_path):
+        log.debug(f"Initramfs found at '{initramfs_path}'")
+    else:
+        raise PathNotExistError("Initramfs not found in unpacked sysroot. Aborting.")
+
+    return initramfs_path
+
+
+def find_initramfs_in_changes_dir(changes_dir, basename=None):
+    """Find path of initramfs binary in the given changes directory."""
+
+    initramfs_subdir = get_initramfs_subdir()
+    initramfs_src_dir = os.path.join(changes_dir, initramfs_subdir)
+    initramfs_src_path = os.path.join(initramfs_src_dir, basename or OSTREE_INITRAMFS_FILENAME)
+    if os.path.isfile(initramfs_src_path):
+        log.debug(f"Initramfs found at '{initramfs_src_path}'", )
+    else:
+        log.debug(f"Initramfs not found at '{initramfs_src_path}'")
+        return None
+
+    return initramfs_src_path
+
+
+def _get_initramfs_path(source):
+    """Get initramfs file path according to source"""
+
+    if source == "sysroot":
+        return find_initramfs_in_sysroot(), source
+
+    changes_dir = splash_be.get_splash_changes_dir()
+    changes_path = find_initramfs_in_changes_dir(changes_dir)
+    if source == "auto":
+        if changes_path:
+            return changes_path, "changes"
+        return find_initramfs_in_sysroot(), "sysroot"
+
+    if source == "changes":
+        return changes_path, source
+    raise InvalidArgumentError(f"_get_initramfs_path(): invalid initramfs source '{source}'")
+
+
+def _get_kernel_path(source):
+    """Get kernel file path according to source"""
+
+    if source == "sysroot":
+        return kernel_be.find_kernel_in_sysroot(), source
+
+    changes_dir = kernel_be.get_kernel_changes_dir()
+    changes_path = kernel_be.find_kernel_in_changes_dir(changes_dir)
+    if source == "auto":
+        if changes_path:
+            return changes_path, "changes"
+        return kernel_be.find_kernel_in_sysroot(), "sysroot"
+
+    if source == "changes":
+        return changes_path, source
+    raise InvalidArgumentError(f"_get_kernel_path(): invalid kernel source '{source}'")
+
+
+def extract_initramfs_from_fit(fit):
+    """Extract initramfs data from a FIT object and save it to a file."""
+
+    initramfs_name, initramfs_data = fit.extract_default_ramdisk()
+
+    changes_dir = kernel_be.get_kernel_changes_dir()
+    os.makedirs(changes_dir, exist_ok=True)
+    initramfs_path = os.path.join(changes_dir, initramfs_name)
+    with open(initramfs_path, "wb") as fhandle:
+        fhandle.write(initramfs_data)
+    log.debug(f"Extracted initramfs node '{initramfs_name}' inside FIT to {initramfs_path}")
+    return initramfs_path
+
+
+def stage_kernel_fit(fit):
+    """Create kernel FIT file from given object and save it to be commited."""
+
+    changes_dir = kernel_be.get_kernel_changes_dir()
+    os.makedirs(changes_dir, exist_ok=True)
+    src_path = os.path.join(changes_dir, kernel_be.KERNEL_FIT_FILENAME)
+    log.debug(f"Writing contents to {src_path}")
+    with open(src_path, "wb") as fhandle:
+        fit.write(fhandle)
+
+    # If the new file was created successfully, remove any previous kernel FIT
+    # and move it to its respective union command "staging dir".
+    dst_path = os.path.join(
+        changes_dir,
+        kernel_be.get_kernel_subdir(),
+        kernel_be.KERNEL_FIT_FILENAME
+    )
+    os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+    if os.path.isfile(dst_path):
+        os.remove(dst_path)
+    log.debug(f"Moving {src_path} -> {dst_path}")
+    shutil.move(src_path, dst_path)
+
+
+def stage_initramfs_contents(data):
+    """Create initramfs file from given data and save it to be commited."""
+
+    changes_dir = splash_be.get_splash_changes_dir()
+    os.makedirs(changes_dir, exist_ok=True)
+    src_path = os.path.join(changes_dir, OSTREE_INITRAMFS_FILENAME)
+    log.debug(f"Writing contents to {src_path}")
+    with open(src_path, "wb") as fhandle:
+        fhandle.write(data)
+
+    # If the new file was created successfully, remove any previous initramfs file
+    # and move it to its respective union command "staging dir".
+    dst_path = os.path.join(
+        changes_dir,
+        get_initramfs_subdir(),
+        OSTREE_INITRAMFS_FILENAME
+    )
+    os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+    if os.path.isfile(dst_path):
+        os.remove(dst_path)
+    log.debug(f"Moving {src_path} -> {dst_path}")
+    shutil.move(src_path, dst_path)
+
+
+class UnpackedInitramfs:
+    """
+    Context Manager to handle an initramfs file, or the initramfs contents of a kernel FIT.
+
+    Unpacks a gzipped initramfs obtained according to 'source' and makes the corresponding
+    directory tree path available while inside the runtime context, allowing direct access and
+    modification of its contents e.g. read/add/remove/modify files or directories.
+
+    Once the context ends the unpacked directory tree is packed and gzipped back to a file
+    (or inside the kernel FIT), which is then copied to a "staging directory", ready to be
+    processed by the union command. This step can be skipped by setting the 'repack' variable
+    to 'False'. The unpacked directory is always deleted at the end of the context.
+
+    Args:
+        source: Indicates the location to search for the kernel FIT or initramfs file
+                Possible values are: 'sysroot', 'changes' or 'auto'
+                If the value is set to:
+                - 'sysroot': Only the unpacked sysroot directory will be checked
+                - 'changes': Only the appropriate changes directory will be checked
+                - 'auto': First search in the appropriate changes directory; if the file is
+                          not found there, search in the unpacked sysroot directory.
+
+        repack: Boolean variable that tells whether the unpacked initramfs is repacked and staged
+                at the end of the context. 'True' by default.
+
+    Usage example:
+    --------------------------------------------------------------------------------------------
+    with UnpackedInitramfs(source="auto", repack=True) as irfs_obj:
+        irfs_path = irfs_obj.get_path()
+        # Unpacked initramfs path available (irfs_path) inside this block.
+        # Any file modification made inside irfs_path will be saved once
+        # execution leaves this block of code.
+
+        # While inside the context the value of 'repack' can be changed
+        # at any time if needed.
+        irfs_obj.set_repack(False)
+
+    # Once outside the block, the unpacked initramfs directory will be packed back and staged if
+    # 'repack' is set to 'True'.
+    --------------------------------------------------------------------------------------------
+
+    NOTE: If source is set to 'changes' and no file is found in the corresponding changes
+          directory, the get_path() method will return 'None'.
+          If no file is found for 'sysroot' and 'auto' source types an exception will be thrown
+          during initialization.
+    """
+
+    def __init__(self, source="auto", repack=True):
+
+        log.debug("UnpackedInitramfs: Checking if unpacked OS image kernel is in FIT format")
+        sysroot_kernel_path = kernel_be.find_kernel_in_sysroot()
+        self.kernel_is_fit = is_file_type_fit(sysroot_kernel_path)
+        log.debug(f"UnpackedInitramfs: kernel_is_fit={self.kernel_is_fit}")
+        log.debug(f"UnpackedInitramfs: source={source}")
+        self.fit_obj = None
+        self.src_initramfs_file = None
+        self.repack = repack
+        suffix = ''
+
+        if self.kernel_is_fit:
+            log.debug("UnpackedInitramfs: Searching for kernel FIT to extract initramfs")
+            kernel_fit_path, suffix = _get_kernel_path(source)
+            if kernel_fit_path:
+                with open(kernel_fit_path, "rb") as fhandle:
+                    self.fit_obj = KernelFit(fhandle)
+                self.src_initramfs_file = extract_initramfs_from_fit(self.fit_obj)
+        else:
+            log.debug("UnpackedInitramfs: Searching for initramfs")
+            self.src_initramfs_file, suffix = _get_initramfs_path(source)
+
+        self.unpacked_initramfs_dir = os.path.join(
+            get_storage_dir(),
+            UNPACKED_INITRAMFS_DIR.format(suffix=suffix)
+        )
+
+    def __enter__(self):
+        """Unpack initramfs contents to storage."""
+
+        if not self.src_initramfs_file:
+            log.debug("__enter__(): Unable to find initramfs contents, skipping unpack.")
+            self.unpacked_initramfs_dir = None
+            return self
+
+        log.debug(f"__enter__(): Unpacking initramfs to {self.unpacked_initramfs_dir}")
+        if os.path.isdir(self.unpacked_initramfs_dir):
+            shutil.rmtree(self.unpacked_initramfs_dir)
+        os.makedirs(self.unpacked_initramfs_dir)
+        try:
+            gzip_out = subprocess.check_output(["gzip", "-dc", self.src_initramfs_file])
+            cpio_cmd = [
+                "cpio", "--directory", self.unpacked_initramfs_dir,
+                "--extract", "--make-directories"
+            ]
+            # gzip -dc initramfs.img |
+            # cpio --directory=unpacked_initramfs_dir --extract --make-directories
+            subprocess.check_output(cpio_cmd, input=gzip_out, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as exc:
+            raise TorizonCoreBuilderError(exc.output.strip())
+
+        log.debug(f"__enter__(): Initramfs contents available in {self.unpacked_initramfs_dir}")
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Repack initramfs contents in storage to changes directory."""
+
+        if not self.unpacked_initramfs_dir:
+            log.debug("__exit__(): Unpack not done, nothing to do.")
+            return
+        try:
+            if not self.repack:
+                log.debug(f"__exit__(): Skipping repack of {self.unpacked_initramfs_dir}")
+                return
+            log.debug(f"__exit__(): Repacking {self.unpacked_initramfs_dir}")
+            # cd unpacked_initramfs_dir/ && find . -print | cpio --create --format=newc | gzip
+            find_cmd = "cd {} && find . -print".format(shlex.quote(self.unpacked_initramfs_dir))
+            find_out = subprocess.check_output(find_cmd, shell=True)
+            cpio_cmd = [
+                "cpio", "--directory", self.unpacked_initramfs_dir,
+                "--create", "--format=newc"
+            ]
+            cpio_out = subprocess.check_output(cpio_cmd, input=find_out)
+            gzip_out = subprocess.check_output("gzip", input=cpio_out)
+
+            check_initramfs_data_size(gzip_out)
+
+            if self.kernel_is_fit:
+                # Update fit object with new initramfs contents
+                initramfs_name = os.path.basename(self.src_initramfs_file)
+                log.debug(f"Updating {initramfs_name} with {len(gzip_out)/1024:.2f} "
+                          "kiB in size into FIT image.")
+                self.fit_obj.update_ramdisk(initramfs_name, gzip_out)
+                # Remove old initramfs file extracted from FIT
+                log.debug(f"__exit__(): Removing {self.src_initramfs_file}")
+                os.remove(self.src_initramfs_file)
+                # Stage updated kernel FIT to be commited
+                stage_kernel_fit(self.fit_obj)
+            else:
+                # Stage updated initramfs to be commited
+                log.debug(f"New initramfs file will be {len(gzip_out)/1024:.2f} kiB in size")
+                stage_initramfs_contents(gzip_out)
+        except subprocess.CalledProcessError as exc:
+            raise TorizonCoreBuilderError(exc.output.strip())
+        finally:
+            log.debug(f"__exit__(): Removing directory {self.unpacked_initramfs_dir}")
+            shutil.rmtree(self.unpacked_initramfs_dir)
+
+    def get_path(self):
+        """Get the path where the initramfs was unpacked."""
+        return self.unpacked_initramfs_dir
+
+    def set_repack(self, repack):
+        """Set value of the repack variable."""
+        self.repack = repack

--- a/tcbuilder/backend/kernel.py
+++ b/tcbuilder/backend/kernel.py
@@ -11,7 +11,8 @@ import urllib.request
 
 from tcbuilder.backend import ostree, dt
 from tcbuilder.backend.common import \
-    (get_tar_compress_program_options, get_storage_dir, progress, set_output_ownership)
+    (get_tar_compress_program_options, get_storage_dir,
+     progress, set_output_ownership, OSTREE_ROOT_DEPLOY_PATH)
 from tcbuilder.errors import \
     (TorizonCoreBuilderError, PathNotExistError)
 
@@ -23,8 +24,8 @@ IMAGE_MAJOR_TO_GCC_MAP = {
     7: "arm-gnu-toolchain-13.3.rel1"
 }
 
+OSTREE_KERNEL_SUBDIR_PATH = "usr/lib/modules/{kver}/"
 OSTREE_KERNEL_FILENAME = "vmlinuz"
-OSTREE_KERNEL_DEPLOY_PATH = "ostree/deploy/torizon/deploy/{csum}/usr/lib/modules/{kver}/"
 KERNEL_FIT_FILENAME = OSTREE_KERNEL_FILENAME
 
 # Name of the "function" in uEnv.txt responsible for handling boot arguments
@@ -287,7 +288,10 @@ def find_kernel_in_sysroot():
     # Add deployment index part to checksum string, which is 0 for a new deployment
     csum += ".0"
 
-    kernel_path = OSTREE_KERNEL_DEPLOY_PATH.format(csum=csum, kver=kernel_version)
+    kernel_path = os.path.join(
+        OSTREE_ROOT_DEPLOY_PATH.format(csum=csum),
+        OSTREE_KERNEL_SUBDIR_PATH.format(kver=kernel_version)
+    )
     kernel_path = os.path.join(sysroot_path, kernel_path, OSTREE_KERNEL_FILENAME)
 
     if os.path.isfile(kernel_path):
@@ -310,7 +314,7 @@ def get_kernel_subdir():
     src_sysroot = ostree.load_sysroot(src_sysroot_dir)
     csum, _ = ostree.get_deployment_info_from_sysroot(src_sysroot)
     kernel_version = ostree.get_kernel_version(src_sysroot.repo(), csum)
-    return os.path.join("usr/lib/modules", kernel_version)
+    return OSTREE_KERNEL_SUBDIR_PATH.format(kver=kernel_version)
 
 
 def find_kernel_in_changes_dir(changes_dir, basename=None):
@@ -328,7 +332,7 @@ def find_kernel_in_changes_dir(changes_dir, basename=None):
     return kernel_src_path
 
 
-def copy_kernel_to_changes_dir(changes_dir, basename=None):
+def copy_kernel_to_changes_dir(changes_dir, *, basename=None):
     """Copy kernel FIT image from sysroot to changes directory.
 
     Find kernel in sysroot and copy it to the appropriate subdirectory in the

--- a/tcbuilder/backend/kernelfit.py
+++ b/tcbuilder/backend/kernelfit.py
@@ -19,6 +19,8 @@ DTB_IMAGE_DATA_PROP = "data"
 DTBO_NODE_SUFFIX = ".dtbo"
 DTB_NODE_SUFFIX = ".dtb"
 DEFAULT_DTB_PROP = "default"
+RAMDISK_IMAGE_NAME_PROP = "ramdisk"
+RAMDISK_IMAGE_DATA_PROP = "data"
 
 SIGNATURE_PROPS_TO_DELETE = [
     "hashed-nodes",
@@ -599,6 +601,17 @@ class KernelFit:
         _set_prop(self.fdt, "str",
                   conf_node_path, DEFAULT_DTB_PROP, conf_name)
 
+    def get_default_dtb(self) -> Optional[str]:
+        """Get the default configuration field in the FIT."""
+
+        conf_node_path = self._get_std_node_path("conf")
+        default_dtb = _get_prop(self.fdt, conf_node_path, DEFAULT_DTB_PROP, defval="unset")
+
+        if str(default_dtb) == "unset":
+            log.debug("Default configuration node not set.")
+            return None
+        return default_dtb.as_str()
+
     def extract_dtb(self, file_name: str, *, overlay=False) -> bytearray:
         """Extract the data of a DTB/DTBO entry.
 
@@ -629,6 +642,88 @@ class KernelFit:
         img_data = bytes(img_data)
         return img_data
 
+    def update_ramdisk(self, ramdisk_name: str, data: Union[bytes, bytearray]) -> None:
+        """Update the data contents of a ramdisk node.
+
+        Args:
+            ramdisk_name (str): Name of the ramdisk node to be updated.
+            data (bytes): New data to be written in the node. Any previous data
+                          will be overwritten.
+        """
+
+        ramdisk_path = self._get_std_node_path("image", ramdisk_name)
+
+        if not _node_present(self.fdt, ramdisk_path):
+            raise KernelFitException(
+                f"update_ramdisk: ramdisk path '{ramdisk_path}' does not exist.")
+
+        log.debug("Updating ramdisk entry '%s'.", ramdisk_name)
+        _set_prop(self.fdt, "raw", ramdisk_path, RAMDISK_IMAGE_DATA_PROP, data)
+
+        # Remove relevant properties from hash nodes:
+        for index in range(8):
+            hash_node_name = f"hash-{index}"
+            hash_node_path = self._get_std_node_path("image", ramdisk_name, hash_node_name)
+            if _node_present(self.fdt, ramdisk_path, hash_node_name):
+                for prop_name in HASH_PROPS_TO_DELETE:
+                    _del_prop(self.fdt, hash_node_path, prop_name)
+
+    def extract_ramdisk(self, conf_name: str) -> tuple[str, bytearray]:
+        """Extract the data of a ramdisk entry in a given DTB configuration node.
+
+        Args:
+            conf_name (str): Name of the configuration node.
+
+        :returns: Tuple with the ramdisk node name, and its raw data as a bytearray.
+        """
+        # Check if the given conf node is a DTB one
+        conf_pref_suf = self._get_dtb_conf_pref_suf()
+        if not conf_name.endswith(conf_pref_suf[1]):
+            raise KernelFitException(
+                f"extract_ramdisk: conf_name {conf_name} does not end with "
+                f"'{conf_pref_suf[1]}'.")
+
+        # Check if the configuration path exists
+        config_path = self._get_std_node_path("conf", conf_name)
+        if not _node_present(self.fdt, config_path):
+            raise KernelFitException(
+                f"extract_ramdisk: Configuration path '{config_path}' does not exist.")
+
+        ramdisk_name = _get_prop(
+            self.fdt, config_path, RAMDISK_IMAGE_NAME_PROP)
+        ramdisk_name = ramdisk_name.as_str()
+
+        log.debug("Extracting ramdisk entry '%s'", ramdisk_name)
+        ramdisk_data = _get_prop(
+            self.fdt,
+            self._get_std_node_path("image", ramdisk_name), RAMDISK_IMAGE_DATA_PROP)
+        return ramdisk_name, bytearray(ramdisk_data)
+
+    def extract_default_ramdisk(self) -> tuple[str, bytearray]:
+        """Extract the data of the ramdisk entry of the default configuration node.
+
+        This method will first try to extract the ramdisk entry pointed by the default
+        configuration node if it is set. Otherwise it will extract the ramdisk pointed
+        by the first DTB config node found in get_dtb_list().
+
+        :returns: Tuple with the ramdisk node name, and its raw data as a bytearray.
+        """
+        default_config = self.get_default_dtb()
+
+        if default_config:
+            log.debug("Using default config node '%s' to get the ramdisk data.", default_config)
+            return self.extract_ramdisk(default_config)
+
+        # Default config not set, so use the first DTB config node on the DTB list
+        # We don't want the overlay configs, as those don't have a ramdisk entry
+        dtb_list = self.get_dtb_list()
+        if not dtb_list:
+            raise KernelFitException(
+                "extract_default_ramdisk: Could not find any DTB configuration "
+                "entries in the kernel FIT.")
+        config_node = dtb_list[0]["conf_name"]
+        log.debug("Using configuration node '%s' to get the ramdisk data.", config_node)
+        return self.extract_ramdisk(config_node)
 
 # TODO: Consider creating unit tests.
 #

--- a/tcbuilder/backend/splash.py
+++ b/tcbuilder/backend/splash.py
@@ -5,62 +5,35 @@ Backend for the splash command
 import logging
 import os
 import shutil
-import subprocess
-import shlex
 
-from gi.repository import Gio
-
-from tcbuilder.backend import ostree
-from tcbuilder.errors import TorizonCoreBuilderError
+from tcbuilder.backend.common import get_storage_dir
 
 log = logging.getLogger("torizon." + __name__)
 
+PLYMOUTH_THEME_PATH = "usr/share/plymouth/themes/spinner/"
+PLYMOUTH_SPLASH_FILENAME = "watermark.png"
 
-def create_splash_initramfs(work_dir, image, src_ostree_archive_dir):
-    """Create a initramfs with a splash screen and append it to the current initramfs"""
+def get_splash_changes_dir():
+    """Returns the directory that contains external splash screen related changes."""
 
-    splash_initramfs = "initramfs.splash"
-    splash_initramfs_dir = "usr/share/plymouth/themes/spinner/"
-    rel_splash_initramfs_dir = os.path.join(work_dir, splash_initramfs_dir)  # relative to work_dir
+    storage_dir = get_storage_dir()
+    return os.path.join(storage_dir, "splash")
 
-    if os.path.exists(rel_splash_initramfs_dir):
-        shutil.rmtree(rel_splash_initramfs_dir)
 
-    os.makedirs(rel_splash_initramfs_dir)
-    shutil.copy(image, os.path.join(rel_splash_initramfs_dir, "watermark.png"))
+def add_plymouth_theme_file(root_dir, src_file, dst_filename=None):
+    """Add file in the Plymouth spinner theme directory tree relative to root_dir"""
 
-    # Currently there is no official library for python 3+ to create
-    # cpio archive. So bash commands are to be used
+    plymouth_theme_abspath = os.path.join(root_dir, PLYMOUTH_THEME_PATH)
+    os.makedirs(plymouth_theme_abspath, exist_ok=True)
 
-    # create splash image only initramfs
-    create_initramfs_cmd = "echo {0} | cpio -H newc -D {1} -o | gzip > {2}".format(
-        shlex.quote(os.path.join(splash_initramfs_dir, "watermark.png")),
-        shlex.quote(work_dir), shlex.quote(os.path.join(work_dir, splash_initramfs)))
-    subprocess.check_output(create_initramfs_cmd, shell=True, stderr=subprocess.STDOUT)
+    if dst_filename:
+        plymouth_theme_abspath = os.path.join(plymouth_theme_abspath, dst_filename)
 
-    # get path of initramfs of current deployment inside sysroot
-    repo = ostree.open_ostree(src_ostree_archive_dir)
-    kernel_version = ostree.get_kernel_version(repo, ostree.OSTREE_BASE_REF)
+    log.debug(f"Splash: copying {src_file} -> {plymouth_theme_abspath}")
+    shutil.copy2(src_file, plymouth_theme_abspath)
 
-    # implement cat `ostree cat ref /usr/lib/modules/${kver}/initramfs.img`
-    # /storage/splash/initrmafs.splash > /storage/splash/usr/lib/modules/${kver}/initramfs.img
-    ret, root, _commit = repo.read_commit(ostree.OSTREE_BASE_REF)
-    if not ret:
-        raise TorizonCoreBuilderError(f"Error couldn't reat commit: {ostree.OSTREE_BASE_REF}")
 
-    sub_path = root.resolve_relative_path(os.path.join("usr/lib/modules",
-                                                       kernel_version, "initramfs.img"))
+def add_plymouth_splash_image(root_dir, splash_img):
+    """Add splash image in the Plymouth theme directory tree relative to root_dir"""
 
-    # create directory for storing finalized initramfs
-    os.makedirs(os.path.join(work_dir, "usr/lib/modules", kernel_version))
-
-    initramfs = Gio.File.new_for_path(
-        os.path.join(work_dir, "usr/lib/modules", kernel_version, "initramfs.img")
-        ).create(Gio.FileCreateFlags.NONE, None)
-
-    initramfs.splice(sub_path.read(None), Gio.OutputStreamSpliceFlags.CLOSE_SOURCE, None)
-    initramfs.splice(Gio.File.new_for_path(os.path.join(work_dir, splash_initramfs)).read(None),
-                     Gio.OutputStreamSpliceFlags.CLOSE_SOURCE |
-                     Gio.OutputStreamSpliceFlags.CLOSE_TARGET, None)
-
-    os.remove(os.path.join(work_dir, splash_initramfs))
+    add_plymouth_theme_file(root_dir, splash_img, PLYMOUTH_SPLASH_FILENAME)

--- a/tcbuilder/cli/splash.py
+++ b/tcbuilder/cli/splash.py
@@ -4,15 +4,16 @@ CLI for the splash command
 
 import argparse
 import os
-import shutil
 import logging
 
 from tcbuilder.errors import \
-    (InvalidArgumentError, FeatureNotImplementedError, PathNotExistError)
+    (InvalidArgumentError, PathNotExistError)
 from tcbuilder.backend import splash as splash_be
-from tcbuilder.backend import kernel as kernel_be
+from tcbuilder.backend.kernel import \
+    (find_kernel_in_sysroot, get_kernel_changes_dir)
+from tcbuilder.backend.initramfs import UnpackedInitramfs
 from tcbuilder.backend.common import \
-    (get_storage_dir, images_unpack_executed, is_file_type_fit)
+    (images_unpack_executed, is_file_type_fit)
 
 log = logging.getLogger("torizon." + __name__)  # use name hierarchy for "main" to be the parent
 
@@ -25,25 +26,28 @@ def splash(splash_image):
         PathNotExistError: If could not find the splash image file.
     """
 
-    storage_dir = get_storage_dir()
-    unpacked_kernel_path = kernel_be.find_kernel_in_sysroot()
-    if is_file_type_fit(unpacked_kernel_path):
-        raise FeatureNotImplementedError("Changing the splash screen is not supported for kernel "
-                                         "in FIT format. Aborting.")
-
-    work_dir = os.path.join(storage_dir, "splash")
-    if os.path.exists(work_dir):
-        shutil.rmtree(work_dir)
-    os.mkdir(work_dir)
-
-    splash_image = os.path.abspath(splash_image)
-    if not os.path.exists(splash_image):
+    splash_abspath = os.path.abspath(splash_image)
+    if not os.path.isfile(splash_abspath):
         raise PathNotExistError(f"Unable to find splash image {splash_image}")
 
-    src_ostree_archive_dir = os.path.join(storage_dir, "ostree-archive")
+    with UnpackedInitramfs(source="auto") as rdm:
+        splash_be.add_plymouth_splash_image(rdm.get_path(), splash_abspath)
 
-    splash_be.create_splash_initramfs(work_dir, splash_image, src_ostree_archive_dir)
-    log.info("splash screen merged to initramfs")
+    log.info("Initramfs splash screen updated")
+
+    unpacked_kernel_path = find_kernel_in_sysroot()
+    kernel_is_fit = is_file_type_fit(unpacked_kernel_path)
+    log.debug(f"splash: kernel_is_fit={kernel_is_fit}")
+
+    if kernel_is_fit:
+        # FIT case: all changes go to the kernel-changes directory.
+        changes_dir = get_kernel_changes_dir()
+    else:
+        # non-FIT case: changes go to the splash-changes directory.
+        changes_dir = splash_be.get_splash_changes_dir()
+
+    splash_be.add_plymouth_splash_image(changes_dir, splash_abspath)
+    log.info("Sysroot splash screen updated")
 
 
 def do_splash(args):

--- a/tests/integration/functions.sh
+++ b/tests/integration/functions.sh
@@ -252,6 +252,13 @@ requires-signed-image() {
 }
 export -f requires-signed-image
 
+requires-unsigned-image() {
+    if [ -n "${DEFAULT_SIGNED_TEZI_IMAGE}" ]; then
+        skip "Unsupported test for signed images"
+    fi
+}
+export -f requires-unsigned-image
+
 requires-supported-kernel-signing-machine() {
     if [ "${IS_KERNEL_SIGNING_SUPPORTED}" != "1" ]; then
         skip "machine not supported"

--- a/tests/integration/testcases/build.bats
+++ b/tests/integration/testcases/build.bats
@@ -245,8 +245,7 @@ teardown_file() {
     rm -rf "${CST_DIR}/linux64"
 }
 
-@test "build: full customization checked on host (non-FIT)" {
-    requires-non-fit-kernel
+@test "build: full customization checked on host" {
     requires-image-version "$DEFAULT_TEZI_IMAGE" "5.3.0"
 
     local OUTDIR='fully_customized_image'
@@ -256,7 +255,7 @@ teardown_file() {
         --set OUTPUT_DIR="$OUTDIR" --force
 
     assert_success
-    assert_output --partial 'splash screen merged'
+    assert_output --partial 'splash screen updated'
     assert_output --partial 'Overlay sample_overlay.dtbo successfully applied.'
     local bootargs_methods="$(echo $output | sed -nE 's#^.*Supported bootargs passing methods: (.*)$#\1#p')"
     case "$bootargs_methods" in
@@ -327,21 +326,6 @@ teardown_file() {
     assert_output --partial "['$COMMIT']"
 }
 
-@test "build: full customization checked on host (FIT)" {
-    requires-fit-kernel
-    requires-image-version "$DEFAULT_TEZI_IMAGE" "5.3.0"
-
-    local OUTDIR='fully_customized_image'
-    run torizoncore-builder build \
-        --file "$SAMPLES_DIR/config/tcbuild-full-customization.yaml" \
-        --set INPUT_IMAGE="$DEFAULT_TEZI_IMAGE" \
-        --set OUTPUT_DIR="$OUTDIR" --force
-
-    assert_failure
-    assert_output --partial \
-	'Error: Changing the splash screen is not supported for kernel in FIT format'
-}
-
 # bats test_tags=requires-device
 @test "build: full customization checked on device" {
     requires-image-version "$DEFAULT_TEZI_IMAGE" "5.3.0"
@@ -354,7 +338,7 @@ teardown_file() {
         --set OUTPUT_DIR="$OUTDIR" --force
 
     assert_success
-    assert_output --partial 'splash screen merged'
+    assert_output --partial 'splash screen updated'
     assert_output --partial 'Overlay sample_overlay.dtbo successfully applied.'
     local bootargs_methods="$(echo $output | sed -nE 's#^.*Supported bootargs passing methods: (.*)$#\1#p')"
     case "$bootargs_methods" in

--- a/tests/integration/testcases/build.bats
+++ b/tests/integration/testcases/build.bats
@@ -329,6 +329,12 @@ teardown_file() {
 # bats test_tags=requires-device
 @test "build: full customization checked on device" {
     requires-image-version "$DEFAULT_TEZI_IMAGE" "5.3.0"
+
+    # Images with a signed bootloader will not boot after the customization
+    # if the kernel is not re-signed with the key expected by the bootloader.
+    # Since we can't change the bootloader installed on the device,
+    # don't run the test for signed images
+    requires-unsigned-image
     requires-device
 
     local OUTDIR='fully_customized_image'

--- a/tests/integration/testcases/splash.bats
+++ b/tests/integration/testcases/splash.bats
@@ -40,26 +40,23 @@ bats_load_library 'bats/bats-file/load.bash'
 }
 
 @test "splash: create splash" {
-    requires-non-fit-kernel
-
     torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
 
     run torizoncore-builder splash $SAMPLES_DIR/splash/fast-banana.png
     assert_success
-    assert_output --partial "splash screen merged to initramfs"
+    assert_output --partial "Initramfs splash screen updated"
+    assert_output --partial "Sysroot splash screen updated"
 
-    run torizoncore-builder-shell "ls -l /storage/splash/usr/lib/modules/*/initramfs.img"
+    local STORAGE_DIR="/storage/splash"
+    if [ "${IS_DEFAULT_TEZI_IMAGE_FIT}" != "1" ]; then
+        run torizoncore-builder-shell "ls -l ${STORAGE_DIR}/usr/lib/modules/*/initramfs.img"
+        assert_success
+    else
+        STORAGE_DIR="/storage/kernel"
+        run torizoncore-builder-shell "ls -l ${STORAGE_DIR}/usr/lib/modules/*/vmlinuz"
+        assert_success
+    fi
+
+    run torizoncore-builder-shell "ls -l ${STORAGE_DIR}/usr/share/plymouth/themes/spinner/watermark.png"
     assert_success
-
-    run torizoncore-builder-shell "ls -l /storage/splash/usr/share/plymouth/themes/spinner/watermark.png"
-    assert_success
-}
-
-@test "splash: throw error on kernel FIT format" {
-    requires-fit-kernel
-
-    torizoncore-builder images --remove-storage unpack $DEFAULT_TEZI_IMAGE
-    run torizoncore-builder splash $SAMPLES_DIR/splash/fast-banana.png
-    assert_failure
-    assert_output --partial "not supported for kernel in FIT format"
 }

--- a/tests/integration/testcases/wic/build.bats
+++ b/tests/integration/testcases/wic/build.bats
@@ -106,7 +106,7 @@ teardown_file() {
         --set OUTPUT_FILE="$OUTFILE" --force
 
     assert_success
-    assert_output --partial 'splash screen merged'
+    assert_output --partial 'splash screen updated'
     assert_output --partial 'Deploying commit ref: my-raw-image-branch'
     assert_output --partial "created successfully"
 
@@ -142,7 +142,7 @@ teardown_file() {
         --set OUTPUT_FILE="$OUTFILE" --force
 
     assert_success
-    assert_output --partial 'splash screen merged'
+    assert_output --partial 'splash screen updated'
     assert_output --partial 'Deploying commit ref: my-raw-image-branch'
     assert_output --partial "created successfully"
     assert_output --partial "Copying docker-compose.yml"
@@ -177,7 +177,7 @@ teardown_file() {
         --set OUTPUT_FILE="$OUTFILE" --force
 
     assert_success
-    assert_output --partial 'splash screen merged'
+    assert_output --partial 'splash screen updated'
     assert_output --partial 'Deploying commit ref: my-raw-image-branch'
     assert_output --partial "created successfully"
     assert_output --partial "Copying docker-compose.yml"

--- a/tests/integration/testcases/wic/splash.bats
+++ b/tests/integration/testcases/wic/splash.bats
@@ -44,7 +44,8 @@ bats_load_library 'bats/bats-file/load.bash'
 
     run torizoncore-builder splash $SAMPLES_DIR/splash/fast-banana.png
     assert_success
-    assert_output --partial "splash screen merged to initramfs"
+    assert_output --partial "Initramfs splash screen updated"
+    assert_output --partial "Sysroot splash screen updated"
 
     run torizoncore-builder-shell "ls -l /storage/splash/usr/lib/modules/*/initramfs.img"
     assert_success


### PR DESCRIPTION
Similarly to previous implementations to support FIT kernel images for other commands like "dt" and "dto", TCB applies the corresponding modifications to the "kernel" changes directory if it detects that the unpacked image has the kernel in FIT format, including related artifacts like the PNG image path.

These modifications would be applied in a "union" command just like the current implementation for non-FIT images. The general workflow to use the "splash" command with FIT images should be basically identical to non-FIT ones, as well as its corresponding entry in tcbuild.yaml when using the "build" command.

Related-to: TCB-757

---

~~Basic implementation is done but I still need to update the tests, so I'm leaving this as a draft PR for now.~~

I've updated the tests, so the PR is now ready for review.