### PR TITLE
Remove internal server download for test-host-tos7-64bit-signed-nightly

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -352,7 +352,6 @@ test-host-tos7-32bit-signed-nightly:
       --tcb-custom-image "${TCB_IMAGE_UNDER_TEST}"
 
 test-host-tos7-64bit-signed-nightly:
-  # TODO: Review once signed images are available publicly.
   tags:
     - "all"
   extends: .test-base
@@ -361,14 +360,8 @@ test-host-tos7-64bit-signed-nightly:
     TARGET_BUILD_TYPE: "nightly"
     TCB_MACHINE: "verdin-imx8mp"
     TARGET_SIGNING_CLASS: "tdx-signed"
-    ACCEPT_VARIANTS: "torizon-minimal"
+    ACCEPT_VARIANTS: "torizon-docker torizon-minimal"
   script:
-    # set extra variables for downloading signed images from the internal Artifactory
-    - export BASE_ARTIFACTORY_URL_PROD=""
-    - export BASE_ARTIFACTORY_URL_PRERELEASE=""
-    - '[ -n "${SIGIMG_ARTIFACTORY_URL}" ] || { echo "SIGIMG_ARTIFACTORY_URL not set"; exit 1; }'
-    - '[ -n "${SIGIMG_ARTIFACTORY_PROD_REPO}" ] && BASE_ARTIFACTORY_URL_PROD="${SIGIMG_ARTIFACTORY_URL}/${SIGIMG_ARTIFACTORY_PROD_REPO}"'
-    - '[ -n "${SIGIMG_ARTIFACTORY_PRERELEASE_REPO}" ] && BASE_ARTIFACTORY_URL_PRERELEASE="${SIGIMG_ARTIFACTORY_URL}/${SIGIMG_ARTIFACTORY_PRERELEASE_REPO}"'
     - ./run_all.sh --machine $TCB_MACHINE --report --testcase "$TCB_HOST_TESTS"
       --tcb-custom-image "${TCB_IMAGE_UNDER_TEST}"
 


### PR DESCRIPTION
The `test-host-tos7-64bit-signed-nightly` job started to fail in recent pipelines due to `tdx-signed` images for the Verdin iMX8M Plus no longer being available in our internal servers.

These are now available in our public Artifactory servers, so this job no longer needs the additional steps to download from our internal servers.