### PR TITLE
Expand raw disk images when combining large container images

### DIFF
--- a/tcbuilder/backend/combine.py
+++ b/tcbuilder/backend/combine.py
@@ -9,11 +9,12 @@ import re
 import datetime
 
 import fnmatch
+import subprocess
 
 from tezi.image import ImageConfig
 from tcbuilder.backend.common import \
     (set_output_ownership, check_licence_acceptance, run_with_loading_animation,
-     open_disk_image, DOCKER_BUNDLE_TARNAME)
+     open_disk_image, get_tar_compress_program_options, DOCKER_BUNDLE_TARNAME)
 from tcbuilder.errors import InvalidStateError, InvalidDataError, TorizonCoreBuilderError
 
 log = logging.getLogger("torizon." + __name__)
@@ -24,6 +25,7 @@ DOCKER_FILES_TO_ADD = [
     TARGET_NAME_FILENAME + ":/ostree/deploy/torizon/var/sota/storage/docker-compose/"
 ]
 DOCKER_STORAGE_DESTINATION = "/ostree/deploy/torizon/var/lib/docker/"
+DOCKER_STORAGE_DIRNAME = "docker-storage"
 
 TEZI_PROPS = [
     "name",
@@ -44,6 +46,14 @@ TAR_EXT_TO_COMPRESSION_TYPE = {
     ".lzo": "lzop",
     ".tar": None
 }
+
+# Disk size increase factor on top of filesystem size increase
+DISK_INCREASE_FACTOR = 1.20
+# Fixed disk size increase
+DISK_FIXED_INCREASE_KB = 200*1024 # 200 MiB
+# Maximum allowed ratio between required and available root filesystem space.
+# If higher than that, the disk size will be increased.
+MAX_REQ_AVAIL_RATIO = 0.98
 
 
 def check_docker_storage_file(bundle_dir):
@@ -200,7 +210,7 @@ def combine_single_tezi_image(bundle_dir, files_to_add, output_dir, tezi_props):
     return update_tezi_files(output_dir, tezi_props, files_to_add)
 
 
-def check_combine_files(bundle_dir):
+def check_combine_files(bundle_dir, *, untar_storage=False):
     """
     Verify if the bundle directory has the required files, and optionally unpack the docker
     storage tarfile.
@@ -225,7 +235,10 @@ def check_combine_files(bundle_dir):
 
         docker_storage_filename = check_docker_storage_file(bundle_dir)
         if docker_storage_filename is not None:
-            files_to_add.append(f"{docker_storage_filename}:{DOCKER_STORAGE_DESTINATION}:true")
+            if untar_storage:
+                unpack_docker_storage(docker_storage_filename, files_to_add, bundle_dir)
+            else:
+                files_to_add.append(f"{docker_storage_filename}:{DOCKER_STORAGE_DESTINATION}:true")
         else:
             log.error("Error: %s not found in bundle directory.", DOCKER_BUNDLE_TARNAME)
             return None
@@ -321,7 +334,7 @@ def combine_raw_image(image_path, bundle_dir, output_path, rootfs_label, force):
 
     log.info("Combining Torizon OS image with Docker Container bundle.")
 
-    files_to_add = check_combine_files(bundle_dir)
+    files_to_add = check_combine_files(bundle_dir, untar_storage=True)
 
     if not files_to_add:
         if delete_on_error and os.path.isfile(output_path):
@@ -329,10 +342,89 @@ def combine_raw_image(image_path, bundle_dir, output_path, rootfs_label, force):
             os.remove(output_path)
         raise TorizonCoreBuilderError("Some required bundle files were not found. Aborting.")
 
+    req_space_kb = get_bundle_size_kb(files_to_add, bundle_dir)
+
     with open_disk_image(output_path, delete_on_error=delete_on_error) as gfs:
         root_partition = gfs.findfs_label(rootfs_label)
         gfs.mount(root_partition, "/")
+        statvfs_dict = gfs.statvfs("/")
+        root_avail_kb = statvfs_dict['bsize'] * statvfs_dict['bavail'] / 1024
+
+        log.info(f"Required free space in root filesystem: {req_space_kb/1024:.2f} MiB")
+        log.info(f"Available space in root filesystem: {root_avail_kb/1024:.2f} MiB")
+
+        req_avail_ratio = req_space_kb / root_avail_kb
+        if req_avail_ratio <= MAX_REQ_AVAIL_RATIO:
+            # Contents fit in root filesystem, add them and return
+            copy_to_mounted_root(gfs, files_to_add, bundle_dir)
+            return
+
+    # Contents don't fit (or barely fit) in root filesystem, disk needs to be increased.
+    extra_disk_size_kb = DISK_FIXED_INCREASE_KB
+    if req_avail_ratio > 1:
+        extra_disk_size_kb += int((req_space_kb - root_avail_kb) * DISK_INCREASE_FACTOR)
+
+    log.info(f"Output disk will be increased by {extra_disk_size_kb/1024:.2f} MiB")
+    subprocess.check_output(["truncate", "-s", f"+{extra_disk_size_kb}K", output_path])
+
+    tmp_image = None
+    if output_path == image_path:
+        # The build command uses in-place modification.
+        # virt-resize doesn't support that, so we need to create a temporary copy.
+        tmp_image = output_path + ".not_bundled"
+        log.debug("Copying '%s' -> '%s' for virt-resize.", output_path, tmp_image)
+        shutil.copyfile(output_path, tmp_image)
+        image_path = tmp_image
+
+    try:
+        expand_disk_partition(image_path, root_partition, output_path)
+    finally:
+        if tmp_image and os.path.isfile(tmp_image):
+            log.debug("Deleting '%s'", tmp_image)
+            os.remove(tmp_image)
+
+    with open_disk_image(output_path, delete_on_error=delete_on_error) as gfs:
+        gfs.mount(root_partition, "/")
         copy_to_mounted_root(gfs, files_to_add, bundle_dir)
+
+
+def expand_disk_partition(src_image, src_partition, dst_image):
+    """
+    Using virt-resize, expand a given partition on src_image and copy the end result into
+    dst_image. The expanded partition will fill any extra disk space in dst_image.
+
+    virt-resize will automatically resize ext4 filesystems after expanding the partition.
+    """
+
+    log.info("Starting virt-resize...")
+    print("------------------------------------------------------------")
+    expandcmd = ["virt-resize", "--format", "raw", "--expand"]
+    expandcmd.extend([src_partition, src_image, dst_image])
+    subprocess.run(expandcmd, check=True)
+    print("------------------------------------------------------------")
+
+
+def get_bundle_size_kb(files_to_add, src_dir):
+    """Get total size of files/directories in a files_to_add list from a source directory."""
+
+    size_kb = 0
+    for src_dest_untar in files_to_add:
+        src_dest_untar = src_dest_untar.split(":")
+        filename = src_dest_untar[0]
+        file_path = os.path.join(src_dir , filename)
+
+        if not os.path.exists(file_path):
+            raise InvalidDataError(f'Error: "{filename}" not found in "{src_dir}". Aborting.')
+
+        if os.path.isdir(file_path):
+            filesize_kb = subprocess.check_output(["du", "-s", file_path], text=True)
+            filesize_kb = int(filesize_kb.split('\t', maxsplit=1)[0])
+        else:
+            filesize_kb = os.path.getsize(file_path) / 1024
+
+        size_kb += filesize_kb
+
+    return size_kb
 
 
 def copy_to_mounted_root(gfs, files_to_add, contents_dir):
@@ -370,3 +462,27 @@ def copy_to_mounted_root(gfs, files_to_add, contents_dir):
                 func=gfs.copy_in,
                 args=(os.path.join(contents_dir, src), dest),
                 loading_msg=f"  Copying {src} to {dest} ...")
+
+
+def unpack_docker_storage(docker_storage_filename, files_to_add, bundle_dir):
+    """Unpack the docker storage tarfile and add its contents to the files_to_add list."""
+
+    docker_storage_path = os.path.join(bundle_dir, docker_storage_filename)
+    extracted_path = os.path.join(bundle_dir, DOCKER_STORAGE_DIRNAME)
+
+    if os.path.isdir(extracted_path):
+        shutil.rmtree(extracted_path)
+    os.mkdir(extracted_path)
+
+    log.info("Unpacking '%s'", docker_storage_filename)
+    tar_compress_options = get_tar_compress_program_options(docker_storage_path)
+    tarcmd = [
+        "tar",
+        "-xf", docker_storage_path,
+        "-C", extracted_path,
+    ] + tar_compress_options
+    subprocess.check_output(tarcmd, stderr=subprocess.STDOUT)
+
+    for content in os.listdir(extracted_path):
+        files_to_add.append(
+            f"{os.path.join(DOCKER_STORAGE_DIRNAME, content)}:{DOCKER_STORAGE_DESTINATION}")

--- a/tcbuilder/backend/combine.py
+++ b/tcbuilder/backend/combine.py
@@ -1,3 +1,7 @@
+"""
+Backend handling for the combine subcommand
+"""
+
 import os
 import shutil
 import logging
@@ -5,12 +9,11 @@ import re
 import datetime
 
 import fnmatch
-import guestfs
 
 from tezi.image import ImageConfig
 from tcbuilder.backend.common import \
-    (set_output_ownership, check_licence_acceptance,
-     run_with_loading_animation, DOCKER_BUNDLE_TARNAME)
+    (set_output_ownership, check_licence_acceptance, run_with_loading_animation,
+     open_disk_image, DOCKER_BUNDLE_TARNAME)
 from tcbuilder.errors import InvalidStateError, InvalidDataError, TorizonCoreBuilderError
 
 log = logging.getLogger("torizon." + __name__)
@@ -20,7 +23,7 @@ DOCKER_FILES_TO_ADD = [
     "docker-compose.yml:/ostree/deploy/torizon/var/sota/storage/docker-compose/",
     TARGET_NAME_FILENAME + ":/ostree/deploy/torizon/var/sota/storage/docker-compose/"
 ]
-DOCKER_BUNDLE_DESTINATION = "/ostree/deploy/torizon/var/lib/docker/:true"
+DOCKER_STORAGE_DESTINATION = "/ostree/deploy/torizon/var/lib/docker/"
 
 TEZI_PROPS = [
     "name",
@@ -43,9 +46,11 @@ TAR_EXT_TO_COMPRESSION_TYPE = {
 }
 
 
-# Search in bundle_dir if there is a file named DOCKER_BUNDLE_TARNAME*
-# e.g. DOCKER_BUNDLE_TARNAME, DOCKER_BUNDLE_TARNAME.xz, DOCKER_BUNDLE_TARNAME.gz, etc.
 def check_docker_storage_file(bundle_dir):
+    """
+    Search in bundle_dir if there is a file named DOCKER_BUNDLE_TARNAME*
+    e.g. DOCKER_BUNDLE_TARNAME, DOCKER_BUNDLE_TARNAME.xz, DOCKER_BUNDLE_TARNAME.gz, etc.
+    """
     for filename in os.listdir(bundle_dir):
         if fnmatch.fnmatch(filename, f"{DOCKER_BUNDLE_TARNAME}*"):
             return filename
@@ -53,6 +58,8 @@ def check_docker_storage_file(bundle_dir):
 
 
 def set_autoreboot(output_dir, include):
+    """Set autoreboot feature in TEZI image."""
+
     wrapup_sh = os.path.join(os.path.abspath(output_dir), 'wrapup.sh')
 
     with open(wrapup_sh, "r", encoding="utf-8") as infile:
@@ -95,7 +102,8 @@ def set_autoreboot(output_dir, include):
         output.writelines(lines)
 
 
-def add_files(tezidir, image_json_filename, filelist, tezi_props):
+def add_files_to_tezi(tezidir, image_json_filename, filelist, tezi_props):
+    """Add files in filelist to a Toradex Easy Installer image directory."""
 
     config_fname = os.path.join(tezidir, image_json_filename)
     config = ImageConfig(config_fname)
@@ -146,6 +154,8 @@ def add_files(tezidir, image_json_filename, filelist, tezi_props):
 
 
 def update_tezi_files(image_dir, tezi_props, files_to_add=None):
+    """Update Toradex Easy Installer metadata present in image.json."""
+
     licence_file_bn = None
     if tezi_props.get("licence_file") is not None:
         licence_file = tezi_props.get("licence_file")
@@ -171,12 +181,14 @@ def update_tezi_files(image_dir, tezi_props, files_to_add=None):
         "filelist": files_to_add,
         "tezi_props": tezi_props
     }
-    version = add_files(**add_files_params)
+    version = add_files_to_tezi(**add_files_params)
 
     return version
 
 
 def combine_single_tezi_image(bundle_dir, files_to_add, output_dir, tezi_props):
+    """Add files in bundle_dir to TEZI image according to files_to_add list."""
+
     for prop in tezi_props:
         assert prop in TEZI_PROPS, f"Unknown property {prop} to combine_single_image"
 
@@ -189,6 +201,10 @@ def combine_single_tezi_image(bundle_dir, files_to_add, output_dir, tezi_props):
 
 
 def check_combine_files(bundle_dir):
+    """
+    Verify if the bundle directory has the required files, and optionally unpack the docker
+    storage tarfile.
+    """
 
     files_to_add = []
     if bundle_dir is not None:
@@ -204,21 +220,31 @@ def check_combine_files(bundle_dir):
             filename = filename.split(":", maxsplit=1)[0]
             filename_path = os.path.join(bundle_dir, filename)
             if not os.path.exists(filename_path):
-                log.error(f"Error: {filename} not found in bundle directory.")
+                log.error("Error: %s not found in bundle directory.", filename)
                 return None
 
         docker_storage_filename = check_docker_storage_file(bundle_dir)
         if docker_storage_filename is not None:
-            files_to_add.append(
-                f"{docker_storage_filename}:{DOCKER_BUNDLE_DESTINATION}")
+            files_to_add.append(f"{docker_storage_filename}:{DOCKER_STORAGE_DESTINATION}:true")
         else:
-            log.error(f"Error: {DOCKER_BUNDLE_TARNAME} not found in bundle directory.")
+            log.error("Error: %s not found in bundle directory.", DOCKER_BUNDLE_TARNAME)
             return None
 
     return files_to_add
 
 
 def combine_tezi_image(image_dir, bundle_dir, output_directory, tezi_props, force):
+    """
+    Combine a container bundle to a Toradex Easy Installer image by copying its contents to the
+    image directory and add instructions in image.json to copy them to the device during
+    installation.
+
+    :param image_path: Path of the Toradex Easy Installer image.
+    :param bundle_dir: Path of the container bundle directory.
+    :param output_path: Path where the resulting image directory will be created.
+    :param tezi_props: TEZI-specific metadata dictionary to be added in the output image.
+    :param force: Overwrite output directory if it already exists.
+    """
 
     check_licence_acceptance(image_dir, tezi_props)
 
@@ -261,94 +287,86 @@ def combine_tezi_image(image_dir, bundle_dir, output_directory, tezi_props, forc
 
 
 def combine_raw_image(image_path, bundle_dir, output_path, rootfs_label, force):
+    """
+    Combine a container bundle to a raw disk image by copying its contents to the image root
+    filesystem. If the size of the container bundle exceeds the available space in root,
+    then the disk image will be resized beforehand.
+
+    :param image_path: Path of the input raw disk image.
+    :param bundle_dir: Path of the container bundle directory.
+    :param output_path: Path where the resulting raw disk image will be created.
+    :param rootfs_label: Filesystem label of the root partition.
+    :param force: Overwrite output file if it already exists.
+    """
+
+    delete_on_error = True
+    if (output_path is None or output_path == image_path) and force:
+        log.info("Updating Torizon OS raw image in place.")
+        delete_on_error = False
+        output_path = image_path
+    else:
+        if os.path.isfile(output_path):
+            if force:
+                log.info(f"Removing existing file '{output_path}'")
+                os.remove(output_path)
+            else:
+                raise InvalidStateError(
+                    f"File {output_path} already exists. "
+                    "Rename output or use --force to overwrite.")
+
+        run_with_loading_animation(
+            func=shutil.copyfile,
+            args=(image_path, output_path),
+            loading_msg="Creating copy of source image...")
+
+    log.info("Combining Torizon OS image with Docker Container bundle.")
 
     files_to_add = check_combine_files(bundle_dir)
 
-    if files_to_add:
-
-        if (output_path is None or output_path == image_path) and force:
-            log.info("Updating Torizon OS raw image in place.")
-            output_path = image_path
-        else:
-            if os.path.exists(output_path):
-                if force:
-                    log.info(f"Removing existing file '{output_path}'")
-                    os.remove(output_path)
-                else:
-                    raise InvalidStateError(
-                        f"File {output_path} already exists. "
-                        "Rename output or use --force to overwrite.")
-
-            run_with_loading_animation(
-                func=shutil.copyfile,
-                args=(image_path, output_path),
-                loading_msg="Creating copy of source image...")
-
-        log.info("Combining Torizon OS image with Docker Container bundle.")
-
-        try:
-            gfs = guestfs.GuestFS(python_return_dict=True)
-            gfs.add_drive_opts(output_path, format="raw")
-            run_with_loading_animation(
-                func=gfs.launch,
-                loading_msg="Initializing image...")
-            if len(gfs.list_partitions()) < 1:
-                raise TorizonCoreBuilderError(
-                    "Image doesn't have any partitions or it's not a valid raw image. Aborting.")
-
-            # Get partition number from ext4 fs called rootfs_label in disk image (.wic/.img)
-            rootfs_partition = gfs.findfs_label(rootfs_label)
-            log.info(f"  rootfs partition found: {rootfs_partition} "
-                     f"(filesystem label: {rootfs_label})")
-            gfs.mount(rootfs_partition, "/")
-
-            log.info("Adding files to rootfs.")
-            for src_dest_untar in files_to_add:
-
-                src_dest_untar = src_dest_untar.split(":")
-                list_len = len(src_dest_untar)
-                untar = False
-
-                if list_len < 2:
-                    raise TorizonCoreBuilderError(
-                        "Internal error: DOCKER_FILES_TO_ADD not properly formatted. Aborting.")
-
-                if list_len >= 3:
-                    untar = src_dest_untar[2]
-                    untar = untar.lower() == 'true'
-
-                src, dest = src_dest_untar[0:2]
-
-                # Create destination path in rootfs if it doesn't exist
-                if not gfs.is_dir(dest):
-                    gfs.mkdir_p(dest)
-
-                if untar:
-                    run_with_loading_animation(
-                        func=gfs.tar_in,
-                        args=(os.path.join(bundle_dir, src), dest),
-                        kwargs={'compress': TAR_EXT_TO_COMPRESSION_TYPE[os.path.splitext(src)[1]]},
-                        loading_msg=f"  Unpacking {src} to {dest} ...")
-
-                else:
-                    run_with_loading_animation(
-                        func=gfs.copy_in,
-                        args=(os.path.join(bundle_dir, src), dest),
-                        loading_msg=f"  Copying {src} to {dest} ...")
-
-            gfs.shutdown()
-            gfs.close()
-        except RuntimeError as gfserr:
-            if output_path != image_path:
-                log.info("Removing copy of source image.")
-                os.remove(output_path)
-            if gfs:
-                gfs.close()
-            if f"unable to resolve 'LABEL={rootfs_label}'" in str(gfserr):
-                # pylint: disable-next=raise-missing-from
-                raise TorizonCoreBuilderError(
-                    f"Filesystem with label '{rootfs_label}' not found in image. Aborting.")
-            # pylint: disable-next=raise-missing-from
-            raise TorizonCoreBuilderError(f"guestfs: {gfserr.args[0]}")
-    else:
+    if not files_to_add:
+        if delete_on_error and os.path.isfile(output_path):
+            log.info("Removing '%s'", output_path)
+            os.remove(output_path)
         raise TorizonCoreBuilderError("Some required bundle files were not found. Aborting.")
+
+    with open_disk_image(output_path, delete_on_error=delete_on_error) as gfs:
+        root_partition = gfs.findfs_label(rootfs_label)
+        gfs.mount(root_partition, "/")
+        copy_to_mounted_root(gfs, files_to_add, bundle_dir)
+
+
+def copy_to_mounted_root(gfs, files_to_add, contents_dir):
+    """Copy list of files inside a directory to a mounted filesystem in '/'."""
+
+    log.info("Adding files to disk root.")
+    for src_dest_untar in files_to_add:
+
+        src_dest_untar = src_dest_untar.split(":")
+        list_len = len(src_dest_untar)
+        untar = False
+
+        if list_len < 2:
+            raise TorizonCoreBuilderError(
+                "Internal error: DOCKER_FILES_TO_ADD not properly formatted. Aborting.")
+
+        if list_len >= 3:
+            untar = src_dest_untar[2]
+            untar = untar.lower() == 'true'
+
+        src, dest = src_dest_untar[0:2]
+
+        # Create destination path in root if it doesn't exist already
+        if not gfs.is_dir(dest):
+            gfs.mkdir_p(dest)
+
+        if untar:
+            run_with_loading_animation(
+                func=gfs.tar_in,
+                args=(os.path.join(contents_dir, src), dest),
+                kwargs={'compress': TAR_EXT_TO_COMPRESSION_TYPE[os.path.splitext(src)[1]]},
+                loading_msg=f"  Unpacking {src} to {dest} ...")
+        else:
+            run_with_loading_animation(
+                func=gfs.copy_in,
+                args=(os.path.join(contents_dir, src), dest),
+                loading_msg=f"  Copying {src} to {dest} ...")

--- a/tcbuilder/backend/common.py
+++ b/tcbuilder/backend/common.py
@@ -12,10 +12,12 @@ import binascii
 import glob
 
 from typing import Optional
+from contextlib import contextmanager
 
 import git
 import dns.resolver
 import ifaddr
+import guestfs
 
 from docker import DockerClient
 from docker.errors import NotFound
@@ -974,3 +976,34 @@ def is_file_type_fit(file_path):
             f"Error running fdtget: {exc.output.strip()}") from exc
 
     return True
+
+
+@contextmanager
+def open_disk_image(image_path, *, delete_on_error=False, readonly=False, loading_msg=None):
+    """Create a context manager to open and manipulate raw disk images."""
+
+    try:
+        gfs = guestfs.GuestFS(python_return_dict=True)
+        gfs.add_drive_opts(image_path, format="raw", readonly=readonly)
+        run_with_loading_animation(
+            func=gfs.launch,
+            loading_msg=loading_msg or "Initializing image...")
+        if len(gfs.list_partitions()) < 1:
+            raise TorizonCoreBuilderError(
+                "Image doesn't have any partitions or it's not a valid raw image. Aborting.")
+        yield gfs
+    except RuntimeError as gfserr:
+        if delete_on_error:
+            log.info("Removing '%s'", image_path)
+            os.remove(image_path)
+        match = re.search(r"unable to resolve 'LABEL=(.*)'", str(gfserr), re.IGNORECASE)
+        if match:
+            # pylint: disable-next=raise-missing-from
+            raise TorizonCoreBuilderError(
+                f"Filesystem with label '{match.group(1)}' not found in image. Aborting.")
+        # pylint: disable-next=raise-missing-from
+        raise TorizonCoreBuilderError(f"guestfs: {gfserr.args[0]}")
+    finally:
+        if gfs:
+            gfs.shutdown()
+            gfs.close()

--- a/tcbuilder/backend/deploy.py
+++ b/tcbuilder/backend/deploy.py
@@ -10,7 +10,6 @@ import subprocess
 import threading
 import shlex
 
-import guestfs
 import fabric
 
 # pylint: disable=wrong-import-position
@@ -20,8 +19,8 @@ from gi.repository import Gio, OSTree
 
 from tcbuilder.backend import ostree
 from tcbuilder.backend.common import (get_rootfs_tarball, resolve_remote_host,
-                                      run_with_loading_animation, REMOTE_CMD_TIMEOUT,
-                                      SECBOOT_ARTIFACTS_DIR)
+                                      run_with_loading_animation, open_disk_image,
+                                      REMOTE_CMD_TIMEOUT, SECBOOT_ARTIFACTS_DIR)
 from tcbuilder.backend.rforward import reverse_forward_tunnel, request_port_forward
 from tcbuilder.backend.secboot import FUSE_CMD_TXT_NAME
 from tcbuilder.errors import TorizonCoreBuilderError, InvalidDataError
@@ -310,6 +309,7 @@ def deploy_tezi_image(tezi_dir, src_sysroot_dir, src_ostree_archive_dir,
     Creates a new Toradex Easy Installer image with a OSTree deployment of the
     given OSTree reference.
     """
+
     commit = deploy_ostree_local(src_sysroot_dir, src_ostree_archive_dir, dst_sysroot_dir, ref)
 
     log.info("Packing rootfs...")
@@ -331,6 +331,7 @@ def create_output_raw_image(base_raw_img, output_raw_img, base_rootfs_partition,
     The result is a copy of the base disk image with all partitions except
     the rootfs one, replaced by an empty partition at the end of the disk.
     """
+
     base_img_size_kb = os.path.getsize(base_raw_img)/1024
     out_size_kb = max(base_img_size_kb,
                       IMAGE_OVERHEAD_FACTOR*(rootfs_size_kb + other_partitions_size_kb))
@@ -366,16 +367,11 @@ def write_rootfs_to_raw_image(raw_disk_img, rootfs_label, rootfs_dir):
     Creates a new rootfs ext4 partition with a given label on the last partition
     of a raw disk and writes the contents of the provided rootfs directory.
     """
-    try:
-        gfs = guestfs.GuestFS(python_return_dict=True)
-        gfs.add_drive_opts(raw_disk_img, format="raw")
-        run_with_loading_animation(
-            func=gfs.launch,
-            loading_msg="Initializing output image...")
 
+    loading_msg="Initializing output image..."
+    with open_disk_image(raw_disk_img, loading_msg=loading_msg) as gfs:
         # virt-resize rearranged all existing partitions and generated a new empty partition at the
         # end of the disk. We will format it to ext4 and put the unpacked rootfs contents in it.
-
         # Its partition number (/dev/sda1, /dev/sda2, etc.) is equal to the number of partitions
         # in the image, given that it is the last one.
         output_rootfs_partition = f"/dev/sda{len(gfs.list_partitions())}"
@@ -396,14 +392,6 @@ def write_rootfs_to_raw_image(raw_disk_img, rootfs_label, rootfs_dir):
                 args=(f"{rootfs_dir}/{content}", "/"),
                 loading_msg=f"  Copying /{content}...")
 
-        gfs.shutdown()
-        gfs.close()
-    except RuntimeError as gfserr:
-        if gfs:
-            gfs.close()
-        # pylint: disable-next=raise-missing-from
-        raise TorizonCoreBuilderError(f"guestfs: {gfserr.args[0]}")
-
 
 # pylint: disable-next=too-many-positional-arguments
 def deploy_raw_image(base_raw_img, src_sysroot_dir, src_ostree_archive_dir,
@@ -415,15 +403,8 @@ def deploy_raw_image(base_raw_img, src_sysroot_dir, src_ostree_archive_dir,
     """
     deploy_ostree_local(src_sysroot_dir, src_ostree_archive_dir, dst_sysroot_dir, ref)
 
-    try:
-        gfs = guestfs.GuestFS(python_return_dict=True)
-        gfs.add_drive_opts(base_raw_img, format="raw", readonly=1)
-        run_with_loading_animation(
-            func=gfs.launch,
-            loading_msg="Initializing base WIC/raw image...")
-        if len(gfs.list_partitions()) < 1:
-            raise TorizonCoreBuilderError(
-                "Image doesn't have any partitions or it's not a valid WIC/raw image. Aborting.")
+    loading_msg="Initializing base WIC/raw image..."
+    with open_disk_image(base_raw_img, readonly=True, loading_msg=loading_msg) as gfs:
         # Get partition number from ext4 fs called rootfs_label in disk image (.wic/.img)
         rootfs_partition = gfs.findfs_label(rootfs_label)
         log.info(f"  '{rootfs_label}' partition found: {rootfs_partition}")
@@ -433,19 +414,6 @@ def deploy_raw_image(base_raw_img, src_sysroot_dir, src_ostree_archive_dir,
         partitions.remove(rootfs_partition)
         for part in partitions:
             other_partitions_size_kb += gfs.blockdev_getsize64(part) / 1024
-
-        # Close read-only handle
-        gfs.shutdown()
-        gfs.close()
-    except RuntimeError as gfserr:
-        if gfs:
-            gfs.close()
-        if f"unable to resolve 'LABEL={rootfs_label}'" in str(gfserr):
-            raise TorizonCoreBuilderError(
-                f"Filesystem with label '{rootfs_label}'"
-                " not found in image. Aborting.") from gfserr
-
-        raise TorizonCoreBuilderError(f"guestfs: {str(gfserr)}") from gfserr
 
     if other_partitions_size_kb > 0:
         log.info("  Combined size of all partitions except rootfs: "

--- a/tcbuilder/backend/images.py
+++ b/tcbuilder/backend/images.py
@@ -19,13 +19,12 @@ import urllib.request
 from zipfile import ZipFile
 from tempfile import TemporaryDirectory
 
-import guestfs
 import fabric
 
 from tcbuilder.backend.common import (get_rootfs_tarball, get_tar_compress_program_options,
                                       set_output_ownership, run_with_loading_animation,
-                                      get_tezi_image_version, DEFAULT_RAW_ROOTFS_LABEL,
-                                      RAW_PROP_TO_ARGNAME, SECBOOT_ARTIFACTS_DIR)
+                                      get_tezi_image_version, open_disk_image, RAW_PROP_TO_ARGNAME,
+                                      DEFAULT_RAW_ROOTFS_LABEL, SECBOOT_ARTIFACTS_DIR)
 from tcbuilder.backend import ostree
 from tcbuilder.backend.secboot import DEFAULT_TCB_SIGNING_FILES_TARNAME, BOOTLOADER_CONTAINER_NAME
 from tcbuilder.errors import (TorizonCoreBuilderError, InvalidArgumentError, InvalidStateError)
@@ -321,19 +320,7 @@ def unpack_local_raw_image(image_dir, sysroot_dir, raw_rootfs_label):
     if raw_rootfs_label is None:
         raw_rootfs_label = DEFAULT_RAW_ROOTFS_LABEL
 
-    try:
-        gfs = guestfs.GuestFS(python_return_dict=True)
-        # Add input image
-        gfs.add_drive_opts(image_dir, format="raw", readonly=1)
-        # Launch libguestfs backend
-        run_with_loading_animation(
-            func=gfs.launch,
-            loading_msg="Initializing WIC/raw image...")
-
-        if len(gfs.list_partitions()) < 1:
-            raise TorizonCoreBuilderError(
-                "Image doesn't have any partitions or it's not a valid WIC/raw image. Aborting.")
-
+    with open_disk_image(image_dir, readonly=True) as gfs:
         # Get partition number from ext4 fs called raw_rootfs_label in disk image (.wic/.img)
         rootfs_partition = gfs.findfs_label(raw_rootfs_label)
         log.info(f"'{raw_rootfs_label}' partition found: {rootfs_partition}")
@@ -342,18 +329,6 @@ def unpack_local_raw_image(image_dir, sysroot_dir, raw_rootfs_label):
             func=gfs.copy_out,
             args=("/", sysroot_dir),
             loading_msg="Unpacking image. This may take a few minutes...")
-        gfs.shutdown()
-        gfs.close()
-    except RuntimeError as gfserr:
-        if gfs:
-            gfs.close()
-        if f"unable to resolve 'LABEL={raw_rootfs_label}'" in str(gfserr):
-            # pylint: disable-next=raise-missing-from
-            raise TorizonCoreBuilderError(
-                f"Filesystem with label '{raw_rootfs_label}' not found in image. Aborting.")
-
-        # pylint: disable-next=raise-missing-from
-        raise TorizonCoreBuilderError(f"guestfs: {str(gfserr)}")
 
 
 def _make_tezi_extract_dir(tezi_dir):

--- a/tcbuilder/cli/build.py
+++ b/tcbuilder/cli/build.py
@@ -772,9 +772,15 @@ def handle_raw_image_bundle_output(image_dir, raw_image_path, bundle_props, raw_
         comb_be.combine_raw_image(**combine_params)
 
     finally:
-        if bundle_dir is not None and is_tmp_dir:
-            log.debug(f"Removing temporary bundle directory {bundle_dir}")
-            shutil.rmtree(bundle_dir)
+        if bundle_dir is not None:
+            if is_tmp_dir:
+                log.debug(f"Removing temporary bundle directory {bundle_dir}")
+                shutil.rmtree(bundle_dir)
+            else:
+                docker_storage_dir_path = os.path.join(bundle_dir, comb_be.DOCKER_STORAGE_DIRNAME)
+                if os.path.isdir(docker_storage_dir_path):
+                    log.debug("Deleting '%s'", docker_storage_dir_path)
+                    shutil.rmtree(docker_storage_dir_path)
 
 
 def handle_provisioning(output_dir, prov_props):

--- a/tcbuilder/cli/combine.py
+++ b/tcbuilder/cli/combine.py
@@ -7,6 +7,7 @@ container(s) from the "bundle" command.
 import os
 import logging
 import argparse
+import shutil
 
 from tcbuilder.backend.common import (add_common_tezi_image_arguments,
                                       add_common_raw_image_arguments,
@@ -103,9 +104,14 @@ def do_combine(args):
             if raw_props_args[prop] is None:
                 raw_props_args[prop] = RAW_PROP_DEFAULTS[prop]
 
-        combine.combine_raw_image(image_path, dir_containers, output_path,
-                                  raw_props_args["raw_rootfs_label"], args.force)
-
+        try:
+            combine.combine_raw_image(image_path, dir_containers, output_path,
+                                      raw_props_args["raw_rootfs_label"], args.force)
+        finally:
+            docker_storage_dir_path = os.path.join(dir_containers, combine.DOCKER_STORAGE_DIRNAME)
+            if os.path.isdir(docker_storage_dir_path):
+                log.debug("Deleting '%s'", docker_storage_dir_path)
+                shutil.rmtree(docker_storage_dir_path)
     # If TEZI image:
     else:
 

--- a/tcbuilder/cli/combine.py
+++ b/tcbuilder/cli/combine.py
@@ -60,6 +60,9 @@ def do_combine(args):
     if not os.path.exists(dir_containers):
         raise PathNotExistError(f"Bundle directory {args.bundle_directory} does not exist.")
 
+    if not os.path.exists(args.image_path):
+        raise PathNotExistError(f"Image path {args.image_path} does not exist. Aborting.")
+
     output_path = os.path.abspath(args.output_path)
 
     image_path = os.path.abspath(args.image_path)

--- a/tests/integration/testcases/wic/build.bats
+++ b/tests/integration/testcases/wic/build.bats
@@ -145,7 +145,7 @@ teardown_file() {
     assert_output --partial 'Deploying commit ref: my-raw-image-branch'
     assert_output --partial "created successfully"
     assert_output --partial "Copying docker-compose.yml"
-    assert_output --partial "Unpacking docker-storage.tar"
+    assert_output --regexp "Unpacking .*docker-storage.*"
 
     local ARCHIVE='/storage/ostree-archive/'
     local COMMIT='my-raw-image-branch'
@@ -194,7 +194,7 @@ teardown_file() {
     assert_output --partial 'Deploying commit ref: my-raw-image-branch'
     assert_output --partial "created successfully"
     assert_output --partial "Copying docker-compose.yml"
-    assert_output --partial "Unpacking docker-storage.tar"
+    assert_output --regexp "Unpacking .*docker-storage.*"
 
     local ARCHIVE='/storage/ostree-archive/'
     local COMMIT='my-raw-image-branch'


### PR DESCRIPTION
Automatically expand the root filesystem of the output disk image if the required size of the uncompressed contents of the container bundle exceeds or almost exceeds the available root space. 

In order to expand the filesystem, its underlying partition and the disk image file itself need to be expanded first. These operations were implemented using the libguestfs `virt-resize` tool.

Also included are some code improvements related to raw disk image manipulation. See the commit messages for more details.

Related-to: TCB-840

Signed-off-by: Lucas Akira Morishita <lucas.morishita@toradex.com>