### PR TITLE
gitlab-ci: review the Docker tags of CI jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,11 +1,6 @@
 include:
   - "/tests/integration/aval/aval-tests.yml"
 
-# TODO: GitLab's documentation recommends specifying a version:
-#       See https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-docker-in-docker
-#       Also in the services attribute.
-image: docker:latest
-
 variables:
   RELEASE_TYPE:
     value: "official"
@@ -18,6 +13,8 @@ variables:
     description: "Whether to allow the pipeline to continue upon failures in Common Torizon tests."
 
   DEBIAN_RELEASE: "bullseye-slim"
+  # This Docker version should be bumped to latest Docker version at the end of the release process
+  DOCKER_VERSION: "28.5.2"
   # Pipeline Settings
   GIT_CLONE_PATH: $CI_BUILDS_DIR/$CI_CONCURRENT_ID/$CI_PROJECT_PATH
   GET_SOURCES_ATTEMPTS: 3
@@ -63,8 +60,10 @@ default:
   tags:
     - saas-linux-small-amd64
 
+image: docker:$DOCKER_VERSION
+
 services:
-  - name: docker:dind
+  - name: docker:$DOCKER_VERSION-dind
 
 stages:
   - pre-build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,7 +82,9 @@ lint-dockerfiles:
     - if: $CI_PIPELINE_SOURCE == "trigger"
       when: never
     - when: on_success
-  image: hadolint/hadolint:latest-debian
+  image:
+    name: hadolint/hadolint:latest-debian
+    pull_policy: always
   script:
     # Some rules cannot be applied in our specific cases.
     # However, since we don't want to completely ignore these rules,
@@ -480,7 +482,9 @@ test-torizoncore:
 
 aggregate-reports:
   stage: report
-  image: homebrew/brew
+  image:
+    name: homebrew/brew
+    pull_policy: always
   rules:
     # Following condition is needed to avoid the execution of merge-request pipelines.
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'


### PR DESCRIPTION
This change explicitly sets "pull_policy: always" for the GitLab CI jobs that use Docker images with tag "latest".

Since latest is a mutable tag that can change over time, it is necessary to always pull the image to guarantee that the pipeline actually runs with the most up-to-date Docker version. Relying on implicit defaults could result in stale images being reused, leading to non-obvious and hard-to-debug behavior.

By explicitly defining "pull_policy: always", the CI configuration becomes clearer, more deterministic, and aligned with the semantics of mutable image tags.

Related-to: TOR-4180