### PR TITLE
tests: Bump aux DinD to 29.3.1 and wait for readiness

### DIFF
--- a/tests/integration/testcases/lib/registries.sh
+++ b/tests/integration/testcases/lib/registries.sh
@@ -16,6 +16,8 @@ export DIND_CONTAINER="dind-for-registries"
 
 export REGISTRIES_NETWORK="registry-network"
 
+export DOCKER_VERSION="29.3.1"
+
 
 _start-registries() {
     local ci_dockerhub_login="$(ci-dockerhub-login-flag)"
@@ -89,11 +91,24 @@ _start-registries() {
     if [ -n "$(docker container ls -qaf name="^${DIND_CONTAINER}\$")" ]; then
         docker container rm -f "${DIND_CONTAINER}"
     fi
+    # --tls=false skips dockerd's intentional ~15s startup slowdown for
+    # plain-TCP-without-TLS; safe since this daemon is only reached over
+    # loopback in the shared netns.
     docker run \
         -d --name "${DIND_CONTAINER}" --privileged --network host \
         -v "$(pwd):/certs" -e DOCKER_HOST="tcp://127.0.0.1:23736" \
-	docker:19.03.8-dind dockerd \
+	docker:${DOCKER_VERSION}-dind dockerd --tls=false \
 	--host=tcp://0.0.0.0:23736 --insecure-registry="${INSEC_REG_IP}"
+
+    # Wait until the inner dockerd is actually accepting connections before
+    # running any docker client commands against it. Without this, fast hosts
+    # can race past the listener coming up.
+    for _ in {1..30}; do
+        if docker exec "${DIND_CONTAINER}" docker version >/dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+    done
 
     # Add the CA certificates to DinD.
     docker exec "${DIND_CONTAINER}" /bin/ash -c "\


### PR DESCRIPTION
The aux DinD in start-registries was pinned to docker:19.03.8-dind, which uses iptables-legacy and needs the kernel's iptable_nat / ip_tables modules loaded to set up its NAT chain at startup. On runners whose host kernel only has the nftables modules (no legacy iptables), the inner dockerd fails with "Table does not exist (do you need to insmod?)" and exits, causing the subsequent docker exec calls to surface as a misleading exit 137 in setup_file.

Bump to docker:29.3.1-dind to match the outer service in .gitlab-ci.yml. The new image is Alpine 3.23-based and uses iptables-nft, so it works on hosts without legacy iptables loaded.

Two extra adjustments are required for the modern daemon:

* --tls=false: dockerd 25+ deliberately delays startup ~15s when binding plain TCP without --tlsverify. Opting out brings cold-start back to ~2s. Safe here because the listener is only reached over loopback in the shared netns of this privileged container.

* Readiness loop: even without the slowdown, dockerd needs ~1-2s for the containerd handshake before it starts listening. Polling 'docker version' against the inner daemon before any client commands prevents a race where login/pull/push hit the listener before it is up. Cheap on a healthy start (exits iter 1) and turns the next startup-timing surprise into a clean diagnostic.

Related-to: TCB-869