### PR TITLE
Add new --fleet option for images provision

### DIFF
--- a/tcbuilder/backend/images.py
+++ b/tcbuilder/backend/images.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import tempfile
 import urllib.request
+import uuid
 
 from zipfile import ZipFile
 from tempfile import TemporaryDirectory
@@ -415,7 +416,8 @@ def prov_check_provdata_presence(input_dir):
     return config.search_filelist(src=PROV_DATA_FILENAME) is not None
 
 
-def prov_gen_provdata_tarball(output_dir, shared_data, online_data, hibernated):
+def prov_gen_provdata_tarball(output_dir, shared_data, online_data, *,
+                              hibernated=False, fleets=None):
     """Generate tarball containing all provisioning data
 
     The tarball will be stored into the output directory; then it should be
@@ -459,6 +461,12 @@ def prov_gen_provdata_tarball(output_dir, shared_data, online_data, hibernated):
                         online_data_obj['hibernated'] = True
                         online_data_json = json.dumps(online_data_obj).encode("utf-8")
 
+                    # Add fleet UUIDs if present
+                    if fleets and isinstance(online_data_obj, dict):
+                        log.info("Adding fleet UUID(s).")
+                        online_data_obj['fleetids'] = fleets
+                        online_data_json = json.dumps(online_data_obj).encode("utf-8")
+
                 except (binascii.Error, json.decoder.JSONDecodeError) as exc:
                     raise TorizonCoreBuilderError(
                         "Failure decoding online data: aborting.") from exc
@@ -489,7 +497,7 @@ def prov_add_provdata_tarball(output_dir):
 
 
 def provision(input_dir, output_dir, shared_data, online_data, *,
-              hibernated=False, force=False):
+              hibernated=False, fleets=None, force=False):
     """Generate TEZI image with added provisioning data
 
     :param input_dir: Path of directory containing input image.
@@ -498,6 +506,7 @@ def provision(input_dir, output_dir, shared_data, online_data, *,
                         offline and online cases) provisioning data.
     :param online_data: Base-64 string containing online provisioning data.
     :param hibernated: Boolean that indicates to whether or not provision in hibernated mode
