### PR TITLE
bundle: Allow container bundling on overlayfs

### DIFF
--- a/tcbuilder/backend/bundle.py
+++ b/tcbuilder/backend/bundle.py
@@ -174,12 +174,12 @@ class DindManager(DockerManager):
         self.host_client = docker.from_env()
 
         storage_driver = self.host_client.info()["Driver"]
-        if storage_driver != "overlay2":
+        if storage_driver not in ["overlay2", "overlayfs"]:
             raise InvalidStorageDriverError(
-                f"Error: Incompatible Docker Storage Driver '{storage_driver}'; "
-                "only 'overlay2' is currently supported.\nLearn more on "
-                "https://developer.toradex.com/software/torizon/"
-                "torizoncore-builder-issue-tracker?issue=TCB-328")
+                f'Error: Incompatible Docker Storage Driver "{storage_driver}"; '
+                'only "overlay2" and "overlayfs" are currently supported.\nLearn '
+                'more on https://developer.toradex.com/software/torizon/'
+                'torizoncore-builder-issue-tracker?issue=TCB-328')
 
         self.network = None
 


### PR DESCRIPTION
Ported from trixie:

Allow the bundle command to run if the storage driver of the base system (where DinD in running) is "overlayfs" (in addition to the previously supported "overlay2" driver).

Related-to: TCB-841
Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