+    :param fleets: List of fleet UUID(s) to provision to
     :param force: Boolean indicating whether to remove output directory if it
                   already exists.
     """
@@ -519,18 +528,26 @@ def provision(input_dir, output_dir, shared_data, online_data, *,
         raise InvalidStateError(
             "Input image already contains provisioning data: aborting.")
 
-    if online_data and hibernated:
-        # Check unpacked version of Torizon OS
-        img_major, img_minor, _ = get_tezi_image_version(input_dir)
+    # Check unpacked version of Torizon OS
+    img_major, img_minor, _ = get_tezi_image_version(input_dir)
 
-        if img_major is None or img_minor is None:
-            log.warning("Warning: Unable to determine image version in input directory. "
-                        "Proceeding anyway.")
-        elif (img_major == 6 and img_minor <= 7) or img_major < 6:
+    if img_major is None or img_minor is None:
+        log.warning("Warning: Unable to determine image version in input directory. "
+                    "Proceeding anyway.")
+    elif online_data:
+        if hibernated and ((img_major == 6 and img_minor <= 7) or img_major < 6):
             # Torizon OS 6.7 or below doesn't support hibernated auto-provisioning
             # without changes to the auto-provisioning script.
             log.warning("Warning: Hibernated auto-provisioning is not supported on Torizon "
                         "OS 6.7 or older. Proceeding anyway.")
+        if fleets:
+            if (img_major == 7 and img_minor <= 6) or img_major < 7:
+                # Torizon OS 7.6 or below doesn't support fleet auto-provisioning
+                log.warning("Warning: Fleet auto-provisioning is not supported on Torizon "
+                            "OS 7.6 or older. Proceeding anyway.")
+
+            _validate_fleets(fleets)
+
 
     # Handle normal or in-place modifications:
     inplace = False
@@ -552,7 +569,12 @@ def provision(input_dir, output_dir, shared_data, online_data, *,
 
     # Actual provisioning:
     try:
-        prov_gen_provdata_tarball(output_dir, shared_data, online_data, hibernated)
+        prov_gen_provdata_tarball(
+            output_dir=output_dir,
+            shared_data=shared_data,
+            online_data=online_data,
+            hibernated=hibernated,
+            fleets=fleets)
         prov_add_provdata_tarball(output_dir)
         set_output_ownership(output_dir)
         log.info("Image successfully provisioned.")
@@ -562,6 +584,26 @@ def provision(input_dir, output_dir, shared_data, online_data, *,
             log.debug("Removing output directory due to error.")
             shutil.rmtree(output_dir)
         raise
+
+
+def _validate_fleets(fleets):
+    """
+    Check if provided list of fleet UUIDs are in the form of UUIDs
+
+    :param fleets: List of potential UUIDs
+    """
+
+    bad_uuids = []
+    for uuids in fleets:
+        try:
+            # Torizon Cloud uses version 4 UUIDs
+            uuid.UUID(uuids, version=4)
+        except ValueError:
+            bad_uuids.append(uuids)
+
+    if bad_uuids:
+        raise InvalidArgumentError(
+            f"The following UUID(s) do not appear to be a UUID: {bad_uuids}")
 
 
 def track_tezi_signed_files(tezi_dir, commit_hash, machine):

--- a/tcbuilder/backend/tcbuild.schema.yaml
+++ b/tcbuilder/backend/tcbuild.schema.yaml
@@ -537,6 +537,13 @@ properties:
                   hibernated:
                     type: boolean
                     description: "provision in hibernated mode"
+                  fleets:
+                    type: array
+                    description: "list of UUID(s) to provision to"
+                    items:
+                      type: string
+                      description: "version 4 UUID string"
+                      tdxMeta: "uuid"
                 required: [mode]
                 additionalProperties: false
               bundle:

--- a/tcbuilder/cli/build.py
+++ b/tcbuilder/cli/build.py
@@ -791,7 +791,8 @@ def handle_provisioning(output_dir, prov_props):
         "output_dir": None,
         "shared_data": prov_props.get("shared-data"),
         "online_data": prov_props.get("online-data"),
-        "hibernated": prov_props.get("hibernated", False)
+        "hibernated": prov_props.get("hibernated", False),
+        "fleets": prov_props.get("fleets")
     }
 
     if prov_props.get("mode") == images_cli.PROV_MODE_OFFLINE:

--- a/tcbuilder/cli/images.py
+++ b/tcbuilder/cli/images.py
@@ -105,6 +105,8 @@ def do_images_provision(args):
             sys.exit(1)
         if args.hibernated:
             log.warning("Warning: --hibernated is specific to online provisioning. Ignoring.")
+        if args.fleets:
+            log.warning("Warning: --fleet is specific to online provisioning. Ignoring.")
 
     elif args.mode == PROV_MODE_ONLINE:
         if not (args.shared_data_file and args.online_data):
@@ -122,6 +124,7 @@ def do_images_provision(args):
             shared_data=args.shared_data_file,
             online_data=args.online_data,
             hibernated=args.hibernated,
+            fleets=args.fleets,
             force=args.force)
 
     except (TorizonCoreBuilderError, TeziError) as exc:
@@ -219,6 +222,11 @@ def init_parser(subparsers):
         help=("(Torizon OS 6.8+) Add flag to auto-provision in hibernated mode. Hibernated "
               "devices are registered, but cannot receive updates from Torizon Cloud nor "
               "send data to it."))
+    subparser.add_argument(
+        "--fleet", dest="fleets", action="append",
+        help=("(Torizon OS 7.7+) Add fleet UUID to the provisioning. Devices that provision "
+              "themselves will also try to be added to the fleet corresponding to the provided "
+              "UUID. Can be passed multiple times to signify multiple fleets."))
     subparser.set_defaults(func=do_images_provision)
 
     # images serve

--- a/tcbuilder/cli/tcbuild.template.yaml
+++ b/tcbuilder/cli/tcbuild.template.yaml
@@ -215,3 +215,7 @@ output:
       # >> cannot send/receive data to/from Torizon Cloud, and they're not counted
       # >> towards a subscription.
       # hibernated: false
+      # >> List of fleet UUIDs to provision to.
+      # >> Replace example UUID with your actual fleet UUID.
+      # fleets:
+        # - 0dfab76b-5b71-4435-ab6f-c6cdc62690c6

--- a/tests/integration/testcases/images.bats
+++ b/tests/integration/testcases/images.bats
@@ -64,6 +64,16 @@ bats_load_library 'bats/bats-file/load.bash'
     assert_output --partial "--hibernated is specific to online provisioning. Ignoring."
     assert_output --partial 'Image successfully provisioned'
 
+    # case: success, with --fleet option ignored
+    rm -fr "${OUTPUT_IMAGE_DIR}"
+    run torizoncore-builder images provision \
+        --shared-data "${SAMPLES_DIR}/provision/shared-data.tar.gz" \
+        --fleet "4a83db78-b746-4685-9ccd-ba566d1a012b" \
+        --mode=offline "$INPUT_IMAGE_DIR" "$OUTPUT_IMAGE_DIR"
+    assert_success
+    assert_output --partial "--fleet is specific to online provisioning. Ignoring."
+    assert_output --partial 'Image successfully provisioned'
+
     run cat "${OUTPUT_IMAGE_DIR}/image.json"
     assert_output --partial 'provisioning-data.tar.gz:/ostree/deploy/torizon/var/sota/:true'
 
@@ -209,6 +219,33 @@ bats_load_library 'bats/bats-file/load.bash'
     tar -xf "${OUTPUT_IMAGE_DIR}/provisioning-data.tar.gz"
     run cat "auto-provisioning.json"
     assert_output --partial '"hibernated": true'
+
+    # case: error with --fleet option, malformed uuid
+    rm -fr "${OUTPUT_IMAGE_DIR}"
+    run torizoncore-builder images provision \
+        --shared-data "${SAMPLES_DIR}/provision/shared-data.tar.gz" \
+        --online-data "eyJkdW1teSI6MX0K" \
+        --fleet "foo" \
+        --mode=online "$INPUT_IMAGE_DIR" "$OUTPUT_IMAGE_DIR"
+    assert_failure
+    assert_output --partial 'do not appear to be a UUID'
+
+    # case: success with --fleet option enabled
+    rm -fr "${OUTPUT_IMAGE_DIR}"
+    run torizoncore-builder images provision \
+        --shared-data "${SAMPLES_DIR}/provision/shared-data.tar.gz" \
+        --online-data "eyJkdW1teSI6MX0K" \
+        --fleet "4a83db78-b746-4685-9ccd-ba566d1a012b" \
+        --mode=online "$INPUT_IMAGE_DIR" "$OUTPUT_IMAGE_DIR"
+    assert_success
+    assert_output --partial 'Adding fleet UUID'
+    assert_output --partial 'Image successfully provisioned'
+
+    run cat "${OUTPUT_IMAGE_DIR}/image.json"
+    assert_output --partial 'provisioning-data.tar.gz:/ostree/deploy/torizon/var/sota/:true'
+    tar -xf "${OUTPUT_IMAGE_DIR}/provisioning-data.tar.gz"
+    run cat "auto-provisioning.json"
+    assert_output --partial '"fleetids"'
 
     # check if uncompressed_size field was updated correctly:
     # we are using 'bc' here due to the floating point calculations.


### PR DESCRIPTION
This adds a new option for `images provision` that allows users to provision their devices to fleets in Torizon Cloud with auto-provisioning. This adds the following:

* Standalone command support `images provision --fleet`
* Support for option in the `build` command
* Test cases for the new option