### PR TITLE
Add completion script to TorizonCore Builder container image

### DIFF
--- a/torizoncore-builder-completion.bash
+++ b/torizoncore-builder-completion.bash
@@ -183,6 +183,7 @@ _TCBCOMP_ARGS_IMAGES_PROVISION="
     --force
     --shared-data
     --online-data
+    --fleet
 "
 
 _TCBCOMP_ARGS_IMAGES_PROVISION_MODES="
@@ -322,6 +323,7 @@ _TCBCOMP_ARGS_DEF_UNION_BRANCH="_TYPE_HERE_UNION_BRANCH_"
 _TCBCOMP_ARGS_DEF_PACKAGE_NAME="_TYPE_HERE_PACKAGE_NAME_"
 _TCBCOMP_ARGS_DEF_PACKAGE_VERSION="_TYPE_HERE_PACKAGE_VERSION_"
 _TCBCOMP_ARGS_DEF_ONLINE_PROVDATA="_TYPE_HERE_ONLINE_PROVISIONING_STRING_"
+_TCBCOMP_ARGS_DEF_FLEET_UUID="_TYPE_HERE_FLEET_UUID_"
 _TCBCOMP_ARGS_DEF_LOCKBOX_NAME="_TYPE_HERE_LOCKBOX_NAME_"
 _TCBCOMP_ARGS_DEF_SHARED_DATA="_TYPE_HERE_SHARED_DATA_FILE_NAME_"
 _TCBCOMP_ARGS_DEF_CLIENT_NAME="_TYPE_HERE_API_CLIENT_NAME_"
@@ -814,6 +816,9 @@ _tcbcomp_images_provision() {
             ;;
         --online-data)
             _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_ONLINE_PROVDATA"
+            ;;
+        --fleet)
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_FLEET_UUID"
             ;;
         *)
             if [ -n "$cur" ]; then

--- a/torizoncore-builder-completion.bash
+++ b/torizoncore-builder-completion.bash
@@ -21,6 +21,7 @@ _TCBCOMP_ARGS_MAIN="
     secboot
     splash
     splash-config
+    ubootenv
     union
 "
 
@@ -252,6 +253,7 @@ _TCBCOMP_ARGS_PLATFORM="
     lockbox
     provisioning-data
     push
+    push-bootloader
 "
 
 _TCBCOMP_ARGS_PLATFORM_LOCKBOX="
@@ -291,6 +293,20 @@ _TCBCOMP_ARGS_PUSH="
     --verbose
 "
 
+_TCBCOMP_ARGS_PLATFORM_PUSH_BOOTLOADER="
+    --help
+    --credentials
+    --hardwareid
+    --package-name
+    --package-version
+    --description
+    --verbose
+    --uboot-json
+    --keep-var
+    --set-var
+    --no-reset
+"
+
 _TCBCOMP_ARGS_SECBOOT="
     --help
     sign-bootloader-hab
@@ -317,10 +333,7 @@ _TCBCOMP_ARGS_SECBOOT_CST_CRYPTO="
     ecdsa
 "
 _TCBCOMP_ARGS_SECBOOT_CST_DIG_ALGO="
-    sha1
     sha256
-    sha384
-    sha512
 "
 _TCBCOMP_ARGS_SECBOOT_CST_SRK_INDEX="
     1
@@ -354,6 +367,17 @@ _TCBCOMP_ARGS_SPLASH_CONFIG_SET="
 _TCBCOMP_ARGS_SPLASH_CONFIG_DUMP="
     --help
     --file
+    --force
+"
+
+_TCBCOMP_ARGS_UBOOTENV="
+    --help
+    fuses
+"
+
+_TCBCOMP_ARGS_UBOOTENV_FUSES="
+    --help
+    --fuse-file
     --force
 "
 
@@ -395,6 +419,8 @@ _TCBCOMP_ARGS_DEF_SHARED_DATA="_TYPE_HERE_SHARED_DATA_FILE_NAME_"
 _TCBCOMP_ARGS_DEF_CLIENT_NAME="_TYPE_HERE_API_CLIENT_NAME_"
 _TCBCOMP_ARGS_DEF_KERNEL_KEY="name=dev;algo=sha256,rsa2048"
 _TCBCOMP_ARGS_DEF_OSTREE_KEY="name=dev;algo=ed25519"
+_TCBCOMP_ARGS_DEF_UBOOTENV_KEEP_VAR="_TYPE_HERE_UBOOT_ENV_VAR_"
+_TCBCOMP_ARGS_DEF_UBOOTENV_SET_VAR="VAR=VALUE"
 
 # return in ${COMPREPLY} a list of files and directories starting from the
 # current working directory. The first parameter can be used to filter
@@ -1143,6 +1169,46 @@ _tcbcomp_platform_push() {
     _tcbcomp_push "$@"
 }
 
+_tcbcomp_platform_push_bootloader() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "${prev}" in
+        --credentials)
+            _tcbcomp_helper_filter_files_and_dirs "credentials.zip"
+            ;;
+        --hardwareid)
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_HARDWAREID}"
+            ;;
+        --package-name)
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_PACKAGE_NAME}"
+            ;;
+        --package-version)
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_PACKAGE_VERSION}"
+            ;;
+        --description)
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_IMAGE_DESCRIPTION}"
+            ;;
+        --uboot-json)
+            _tcbcomp_helper_filter_files_and_dirs "*.json" true
+            ;;
+        --keep-var)
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_UBOOTENV_KEEP_VAR}"
+            ;;
+        --set-var)
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_UBOOTENV_SET_VAR}"
+            ;;
+        *)
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_PLATFORM_PUSH_BOOTLOADER}"
+            fi
+            if [ -z "${COMPREPLY}" ]; then
+                _tcbcomp_helper_filter_files_and_dirs "*"
+            fi
+            ;;
+    esac
+}
+
 # 'platform' command
 _tcbcomp_platform() {
     local cmd=$(_tcbcomp_helper_find_subcmd "platform" "${_TCBCOMP_ARGS_PLATFORM}")
@@ -1156,6 +1222,9 @@ _tcbcomp_platform() {
             ;;
         push)
             _tcbcomp_platform_push
+            ;;
+        push-bootloader)
+            _tcbcomp_platform_push_bootloader
             ;;
         *)
             _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_PLATFORM}"
@@ -1311,6 +1380,40 @@ _tcbcomp_secboot() {
             ;;
         *)
             _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_SECBOOT}"
+            ;;
+    esac
+}
+
+# 'ubootenv fuses' command
+_tcbcomp_ubootenv_fuses() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "${prev}" in
+        --fuse-file)
+            _tcbcomp_helper_filter_files_and_dirs "*.y*ml" true
+            ;;
+        *)
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_UBOOTENV_FUSES}"
+            fi
+            if [ -z "${COMPREPLY}" ]; then
+                _tcbcomp_helper_filter_dirs
+            fi
+            ;;
+    esac
+}
+
+# 'ubootenv' command
+_tcbcomp_ubootenv() {
+    local cmd=$(_tcbcomp_helper_find_subcmd "ubootenv" "${_TCBCOMP_ARGS_UBOOTENV}")
+
+    case "${cmd}" in
+        fuses)
+            _tcbcomp_ubootenv_fuses
+            ;;
+        *)
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_UBOOTENV}"
             ;;
     esac
 }
@@ -1475,6 +1578,9 @@ _tcbcomp() {
             ;;
         splash-config)
             _tcbcomp_splash_config
+            ;;
+        ubootenv)
+            _tcbcomp_ubootenv
             ;;
         union)
             _tcbcomp_union

--- a/torizoncore-builder-completion.bash
+++ b/torizoncore-builder-completion.bash
@@ -267,7 +267,7 @@ _TCBCOMP_ARGS_PLATFORM_LOCKBOX="
     --output-directory
 "
 
-_TCBCOMP_ARGS_PLATFORM_LOCKBOX_PLATFORM="$_TCBCOMP_ARGS_BUNDLE_PLATFORM"
+_TCBCOMP_ARGS_PLATFORM_LOCKBOX_PLATFORM="${_TCBCOMP_ARGS_BUNDLE_PLATFORM}"
 
 _TCBCOMP_ARGS_PLATFORM_PROVDATA="
     --help
@@ -396,7 +396,7 @@ _TCBCOMP_ARGS_DEF_CLIENT_NAME="_TYPE_HERE_API_CLIENT_NAME_"
 _TCBCOMP_ARGS_DEF_KERNEL_KEY="name=dev;algo=sha256,rsa2048"
 _TCBCOMP_ARGS_DEF_OSTREE_KEY="name=dev;algo=ed25519"
 
-# return in $COMPREPLY a list of files and directories starting from the
+# return in ${COMPREPLY} a list of files and directories starting from the
 # current working directory. The first parameter can be used to filter
 # the output files (e.g. *.txt), and if not passed, only directories are
 # returned. The second parameter, if true, can be used in conjuction with the first
@@ -414,24 +414,24 @@ _tcbcomp_helper_filter_files_and_dirs() {
         arg=()
     fi
 
-    if [ -z "$ZSH_VERSION" ]; then
+    if [ -z "${ZSH_VERSION}" ]; then
         compopt -o nospace
     fi
 
-    if [ -z "$filterpath" ]; then
+    if [ -z "${filterpath}" ]; then
         COMPREPLY=($(compgen_compat -d -- ${cur}))
     else
-        COMPREPLY=($(compgen_compat ${arg[@]} -f -X "!$filterpath" -- ${cur}))
+        COMPREPLY=($(compgen_compat ${arg[@]} -f -X "!${filterpath}" -- ${cur}))
     fi
 
     if [ ${#COMPREPLY[@]} = 1 ]; then
-        [ -d "$COMPREPLY" ] && LASTCHAR=/
-        [ -z "$ZSH_VERSION" ] && \
-            COMPREPLY=$(printf %q%s "$COMPREPLY" "$LASTCHAR")
+        [ -d "${COMPREPLY}" ] && LASTCHAR=/
+        [ -z "${ZSH_VERSION}" ] && \
+            COMPREPLY=$(printf %q%s "${COMPREPLY}" "${LASTCHAR}")
     else
         for ((i=0; i < ${#COMPREPLY[@]}; i++)); do
-            [ -z "$ZSH_VERSION" ] && [ -d "${COMPREPLY[$i]}" ] && \
-                COMPREPLY[$i]=${COMPREPLY[$i]}/
+            [ -z "${ZSH_VERSION}" ] && [ -d "${COMPREPLY[${i}]}" ] && \
+                COMPREPLY[${i}]=${COMPREPLY[${i}]}/
         done
     fi
 }
@@ -440,13 +440,13 @@ _tcbcomp_helper_filter_files() {
     _tcbcomp_helper_filter_files_and_dirs "$1" true
 }
 
-# return in $COMPREPLY a list of directories starting from the current
+# return in ${COMPREPLY} a list of directories starting from the current
 # working directory.
 _tcbcomp_helper_filter_dirs() {
     _tcbcomp_helper_filter_files_and_dirs ""
 }
 
-# return in $COMPREPLY a list of static options passed as a parameter
+# return in ${COMPREPLY} a list of static options passed as a parameter
 # to this function, removing the list the last typed word
 _tcbcomp_helper_static_options() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
@@ -454,7 +454,7 @@ _tcbcomp_helper_static_options() {
     local opts=($(compgen_compat -W "$@" -- ${cur}))
     local i=0
     for opt in "${opts[@]}"; do
-      [ "$opt" = "$prev" ] && unset opts["$i"]
+      [ "${opt}" = "${prev}" ] && unset opts["${i}"]
       ((++i))
     done
     COMPREPLY=(${opts[@]})
@@ -469,18 +469,18 @@ _tcbcomp_helper_find_subcmd() {
     local cmd_found=0
     local i=1
 
-    while [ $i -lt $((COMP_CWORD+1)) ]; do
+    while [ ${i} -lt $((COMP_CWORD+1)) ]; do
         local word="${COMP_WORDS[i]}"
         local opt=""
 
-        first_chars=$(echo $word | cut -c1-2)
+        first_chars=$(echo ${word} | cut -c1-2)
 
-        if [ "$word" == "$cmd" ]; then
+        if [ "${word}" == "${cmd}" ]; then
             cmd_found=1
-        elif [ "$cmd_found" == "1" -a "$first_chars" != "--" ]; then
-            for opt in $opts; do
-                if [ "$word" == "$opt" ]; then
-                    echo $word
+        elif [ "${cmd_found}" == "1" -a "${first_chars}" != "--" ]; then
+            for opt in ${opts}; do
+                if [ "${word}" == "${opt}" ]; then
+                    echo ${word}
                     return
                 fi
             done
@@ -494,15 +494,15 @@ _tcbcomp_helper_find_subcmd() {
 _tcbcomp_build() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         --file)
             _tcbcomp_helper_filter_files_and_dirs "*.y*ml"
             ;;
         --set)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_BUILD_SET"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_BUILD_SET}"
             ;;
         *)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_BUILD"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_BUILD}"
             ;;
     esac
 }
@@ -514,54 +514,54 @@ _tcbcomp_bundle() {
     local prev2="${COMP_WORDS[COMP_CWORD-2]}"
     local prev3="${COMP_WORDS[COMP_CWORD-3]}"
 
-    case "$prev3" in
+    case "${prev3}" in
         --login-to)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_PASSWORD"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_PASSWORD}"
             return
             ;;
     esac
 
-    case "$prev2" in
+    case "${prev2}" in
         --login)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_PASSWORD"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_PASSWORD}"
             return
             ;;
         --login-to)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_USERNAME"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_USERNAME}"
             return
             ;;
         --cacert-to)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_CERT"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_CERT}"
             ;;
     esac
 
-    case "$prev1" in
+    case "${prev1}" in
         --bundle-directory)
             _tcbcomp_helper_filter_dirs
             ;;
         --platform)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_BUNDLE_PLATFORM"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_BUNDLE_PLATFORM}"
             ;;
         --login)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_USERNAME"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_USERNAME}"
             ;;
         --login-to)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REGISTRY"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REGISTRY}"
             ;;
         --cacert-to)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REGISTRY"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REGISTRY}"
             ;;
         --dind-param)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_DIND_PARAM"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_DIND_PARAM}"
             ;;
         --dind-env)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_DIND_ENV"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_DIND_ENV}"
             ;;
         *)
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_BUNDLE"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_BUNDLE}"
             fi
-            if [ -z "$COMPREPLY" ]; then
+            if [ -z "${COMPREPLY}" ]; then
                 _tcbcomp_helper_filter_files_and_dirs "*.y*ml"
             fi
             ;;
@@ -573,24 +573,24 @@ _tcbcomp_combine() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         --bundle-directory)
             _tcbcomp_helper_filter_dirs
             ;;
         --image-name)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_IMAGE_NAME"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_IMAGE_NAME}"
             ;;
         --image-description)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_IMAGE_DESCRIPTION"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_IMAGE_DESCRIPTION}"
             ;;
         --image-licence|--image-release-notes)
             _tcbcomp_helper_filter_files_and_dirs "*"
             ;;
         *)
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_COMBINE"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_COMBINE}"
             fi
-            if [ -z "$COMPREPLY" ]; then
+            if [ -z "${COMPREPLY}" ]; then
                 _tcbcomp_helper_filter_dirs
             fi
             ;;
@@ -601,40 +601,40 @@ _tcbcomp_combine() {
 _tcbcomp_deploy() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         --bundle-directory|--output-directory|--deploy-sysroot-directory)
             _tcbcomp_helper_filter_dirs
             ;;
         --image-name)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_IMAGE_NAME"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_IMAGE_NAME}"
             ;;
         --image-description)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_IMAGE_DESCRIPTION"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_IMAGE_DESCRIPTION}"
             ;;
         --remote-host)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_HOST"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REMOTE_HOST}"
             ;;
         --remote-username)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_USERNAME"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REMOTE_USERNAME}"
             ;;
         --remote-password)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_PASSWORD"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REMOTE_PASSWORD}"
             ;;
         --remote-port)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_PORT"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REMOTE_PORT}"
             ;;
         --mdns-source)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_MDNS_SOURCE"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_MDNS_SOURCE}"
             ;;
         --image-licence|--image-release-notes)
             _tcbcomp_helper_filter_files_and_dirs "*"
             ;;
         *)
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEPLOY"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEPLOY}"
             fi
-            if [ -z "$COMPREPLY" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_OSTREE_REF"
+            if [ -z "${COMPREPLY}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_OSTREE_REF}"
             fi
             ;;
     esac
@@ -645,17 +645,17 @@ _tcbcomp_dt_apply() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         --include-dir)
             _tcbcomp_helper_filter_dirs
             ;;
         *.dts)
             ;;
         *)
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DT_APPLY"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DT_APPLY}"
             fi
-            if [ -z "$COMPREPLY" ]; then
+            if [ -z "${COMPREPLY}" ]; then
                 _tcbcomp_helper_filter_files_and_dirs "*.dts"
             fi
             ;;
@@ -666,21 +666,21 @@ _tcbcomp_dt_apply() {
 _tcbcomp_dt() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    local cmd=$(_tcbcomp_helper_find_subcmd "dt" "$_TCBCOMP_ARGS_DT")
+    local cmd=$(_tcbcomp_helper_find_subcmd "dt" "${_TCBCOMP_ARGS_DT}")
 
-    case "$cmd" in
+    case "${cmd}" in
         status)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DT_STATUS"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DT_STATUS}"
             ;;
         checkout)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DT_CHECKOUT"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DT_CHECKOUT}"
             ;;
         apply)
             _tcbcomp_dt_apply
             ;;
         *)
-            if [ "$prev" = "dt" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DT"
+            if [ "${prev}" = "dt" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DT}"
             fi
             ;;
     esac
@@ -692,7 +692,7 @@ _tcbcomp_dto_apply() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
     local prev2="${COMP_WORDS[COMP_CWORD-2]}"
 
-    case "$prev" in
+    case "${prev}" in
         --include-dir)
             _tcbcomp_helper_filter_dirs
             ;;
@@ -700,21 +700,21 @@ _tcbcomp_dto_apply() {
             _tcbcomp_helper_filter_files_and_dirs "*.dts"
             ;;
         *.dts)
-            if [ "$prev2" != "--device-tree" ]; then
+            if [ "${prev2}" != "--device-tree" ]; then
                 return;
             fi
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DTO_APPLY"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DTO_APPLY}"
             fi
-            if [ -z "$COMPREPLY" ]; then
+            if [ -z "${COMPREPLY}" ]; then
                 _tcbcomp_helper_filter_files_and_dirs "*.dts"
             fi
             ;;
         *)
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DTO_APPLY"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DTO_APPLY}"
             fi
-            if [ -z "$COMPREPLY" ]; then
+            if [ -z "${COMPREPLY}" ]; then
                 _tcbcomp_helper_filter_files_and_dirs "*.dts"
             fi
             ;;
@@ -725,12 +725,12 @@ _tcbcomp_dto_apply() {
 _tcbcomp_dto_list() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         --device-tree)
             _tcbcomp_helper_filter_files_and_dirs "*.dts"
             ;;
         *)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DTO_LIST"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DTO_LIST}"
             ;;
     esac
 }
@@ -739,11 +739,11 @@ _tcbcomp_dto_list() {
 _tcbcomp_dto_remove() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         *.dtbo)
             ;;
         *)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DTO_REMOVE"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DTO_REMOVE}"
             ;;
     esac
 }
@@ -754,7 +754,7 @@ _tcbcomp_dto_deploy() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
     local prev2="${COMP_WORDS[COMP_CWORD-2]}"
 
-    case "$prev" in
+    case "${prev}" in
         --include-dir)
             _tcbcomp_helper_filter_dirs
             ;;
@@ -762,36 +762,36 @@ _tcbcomp_dto_deploy() {
             _tcbcomp_helper_filter_files_and_dirs "*.dts"
             ;;
         --remote-host)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_HOST"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REMOTE_HOST}"
             ;;
         --remote-username)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_USERNAME"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REMOTE_USERNAME}"
             ;;
         --remote-password)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_PASSWORD"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REMOTE_PASSWORD}"
             ;;
         --remote-port)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_PORT"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REMOTE_PORT}"
             ;;
         --mdns-source)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_MDNS_SOURCE"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_MDNS_SOURCE}"
             ;;
         *.dts)
-            if [ "$prev2" != "--device-tree" ]; then
+            if [ "${prev2}" != "--device-tree" ]; then
                 return;
             fi
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DTO_DEPLOY"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DTO_DEPLOY}"
             fi
-            if [ -z "$COMPREPLY" ]; then
+            if [ -z "${COMPREPLY}" ]; then
                 _tcbcomp_helper_filter_files_and_dirs "*.dts"
             fi
             ;;
         *)
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DTO_DEPLOY"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DTO_DEPLOY}"
             fi
-            if [ -z "$COMPREPLY" ]; then
+            if [ -z "${COMPREPLY}" ]; then
                 _tcbcomp_helper_filter_files_and_dirs "*.dts"
             fi
             ;;
@@ -801,9 +801,9 @@ _tcbcomp_dto_deploy() {
 # 'dto' command
 _tcbcomp_dto() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
-    local cmd=$(_tcbcomp_helper_find_subcmd "dto" "$_TCBCOMP_ARGS_DTO")
+    local cmd=$(_tcbcomp_helper_find_subcmd "dto" "${_TCBCOMP_ARGS_DTO}")
 
-    case "$cmd" in
+    case "${cmd}" in
         apply)
             _tcbcomp_dto_apply
             ;;
@@ -811,7 +811,7 @@ _tcbcomp_dto() {
             _tcbcomp_dto_list
             ;;
         status)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DTO_STATUS"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DTO_STATUS}"
             ;;
         remove)
             _tcbcomp_dto_remove
@@ -820,8 +820,8 @@ _tcbcomp_dto() {
             _tcbcomp_dto_deploy
             ;;
         *)
-            if [ "$prev" = "dto" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DTO"
+            if [ "${prev}" = "dto" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DTO}"
             fi
             ;;
     esac
@@ -832,12 +832,12 @@ _tcbcomp_images_unpack() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         *)
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_IMAGES_UNPACK"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_IMAGES_UNPACK}"
             fi
-            if [ -z "$COMPREPLY" ]; then
+            if [ -z "${COMPREPLY}" ]; then
                 _tcbcomp_helper_filter_files_and_dirs "*"
             fi
             ;;
@@ -848,24 +848,24 @@ _tcbcomp_images_unpack() {
 _tcbcomp_images_download() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         --remote-host)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_HOST"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REMOTE_HOST}"
             ;;
         --remote-username)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_USERNAME"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REMOTE_USERNAME}"
             ;;
         --remote-password)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_PASSWORD"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REMOTE_PASSWORD}"
             ;;
         --remote-port)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_PORT"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REMOTE_PORT}"
             ;;
         --mdns-source)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_MDNS_SOURCE"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_MDNS_SOURCE}"
             ;;
         *)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_IMAGES_DOWNLOAD"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_IMAGES_DOWNLOAD}"
             ;;
     esac
 }
@@ -875,24 +875,24 @@ _tcbcomp_images_provision() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         --mode)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_IMAGES_PROVISION_MODES"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_IMAGES_PROVISION_MODES}"
             ;;
         --shared-data)
             _tcbcomp_helper_filter_files_and_dirs "*.tar.gz"
             ;;
         --online-data)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_ONLINE_PROVDATA"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_ONLINE_PROVDATA}"
             ;;
         --fleet)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_FLEET_UUID"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_FLEET_UUID}"
             ;;
         *)
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_IMAGES_PROVISION"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_IMAGES_PROVISION}"
             fi
-            if [ -z "$COMPREPLY" ]; then
+            if [ -z "${COMPREPLY}" ]; then
                 _tcbcomp_helper_filter_dirs
             fi
             ;;
@@ -904,12 +904,12 @@ _tcbcomp_images_serve() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         *)
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_IMAGES_SERVE"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_IMAGES_SERVE}"
             fi
-            if [ -z "$COMPREPLY" ]; then
+            if [ -z "${COMPREPLY}" ]; then
                 _tcbcomp_helper_filter_dirs
             fi
             ;;
@@ -918,9 +918,9 @@ _tcbcomp_images_serve() {
 
 # 'images' command
 _tcbcomp_images() {
-    local cmd=$(_tcbcomp_helper_find_subcmd "images" "$_TCBCOMP_ARGS_IMAGES")
+    local cmd=$(_tcbcomp_helper_find_subcmd "images" "${_TCBCOMP_ARGS_IMAGES}")
 
-    case "$cmd" in
+    case "${cmd}" in
         download)
             _tcbcomp_images_download
             ;;
@@ -934,7 +934,7 @@ _tcbcomp_images() {
             _tcbcomp_images_unpack
             ;;
         *)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_IMAGES"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_IMAGES}"
             ;;
     esac
 }
@@ -943,27 +943,27 @@ _tcbcomp_images() {
 _tcbcomp_isolate() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         --changes-directory)
             _tcbcomp_helper_filter_dirs
             ;;
         --remote-host)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_HOST"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REMOTE_HOST}"
             ;;
         --remote-username)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_USERNAME"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REMOTE_USERNAME}"
             ;;
         --remote-password)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_PASSWORD"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REMOTE_PASSWORD}"
             ;;
         --remote-port)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_PORT"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REMOTE_PORT}"
             ;;
         --mdns-source)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_MDNS_SOURCE"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_MDNS_SOURCE}"
             ;;
         *)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_ISOLATE"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_ISOLATE}"
             ;;
     esac
 }
@@ -973,12 +973,12 @@ _tcbcomp_kernel_build_module() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         *)
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_KERNEL_BUILD_MODULE"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_KERNEL_BUILD_MODULE}"
             fi
-            if [ -z "$COMPREPLY" ]; then
+            if [ -z "${COMPREPLY}" ]; then
                 _tcbcomp_helper_filter_dirs "*"
             fi
             ;;
@@ -990,13 +990,13 @@ _tcbcomp_kernel_set_custom_args() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         set_custom_args)
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_KERNEL_SET_CUSTOM_ARGS"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_KERNEL_SET_CUSTOM_ARGS}"
             fi
-            if [ -z "$COMPREPLY" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_KERNEL_ARGS"
+            if [ -z "${COMPREPLY}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_KERNEL_ARGS}"
             fi
             ;;
     esac
@@ -1004,9 +1004,9 @@ _tcbcomp_kernel_set_custom_args() {
 
 # 'kernel' command
 _tcbcomp_kernel() {
-    local cmd=$(_tcbcomp_helper_find_subcmd "kernel" "$_TCBCOMP_ARGS_KERNEL")
+    local cmd=$(_tcbcomp_helper_find_subcmd "kernel" "${_TCBCOMP_ARGS_KERNEL}")
 
-    case "$cmd" in
+    case "${cmd}" in
         build_module)
             _tcbcomp_kernel_build_module
             ;;
@@ -1014,13 +1014,13 @@ _tcbcomp_kernel() {
             _tcbcomp_kernel_set_custom_args
             ;;
         get_custom_args)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_KERNEL_GET_CUSTOM_ARGS"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_KERNEL_GET_CUSTOM_ARGS}"
             ;;
         clear_custom_args)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_KERNEL_CLEAR_CUSTOM_ARGS"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_KERNEL_CLEAR_CUSTOM_ARGS}"
             ;;
         *)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_KERNEL"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_KERNEL}"
             ;;
     esac
 }
@@ -1029,12 +1029,12 @@ _tcbcomp_kernel() {
 _tcbcomp_ostree_serve() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         --ostree-repo-directory)
             _tcbcomp_helper_filter_dirs
             ;;
         *)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_OSTREE_SERVE"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_OSTREE_SERVE}"
             ;;
     esac
 }
@@ -1042,14 +1042,14 @@ _tcbcomp_ostree_serve() {
 # 'ostree' command
 _tcbcomp_ostree() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
-    local cmd=$(_tcbcomp_helper_find_subcmd "ostree" "$_TCBCOMP_ARGS_OSTREE")
+    local cmd=$(_tcbcomp_helper_find_subcmd "ostree" "${_TCBCOMP_ARGS_OSTREE}")
 
-    case "$cmd" in
+    case "${cmd}" in
         serve)
             _tcbcomp_ostree_serve
             ;;
         *)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_OSTREE"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_OSTREE}"
             ;;
     esac
 }
@@ -1060,58 +1060,58 @@ _tcbcomp_platform_lockbox() {
     local prev2="${COMP_WORDS[COMP_CWORD-2]}"
     local prev3="${COMP_WORDS[COMP_CWORD-3]}"
 
-    case "$prev3" in
+    case "${prev3}" in
         --login-to)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_PASSWORD"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_PASSWORD}"
             return
             ;;
     esac
 
-    case "$prev2" in
+    case "${prev2}" in
         --login)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_PASSWORD"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_PASSWORD}"
             return
             ;;
         --login-to)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_USERNAME"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_USERNAME}"
             return
             ;;
         --cacert-to)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_CERT"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_CERT}"
             ;;
     esac
 
-    case "$prev1" in
+    case "${prev1}" in
         --credentials)
             _tcbcomp_helper_filter_files_and_dirs "credentials.zip"
             ;;
         --platform)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_PLATFORM_LOCKBOX_PLATFORM"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_PLATFORM_LOCKBOX_PLATFORM}"
             ;;
         --login)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_USERNAME"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_USERNAME}"
             ;;
         --login-to)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REGISTRY"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REGISTRY}"
             ;;
         --cacert-to)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REGISTRY"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_REGISTRY}"
             ;;
         --dind-param)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_DIND_PARAM"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_DIND_PARAM}"
             ;;
         --dind-env)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_DIND_ENV"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_DIND_ENV}"
             ;;
         --output-directory)
             _tcbcomp_helper_filter_dirs
             ;;
         *)
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_PLATFORM_LOCKBOX"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_PLATFORM_LOCKBOX}"
             fi
-            if [ -z "$COMPREPLY" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_LOCKBOX_NAME"
+            if [ -z "${COMPREPLY}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_LOCKBOX_NAME}"
             fi
             ;;
     esac
@@ -1121,19 +1121,19 @@ _tcbcomp_platform_provisioning_data() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         --credentials)
             _tcbcomp_helper_filter_files_and_dirs "credentials.zip"
             ;;
         --shared-data)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_SHARED_DATA"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_SHARED_DATA}"
             ;;
         --online-data)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_CLIENT_NAME"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_CLIENT_NAME}"
             ;;
         *)
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_PLATFORM_PROVDATA"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_PLATFORM_PROVDATA}"
             fi
             ;;
     esac
@@ -1145,9 +1145,9 @@ _tcbcomp_platform_push() {
 
 # 'platform' command
 _tcbcomp_platform() {
-    local cmd=$(_tcbcomp_helper_find_subcmd "platform" "$_TCBCOMP_ARGS_PLATFORM")
+    local cmd=$(_tcbcomp_helper_find_subcmd "platform" "${_TCBCOMP_ARGS_PLATFORM}")
 
-    case "$cmd" in
+    case "${cmd}" in
         lockbox)
             _tcbcomp_platform_lockbox
             ;;
@@ -1158,12 +1158,12 @@ _tcbcomp_platform() {
             _tcbcomp_platform_push
             ;;
         *)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_PLATFORM"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_PLATFORM}"
             ;;
     esac
 }
 
-# return in $COMPREPLY a list of references. references can either be
+# return in ${COMPREPLY} a list of references. references can either be
 # a compose file ending with .yaml/yml or the list of references from
 # the ostree folder if the `--repo` argument is already present and it
 # points to a valid ostree folder.
@@ -1181,13 +1181,13 @@ _tcbcomp_push_reference() {
         fi
     done
 
-    repo=$(echo $repo | tr -d '"')
-    local refs_path="$PWD/$repo/refs/heads/"
+    repo=$(echo ${repo} | tr -d '"')
+    local refs_path="${PWD}/${repo}/refs/heads/"
 
-    if [ -d "$refs_path"  -a -n "$repo" ]; then
-        local results=($(find "$refs_path" -type f 2>/dev/null))
-        results=${results[@]/$refs_path/}
-        COMPREPLY=($(compgen_compat -W "$results" -- ${cur}))
+    if [ -d "${refs_path}"  -a -n "${repo}" ]; then
+        local results=($(find "${refs_path}" -type f 2>/dev/null))
+        results=${results[@]/${refs_path}/}
+        COMPREPLY=($(compgen_compat -W "${results}" -- ${cur}))
     else
         _tcbcomp_helper_filter_files "*.y*ml"
     fi
@@ -1197,7 +1197,7 @@ _tcbcomp_push_reference() {
 _tcbcomp_push() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         --credentials)
             _tcbcomp_helper_filter_files_and_dirs "credentials.zip"
             ;;
@@ -1205,19 +1205,19 @@ _tcbcomp_push() {
             _tcbcomp_helper_filter_dirs
             ;;
         --hardwareid)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_HARDWAREID"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_HARDWAREID}"
             ;;
         --package-name)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_PACKAGE_NAME"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_PACKAGE_NAME}"
             ;;
         --package-version)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_PACKAGE_VERSION"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_PACKAGE_VERSION}"
             ;;
         *)
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_PUSH"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_PUSH}"
             fi
-            if [ -z "$COMPREPLY" ]; then
+            if [ -z "${COMPREPLY}" ]; then
                 _tcbcomp_push_reference
             fi
             ;;
@@ -1229,12 +1229,12 @@ _tcbcomp_splash() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         *)
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SPLASH"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_SPLASH}"
             fi
-            if [ -z "$COMPREPLY" ]; then
+            if [ -z "${COMPREPLY}" ]; then
                 _tcbcomp_helper_filter_files_and_dirs "*"
             fi
             ;;
@@ -1245,32 +1245,32 @@ _tcbcomp_splash() {
 _tcbcomp_secboot_sign_bootloader_hab() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         --cst-dir)
             _tcbcomp_helper_filter_dirs
             ;;
         --cst-crypto)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SECBOOT_CST_CRYPTO"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_SECBOOT_CST_CRYPTO}"
             ;;
         --cst-key-size|--cst-key-exp)
             ;;
         --cst-dig-algo)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SECBOOT_CST_DIG_ALGO"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_SECBOOT_CST_DIG_ALGO}"
             ;;
         --cst-srk-index)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SECBOOT_CST_SRK_INDEX"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_SECBOOT_CST_SRK_INDEX}"
             ;;
         --cst-srk-table|--cst-srk-fuse)
             _tcbcomp_helper_filter_files_and_dirs "*.bin"
             ;;
         --kernel-key)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_KERNEL_KEY"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_KERNEL_KEY}"
             ;;
         --kernel-key-dir)
             _tcbcomp_helper_filter_dirs
             ;;
         *)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SECBOOT_SIGN_BOOTLOADER_HAB"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_SECBOOT_SIGN_BOOTLOADER_HAB}"
             ;;
     esac
 }
@@ -1279,30 +1279,30 @@ _tcbcomp_secboot_sign_bootloader_hab() {
 _tcbcomp_secboot_sign_kernel() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         --kernel-key)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_KERNEL_KEY"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_KERNEL_KEY}"
             ;;
         --kernel-key-dir)
             _tcbcomp_helper_filter_dirs
             ;;
         --ostree-key)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_OSTREE_KEY"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_OSTREE_KEY}"
             ;;
         --ostree-key-dir)
             _tcbcomp_helper_filter_dirs
             ;;
         *)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SECBOOT_SIGN_KERNEL"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_SECBOOT_SIGN_KERNEL}"
             ;;
     esac
 }
 
 # 'secboot' command
 _tcbcomp_secboot() {
-    local cmd=$(_tcbcomp_helper_find_subcmd "secboot" "$_TCBCOMP_ARGS_SECBOOT")
+    local cmd=$(_tcbcomp_helper_find_subcmd "secboot" "${_TCBCOMP_ARGS_SECBOOT}")
 
-    case "$cmd" in
+    case "${cmd}" in
         sign-bootloader-hab)
             _tcbcomp_secboot_sign_bootloader_hab
             ;;
@@ -1310,7 +1310,7 @@ _tcbcomp_secboot() {
             _tcbcomp_secboot_sign_kernel
             ;;
         *)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SECBOOT"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_SECBOOT}"
             ;;
     esac
 }
@@ -1319,28 +1319,28 @@ _tcbcomp_secboot() {
 _tcbcomp_union() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         --changes-directory)
             _tcbcomp_helper_filter_dirs
             ;;
         --subject)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_SUBJECT"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_SUBJECT}"
             ;;
         --body)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_BODY"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_BODY}"
             ;;
         --ostree-key)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_OSTREE_KEY"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_OSTREE_KEY}"
             ;;
         --ostree-key-dir)
             _tcbcomp_helper_filter_dirs
             ;;
         *)
-            if [ -n "$cur" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_UNION"
+            if [ -n "${cur}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_UNION}"
             fi
-            if [ -z "$COMPREPLY" ]; then
-                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_UNION_BRANCH"
+            if [ -z "${COMPREPLY}" ]; then
+                _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_DEF_UNION_BRANCH}"
             fi
             ;;
     esac
@@ -1348,9 +1348,9 @@ _tcbcomp_union() {
 
 # 'splash-config' command
 _tcbcomp_splash_config() {
-    local cmd=$(_tcbcomp_helper_find_subcmd "splash-config" "$_TCBCOMP_ARGS_SPLASH_CONFIG")
+    local cmd=$(_tcbcomp_helper_find_subcmd "splash-config" "${_TCBCOMP_ARGS_SPLASH_CONFIG}")
 
-    case "$cmd" in
+    case "${cmd}" in
         set)
             _tcbcomp_splash_config_set
             ;;
@@ -1358,7 +1358,7 @@ _tcbcomp_splash_config() {
             _tcbcomp_splash_config_dump
             ;;
         *)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SPLASH_CONFIG"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_SPLASH_CONFIG}"
             ;;
     esac
 }
@@ -1367,10 +1367,10 @@ _tcbcomp_splash_config() {
 _tcbcomp_splash_config_set() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
 
-    if [ -n "$cur" ]; then
-        _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SPLASH_CONFIG_SET"
+    if [ -n "${cur}" ]; then
+        _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_SPLASH_CONFIG_SET}"
     fi
-    if [ -z "$COMPREPLY" ]; then
+    if [ -z "${COMPREPLY}" ]; then
         _tcbcomp_helper_filter_files_and_dirs "*"
     fi
 }
@@ -1379,12 +1379,12 @@ _tcbcomp_splash_config_set() {
 _tcbcomp_splash_config_dump() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    case "$prev" in
+    case "${prev}" in
         --file)
             _tcbcomp_helper_filter_files_and_dirs "*"
             ;;
         *)
-            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SPLASH_CONFIG_DUMP"
+            _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_SPLASH_CONFIG_DUMP}"
             ;;
     esac
 }
@@ -1395,21 +1395,21 @@ _tcbcomp() {
     local i=1 cmd
 
     # find the subcommand
-    while [[ "$i" -lt "$COMP_CWORD" ]]
+    while [[ "${i}" -lt "${COMP_CWORD}" ]]
     do
         local s="${COMP_WORDS[i]}"
         i=$((i + 1))
-        case "$s" in
+        case "${s}" in
             --log-level)
-                if [ "$i" -eq "$COMP_CWORD" ]; then
-                    _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_MAIN_LOGLEVEL"
+                if [ "${i}" -eq "${COMP_CWORD}" ]; then
+                    _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_MAIN_LOGLEVEL}"
                     return
                 else
                     i=$((i + 1))
                 fi
                 ;;
             --log-file)
-                if [ "$i" -eq "$COMP_CWORD" ]; then
+                if [ "${i}" -eq "${COMP_CWORD}" ]; then
                     _tcbcomp_helper_filter_files_and_dirs "*"
                     return
                 else
@@ -1419,18 +1419,18 @@ _tcbcomp() {
             -*)
                 ;;
             *)
-                cmd="$s"
+                cmd="${s}"
                 break
                 ;;
         esac
     done
 
-    if [ -z "$cmd" ]; then
-        _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_MAIN"
+    if [ -z "${cmd}" ]; then
+        _tcbcomp_helper_static_options "${_TCBCOMP_ARGS_MAIN}"
         return
     fi
 
-    case "$cmd" in
+    case "${cmd}" in
         build)
             _tcbcomp_build
             ;;
@@ -1485,7 +1485,7 @@ _tcbcomp() {
 }
 
 compgen_compat() {
-    if [ -z "$ZSH_VERSION" ]; then
+    if [ -z "${ZSH_VERSION}" ]; then
         compgen "$@"
     else
         compgen_zsh "$@"
@@ -1537,35 +1537,35 @@ compgen_zsh() {
         shift
     done
 
-    if [ "$COMP_OPTION" = "plusdirs" ]; then
+    if [ "${COMP_OPTION}" = "plusdirs" ]; then
         ARGS+='adp'
     fi
 
-    if [ -n "$WORD" -a -n "$CUR" ]; then
-        echo "$WORD" | awk 'NF' | tr ' ' '\n' | sed -En "s;^($CUR.*)$;\1;p"
+    if [ -n "${WORD}" -a -n "${CUR}" ]; then
+        echo "${WORD}" | awk 'NF' | tr ' ' '\n' | sed -En "s;^(${CUR}.*)$;\1;p"
         return
     fi
 
-    # Update pattern to comply with compgen -X '<patter>'
-    if [ -n "$X" ]; then
-        if [ "$COMP_OPTION" = "plusdirs" ]; then
-            FILTER="/($X|.*\/)$/p;"
+    # Update pattern to comply with compgen -X '<pattern>'
+    if [ -n "${X}" ]; then
+        if [ "${COMP_OPTION}" = "plusdirs" ]; then
+            FILTER="/(${X}|.*\/)$/p;"
         else
-            FILTER="/$X$/p;"
+            FILTER="/${X}$/p;"
         fi
     fi
 
     # Gets the base dir and add `(.*|*)`.
-    [ -d "$CUR" -a "$CUR" != '..' ] && R_PATH="$CUR(.*|*)"
-    if [ ! -d "$CUR" -a -n "$CUR" ]; then
-        [ $(dirname -- "$CUR") = '.' ] && R_PATH="(.*|*)" || \
-                R_PATH=$(dirname -- "$CUR" | sed -En -e 's@$@\/(.*|*)@p')
+    [ -d "${CUR}" -a "${CUR}" != '..' ] && R_PATH="${CUR}(.*|*)"
+    if [ ! -d "${CUR}" -a -n "${CUR}" ]; then
+        [ $(dirname -- "${CUR}") = '.' ] && R_PATH="(.*|*)" || \
+                R_PATH=$(dirname -- "${CUR}" | sed -En -e 's@$@\/(.*|*)@p')
     fi
 
     # If either no arguments are passed or the target folder is empty, return nothing
-    [ "$ARGS" = "-1" -o $( (eval "ls -1d $R_PATH" 2>/dev/null) | wc -l) -eq 0 ] && return
+    [ "${ARGS}" = "-1" -o $( (eval "ls -1d ${R_PATH}" 2>/dev/null) | wc -l) -eq 0 ] && return
 
-    eval "ls $ARGS $R_PATH | sed -En -e '$DIR_FILTER' | sed -En -e '$FILTER' | sed -En -e 's;^($CUR.*)$;\1;p'"
+    eval "ls ${ARGS} ${R_PATH} | sed -En -e '${DIR_FILTER}' | sed -En -e '${FILTER}' | sed -En -e 's;^(${CUR}.*)$;\1;p'"
 }
 
 _bash_complete_zsh () {
@@ -1573,23 +1573,23 @@ _bash_complete_zsh () {
     local -a suf matches
     local -x COMP_POINT COMP_CWORD
     local -a COMP_WORDS COMPREPLY BASH_VERSINFO
-    local -x COMP_LINE="$words"
+    local -x COMP_LINE="${words}"
     local -A savejobstates savejobtexts
     (( COMP_POINT = 1 + ${#${(j. .)words[1,CURRENT-1]}} + $#QIPREFIX + $#IPREFIX + $#PREFIX ))
     (( COMP_CWORD = CURRENT - 1))
-    COMP_WORDS=($words)
+    COMP_WORDS=(${words})
     BASH_VERSINFO=(2 05b 0 1 release)
     savejobstates=(${(kv)jobstates})
     savejobtexts=(${(kv)jobtexts})
     [[ ${argv[${argv[(I)nospace]:-0}-1]} = -o ]] && suf=(-S '')
     matches=(${(f)"$(compgen $@ -- ${words[CURRENT]})"})
-    if [[ -n $matches ]]; then
+    if [[ -n ${matches} ]]; then
 	if [[ ${argv[${argv[(I)filenames]:-0}-1]} = -o ]]; then
 	    compset -P '*/' && matches=(${matches##*/})
 	    compset -S '/*' && matches=(${matches%%/*})
 	    compadd -Q -f "${suf[@]}" -a matches && ret=0
 	else
-            if [ ${#matches[@]} = 1 ] && [ -d "$matches" ]; then
+            if [ ${#matches[@]} = 1 ] && [ -d "${matches}" ]; then
                 compadd -Q -S '' "${suf[@]}" -a matches && ret=0
             else
                 compadd -Q "${suf[@]}" -a matches && ret=0
@@ -1607,7 +1607,7 @@ _bash_complete_zsh () {
     return ret
 }
 
-if [ -z "$ZSH_VERSION" ]; then
+if [ -z "${ZSH_VERSION}" ]; then
     complete -o bashdefault -F _tcbcomp ${TCB_FUNCTION_NAME:-torizoncore-builder}
 else
     setopt completealiases

--- a/torizoncore-builder-completion.bash
+++ b/torizoncore-builder-completion.bash
@@ -18,6 +18,7 @@ _TCBCOMP_ARGS_MAIN="
     ostree
     platform
     push
+    secboot
     splash
     splash-config
     union
@@ -290,6 +291,52 @@ _TCBCOMP_ARGS_PUSH="
     --verbose
 "
 
+_TCBCOMP_ARGS_SECBOOT="
+    --help
+    sign-bootloader-hab
+    sign-kernel
+"
+
+_TCBCOMP_ARGS_SECBOOT_SIGN_BOOTLOADER_HAB="
+    --help
+    --cst-dir
+    --cst-crypto
+    --cst-key-size
+    --cst-key-exp
+    --cst-dig-algo
+    --cst-srk-index
+    --cst-srk-table
+    --cst-srk-fuse
+    --cst-srk-no-ca
+    --kernel-key
+    --kernel-key-dir
+"
+
+_TCBCOMP_ARGS_SECBOOT_CST_CRYPTO="
+    rsa
+    ecdsa
+"
+_TCBCOMP_ARGS_SECBOOT_CST_DIG_ALGO="
+    sha1
+    sha256
+    sha384
+    sha512
+"
+_TCBCOMP_ARGS_SECBOOT_CST_SRK_INDEX="
+    1
+    2
+    3
+    4
+"
+
+_TCBCOMP_ARGS_SECBOOT_SIGN_KERNEL="
+    --help
+    --kernel-key
+    --kernel-key-dir
+    --ostree-key
+    --ostree-key-dir
+"
+
 _TCBCOMP_ARGS_SPLASH="
     --help
 "
@@ -346,6 +393,8 @@ _TCBCOMP_ARGS_DEF_FLEET_UUID="_TYPE_HERE_FLEET_UUID_"
 _TCBCOMP_ARGS_DEF_LOCKBOX_NAME="_TYPE_HERE_LOCKBOX_NAME_"
 _TCBCOMP_ARGS_DEF_SHARED_DATA="_TYPE_HERE_SHARED_DATA_FILE_NAME_"
 _TCBCOMP_ARGS_DEF_CLIENT_NAME="_TYPE_HERE_API_CLIENT_NAME_"
+_TCBCOMP_ARGS_DEF_KERNEL_KEY="name=dev;algo=sha256,rsa2048"
+_TCBCOMP_ARGS_DEF_OSTREE_KEY="name=dev;algo=ed25519"
 
 # return in $COMPREPLY a list of files and directories starting from the
 # current working directory. The first parameter can be used to filter
@@ -1193,6 +1242,80 @@ _tcbcomp_splash() {
     esac
 }
 
+# 'secboot sign-bootloader-hab' command
+_tcbcomp_secboot_sign_bootloader_hab() {
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        --cst-dir)
+            _tcbcomp_helper_filter_dirs
+            ;;
+        --cst-crypto)
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SECBOOT_CST_CRYPTO"
+            ;;
+        --cst-key-size|--cst-key-exp)
+            ;;
+        --cst-dig-algo)
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SECBOOT_CST_DIG_ALGO"
+            ;;
+        --cst-srk-index)
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SECBOOT_CST_SRK_INDEX"
+            ;;
+        --cst-srk-table|--cst-srk-fuse)
+            _tcbcomp_helper_filter_files_and_dirs "*.bin"
+            ;;
+        --kernel-key)
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_KERNEL_KEY"
+            ;;
+        --kernel-key-dir)
+            _tcbcomp_helper_filter_dirs
+            ;;
+        *)
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SECBOOT_SIGN_BOOTLOADER_HAB"
+            ;;
+    esac
+}
+
+# 'secboot sign-kernel' command
+_tcbcomp_secboot_sign_kernel() {
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        --kernel-key)
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_KERNEL_KEY"
+            ;;
+        --kernel-key-dir)
+            _tcbcomp_helper_filter_dirs
+            ;;
+        --ostree-key)
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_OSTREE_KEY"
+            ;;
+        --ostree-key-dir)
+            _tcbcomp_helper_filter_dirs
+            ;;
+        *)
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SECBOOT_SIGN_KERNEL"
+            ;;
+    esac
+}
+
+# 'secboot' command
+_tcbcomp_secboot() {
+    local cmd=$(_tcbcomp_helper_find_subcmd "secboot" "$_TCBCOMP_ARGS_SECBOOT")
+
+    case "$cmd" in
+        sign-bootloader-hab)
+            _tcbcomp_secboot_sign_bootloader_hab
+            ;;
+        sign-kernel)
+            _tcbcomp_secboot_sign_kernel
+            ;;
+        *)
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SECBOOT"
+            ;;
+    esac
+}
+
 # 'union' command
 _tcbcomp_union() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
@@ -1344,6 +1467,9 @@ _tcbcomp() {
             ;;
         push)
             _tcbcomp_push
+            ;;
+        secboot)
+            _tcbcomp_secboot
             ;;
         splash)
             _tcbcomp_splash

--- a/torizoncore-builder-completion.bash
+++ b/torizoncore-builder-completion.bash
@@ -298,6 +298,8 @@ _TCBCOMP_ARGS_UNION="
     --changes-directory
     --subject
     --body
+    --ostree-key
+    --ostree-key-dir
 "
 
 # default value to complete parameters
@@ -1187,6 +1189,12 @@ _tcbcomp_union() {
             ;;
         --body)
             _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_BODY"
+            ;;
+        --ostree-key)
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_OSTREE_KEY"
+            ;;
+        --ostree-key-dir)
+            _tcbcomp_helper_filter_dirs
             ;;
         *)
             if [ -n "$cur" ]; then

--- a/torizoncore-builder-completion.bash
+++ b/torizoncore-builder-completion.bash
@@ -415,7 +415,7 @@ _tcbcomp_helper_filter_files_and_dirs() {
     fi
 
     if [ -z "$ZSH_VERSION" ]; then
-      compopt -o nospace
+        compopt -o nospace
     fi
 
     if [ -z "$filterpath" ]; then
@@ -427,11 +427,11 @@ _tcbcomp_helper_filter_files_and_dirs() {
     if [ ${#COMPREPLY[@]} = 1 ]; then
         [ -d "$COMPREPLY" ] && LASTCHAR=/
         [ -z "$ZSH_VERSION" ] && \
-        COMPREPLY=$(printf %q%s "$COMPREPLY" "$LASTCHAR")
+            COMPREPLY=$(printf %q%s "$COMPREPLY" "$LASTCHAR")
     else
         for ((i=0; i < ${#COMPREPLY[@]}; i++)); do
             [ -z "$ZSH_VERSION" ] && [ -d "${COMPREPLY[$i]}" ] && \
-            COMPREPLY[$i]=${COMPREPLY[$i]}/
+                COMPREPLY[$i]=${COMPREPLY[$i]}/
         done
     fi
 }
@@ -1191,7 +1191,6 @@ _tcbcomp_push_reference() {
     else
         _tcbcomp_helper_filter_files "*.y*ml"
     fi
-
 }
 
 # 'push' command
@@ -1486,137 +1485,133 @@ _tcbcomp() {
 }
 
 compgen_compat() {
-  if [ -z "$ZSH_VERSION" ]; then
-      compgen "$@"
-  else
-      compgen_zsh "$@"
-  fi
+    if [ -z "$ZSH_VERSION" ]; then
+        compgen "$@"
+    else
+        compgen_zsh "$@"
+    fi
 }
 
 # Mimics the results bash compgen function would output
 compgen_zsh() {
-  local R_PATH="*"
-  local CUR=".*"
-  local ARGS="-1"
-  local X
-  local WORD
-  local FILTER=";p"
-  local DIR_FILTER=";p"
+    local R_PATH="*"
+    local CUR=".*"
+    local ARGS="-1"
+    local X
+    local WORD
+    local FILTER=";p"
+    local DIR_FILTER=";p"
 
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --)
-        # Prevents unwanted output if nothing is passed after `--`
-        [ -n "$2" ] && shift || break;
-        CUR="$1"
-        ;;
-      -o)
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --)
+                # Prevents unwanted output if nothing is passed after `--`
+                [ -n "$2" ] && shift || break;
+                CUR="$1"
+                ;;
+            -o)
+                shift
+                COMP_OPTION="$1"
+                ;;
+            -d)
+                # Filter only Directories
+                ARGS+='adp'
+                DIR_FILTER='/\/$/p'
+                ;;
+            -f)
+                ARGS+='adp'
+                ;;
+            -X)
+                shift
+                # Dumb parser to comply with regex. tested only with the patterns in this file.
+                X=$(tr -d '!' <<< "$1" | sed -En -e  's@^\*@\.\*@1; s@\*@.?@2; s@\.@\\.@2; p;')
+                ;;
+            -W)
+                shift
+                WORD="$1"
+                ;;
+            *)
+
+                ;;
+        esac
         shift
-        COMP_OPTION="$1"
-        ;;
-      -d)
-        # Filter only Directories
-        ARGS+='adp'
-        DIR_FILTER='/\/$/p'
-      ;;
-      -f)
-        ARGS+='adp'
-      ;;
-      -X)
-        shift
-        # Dumb parser to comply with regex. tested only with the patterns in this file.
-        X=$(tr -d '!' <<< "$1" | sed -En -e  's@^\*@\.\*@1; s@\*@.?@2; s@\.@\\.@2; p;')
-      ;;
-      -W)
-        shift
-        WORD="$1"
-      ;;
-      *)
+    done
 
-      ;;
-    esac
-    shift
-  done
-
-  if [ "$COMP_OPTION" = "plusdirs" ]; then
-    ARGS+='adp'
-  fi
-
-  if [ -n "$WORD" -a -n "$CUR" ]; then
-    echo "$WORD" | awk 'NF' | tr ' ' '\n' | sed -En "s;^($CUR.*)$;\1;p"
-    return
-  fi
-
-  # Update pattern to comply with compgen -X '<patter>'
-  if [ -n "$X" ]; then
     if [ "$COMP_OPTION" = "plusdirs" ]; then
-      FILTER="/($X|.*\/)$/p;"
-    else
-      FILTER="/$X$/p;"
+        ARGS+='adp'
     fi
-  fi
 
-  # Gets the base dir and add `(.*|*)`.
-  [ -d "$CUR" -a "$CUR" != '..' ] && R_PATH="$CUR(.*|*)"
-  if [ ! -d "$CUR" -a -n "$CUR" ]; then
-    [ $(dirname -- "$CUR") = '.' ] && R_PATH="(.*|*)" || \
-    R_PATH=$(dirname -- "$CUR" | sed -En -e 's@$@\/(.*|*)@p')
-  fi
+    if [ -n "$WORD" -a -n "$CUR" ]; then
+        echo "$WORD" | awk 'NF' | tr ' ' '\n' | sed -En "s;^($CUR.*)$;\1;p"
+        return
+    fi
 
-  # If either no arguments are passed or the target folder is empty, return nothing
-  [ "$ARGS" = "-1" -o $( (eval "ls -1d $R_PATH" 2>/dev/null) | wc -l) -eq 0 ] && return
+    # Update pattern to comply with compgen -X '<patter>'
+    if [ -n "$X" ]; then
+        if [ "$COMP_OPTION" = "plusdirs" ]; then
+            FILTER="/($X|.*\/)$/p;"
+        else
+            FILTER="/$X$/p;"
+        fi
+    fi
 
-  eval "ls $ARGS $R_PATH | sed -En -e '$DIR_FILTER' | sed -En -e '$FILTER' | sed -En -e 's;^($CUR.*)$;\1;p'"
+    # Gets the base dir and add `(.*|*)`.
+    [ -d "$CUR" -a "$CUR" != '..' ] && R_PATH="$CUR(.*|*)"
+    if [ ! -d "$CUR" -a -n "$CUR" ]; then
+        [ $(dirname -- "$CUR") = '.' ] && R_PATH="(.*|*)" || \
+                R_PATH=$(dirname -- "$CUR" | sed -En -e 's@$@\/(.*|*)@p')
+    fi
+
+    # If either no arguments are passed or the target folder is empty, return nothing
+    [ "$ARGS" = "-1" -o $( (eval "ls -1d $R_PATH" 2>/dev/null) | wc -l) -eq 0 ] && return
+
+    eval "ls $ARGS $R_PATH | sed -En -e '$DIR_FILTER' | sed -En -e '$FILTER' | sed -En -e 's;^($CUR.*)$;\1;p'"
 }
 
 _bash_complete_zsh () {
-	local ret=1
-	local -a suf matches
-	local -x COMP_POINT COMP_CWORD
-	local -a COMP_WORDS COMPREPLY BASH_VERSINFO
-	local -x COMP_LINE="$words"
-	local -A savejobstates savejobtexts
-	(( COMP_POINT = 1 + ${#${(j. .)words[1,CURRENT-1]}} + $#QIPREFIX + $#IPREFIX + $#PREFIX ))
-	(( COMP_CWORD = CURRENT - 1))
-	COMP_WORDS=($words)
-	BASH_VERSINFO=(2 05b 0 1 release)
-	savejobstates=(${(kv)jobstates})
-	savejobtexts=(${(kv)jobtexts})
-	[[ ${argv[${argv[(I)nospace]:-0}-1]} = -o ]] && suf=(-S '')
-	matches=(${(f)"$(compgen $@ -- ${words[CURRENT]})"})
-	if [[ -n $matches ]]
+    local ret=1
+    local -a suf matches
+    local -x COMP_POINT COMP_CWORD
+    local -a COMP_WORDS COMPREPLY BASH_VERSINFO
+    local -x COMP_LINE="$words"
+    local -A savejobstates savejobtexts
+    (( COMP_POINT = 1 + ${#${(j. .)words[1,CURRENT-1]}} + $#QIPREFIX + $#IPREFIX + $#PREFIX ))
+    (( COMP_CWORD = CURRENT - 1))
+    COMP_WORDS=($words)
+    BASH_VERSINFO=(2 05b 0 1 release)
+    savejobstates=(${(kv)jobstates})
+    savejobtexts=(${(kv)jobtexts})
+    [[ ${argv[${argv[(I)nospace]:-0}-1]} = -o ]] && suf=(-S '')
+    matches=(${(f)"$(compgen $@ -- ${words[CURRENT]})"})
+    if [[ -n $matches ]]; then
+	if [[ ${argv[${argv[(I)filenames]:-0}-1]} = -o ]]; then
+	    compset -P '*/' && matches=(${matches##*/})
+	    compset -S '/*' && matches=(${matches%%/*})
+	    compadd -Q -f "${suf[@]}" -a matches && ret=0
+	else
+            if [ ${#matches[@]} = 1 ] && [ -d "$matches" ]; then
+                compadd -Q -S '' "${suf[@]}" -a matches && ret=0
+            else
+                compadd -Q "${suf[@]}" -a matches && ret=0
+            fi
+        fi
+    fi
+    if (( ret )); then
+	if [[ ${argv[${argv[(I)default]:-0}-1]} = -o ]]; then
+	    _default "${suf[@]}" && ret=0
+	elif [[ ${argv[${argv[(I)dirnames]:-0}-1]} = -o ]]
 	then
-		if [[ ${argv[${argv[(I)filenames]:-0}-1]} = -o ]]
-		then
-			compset -P '*/' && matches=(${matches##*/})
-			compset -S '/*' && matches=(${matches%%/*})
-			compadd -Q -f "${suf[@]}" -a matches && ret=0
-		else
-			if [ ${#matches[@]} = 1 ] && [ -d "$matches" ]; then
-        compadd -Q -S '' "${suf[@]}" -a matches && ret=0
-      else
-        compadd -Q "${suf[@]}" -a matches && ret=0
-      fi
-		fi
-	fi
-	if (( ret ))
-	then
-		if [[ ${argv[${argv[(I)default]:-0}-1]} = -o ]]
-		then
-			_default "${suf[@]}" && ret=0
-		elif [[ ${argv[${argv[(I)dirnames]:-0}-1]} = -o ]]
-		then
-			_directories "${suf[@]}" && ret=0
-		fi
-	fi
-	return ret
+            _directories "${suf[@]}" && ret=0
+        fi
+    fi
+    return ret
 }
 
 if [ -z "$ZSH_VERSION" ]; then
-  complete -o bashdefault -F _tcbcomp torizoncore-builder
+    complete -o bashdefault -F _tcbcomp torizoncore-builder
 else
-  setopt completealiases
-  autoload bashcompinit && bashcompinit
-  _function=('-F' '_tcbcomp')
-  compdef _bash_complete_zsh\ ${(j. .)${(q)_function}} torizoncore-builder
+    setopt completealiases
+    autoload bashcompinit && bashcompinit
+    _function=('-F' '_tcbcomp')
+    compdef _bash_complete_zsh\ ${(j. .)${(q)_function}} torizoncore-builder
 fi

--- a/torizoncore-builder-completion.bash
+++ b/torizoncore-builder-completion.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TCB_COMP_ARGS_MAIN="
+_TCBCOMP_ARGS_MAIN="
     -h --help
     --verbose
     --log-level
@@ -22,7 +22,7 @@ TCB_COMP_ARGS_MAIN="
     union
 "
 
-TCB_COMP_ARGS_MAIN_LOGLEVEL="
+_TCBCOMP_ARGS_MAIN_LOGLEVEL="
     debug
     info
     warning
@@ -30,7 +30,7 @@ TCB_COMP_ARGS_MAIN_LOGLEVEL="
     critical
 "
 
-TCB_COMP_ARGS_BUILD="
+_TCBCOMP_ARGS_BUILD="
     --help
     --create-template
     --file
@@ -39,11 +39,11 @@ TCB_COMP_ARGS_BUILD="
     --no-subst
 "
 
-TCB_COMP_ARGS_BUILD_SET="
+_TCBCOMP_ARGS_BUILD_SET="
     VAR=\"value\"
 "
 
-TCB_COMP_ARGS_BUNDLE="
+_TCBCOMP_ARGS_BUNDLE="
     --help
     --bundle-directory
     --force
@@ -56,12 +56,12 @@ TCB_COMP_ARGS_BUNDLE="
     --dind-env
 "
 
-TCB_COMP_ARGS_BUNDLE_PLATFORM="
+_TCBCOMP_ARGS_BUNDLE_PLATFORM="
     linux/arm/v7
     linux/arm64
 "
 
-TCB_COMP_ARGS_COMBINE="
+_TCBCOMP_ARGS_COMBINE="
     --help
     --bundle-directory
     --image-name
@@ -74,7 +74,7 @@ TCB_COMP_ARGS_COMBINE="
     --no-image-autoreboot
 "
 
-TCB_COMP_ARGS_DEPLOY="
+_TCBCOMP_ARGS_DEPLOY="
     --help
     --output-directory
     --remote-host
@@ -94,28 +94,28 @@ TCB_COMP_ARGS_DEPLOY="
     --no-image-autoreboot
 "
 
-TCB_COMP_ARGS_DT="
+_TCBCOMP_ARGS_DT="
     --help
     status
     checkout
     apply
 "
 
-TCB_COMP_ARGS_DT_STATUS="
+_TCBCOMP_ARGS_DT_STATUS="
     --help
 "
 
-TCB_COMP_ARGS_DT_CHECKOUT="
+_TCBCOMP_ARGS_DT_CHECKOUT="
     --help
     --update
 "
 
-TCB_COMP_ARGS_DT_APPLY="
+_TCBCOMP_ARGS_DT_APPLY="
     --help
     --include-dir
 "
 
-TCB_COMP_ARGS_DTO="
+_TCBCOMP_ARGS_DTO="
     --help
     apply
     list
@@ -124,28 +124,28 @@ TCB_COMP_ARGS_DTO="
     deploy
 "
 
-TCB_COMP_ARGS_DTO_APPLY="
+_TCBCOMP_ARGS_DTO_APPLY="
     --help
     --include-dir
     --device-tree
     --force
 "
 
-TCB_COMP_ARGS_DTO_LIST="
+_TCBCOMP_ARGS_DTO_LIST="
     --help
     --device-tree
 "
 
-TCB_COMP_ARGS_DTO_STATUS="
+_TCBCOMP_ARGS_DTO_STATUS="
     --help
 "
 
-TCB_COMP_ARGS_DTO_REMOVE="
+_TCBCOMP_ARGS_DTO_REMOVE="
     --help
     --all
 "
 
-TCB_COMP_ARGS_DTO_DEPLOY="
+_TCBCOMP_ARGS_DTO_DEPLOY="
     --help
     --remote-host
     --remote-username
@@ -159,7 +159,7 @@ TCB_COMP_ARGS_DTO_DEPLOY="
     --clear
 "
 
-TCB_COMP_ARGS_IMAGES="
+_TCBCOMP_ARGS_IMAGES="
     --help
     --remove-storage
     download
@@ -168,7 +168,7 @@ TCB_COMP_ARGS_IMAGES="
     unpack
 "
 
-TCB_COMP_ARGS_IMAGES_DOWNLOAD="
+_TCBCOMP_ARGS_IMAGES_DOWNLOAD="
     --help
     --remote-host
     --remote-username
@@ -177,7 +177,7 @@ TCB_COMP_ARGS_IMAGES_DOWNLOAD="
     --mdns-source
 "
 
-TCB_COMP_ARGS_IMAGES_PROVISION="
+_TCBCOMP_ARGS_IMAGES_PROVISION="
     --help
     --mode
     --force
@@ -185,20 +185,20 @@ TCB_COMP_ARGS_IMAGES_PROVISION="
     --online-data
 "
 
-TCB_COMP_ARGS_IMAGES_PROVISION_MODES="
+_TCBCOMP_ARGS_IMAGES_PROVISION_MODES="
     offline
     online
 "
 
-TCB_COMP_ARGS_IMAGES_UNPACK="
+_TCBCOMP_ARGS_IMAGES_UNPACK="
     --help
 "
 
-TCB_COMP_ARGS_IMAGES_SERVE="
+_TCBCOMP_ARGS_IMAGES_SERVE="
     --help
 "
 
-TCB_COMP_ARGS_ISOLATE="
+_TCBCOMP_ARGS_ISOLATE="
     --help
     --changes-directory
     --force
@@ -209,7 +209,7 @@ TCB_COMP_ARGS_ISOLATE="
     --mdns-source
 "
 
-TCB_COMP_ARGS_KERNEL="
+_TCBCOMP_ARGS_KERNEL="
     --help
     build_module
     set_custom_args
@@ -217,41 +217,41 @@ TCB_COMP_ARGS_KERNEL="
     clear_custom_args
 "
 
-TCB_COMP_ARGS_KERNEL_BUILD_MODULE="
+_TCBCOMP_ARGS_KERNEL_BUILD_MODULE="
     --help
     --autoload
 "
 
-TCB_COMP_ARGS_KERNEL_SET_CUSTOM_ARGS="
+_TCBCOMP_ARGS_KERNEL_SET_CUSTOM_ARGS="
     --help
 "
 
-TCB_COMP_ARGS_KERNEL_GET_CUSTOM_ARGS="
+_TCBCOMP_ARGS_KERNEL_GET_CUSTOM_ARGS="
     --help
 "
 
-TCB_COMP_ARGS_KERNEL_CLEAR_CUSTOM_ARGS="
+_TCBCOMP_ARGS_KERNEL_CLEAR_CUSTOM_ARGS="
     --help
 "
 
-TCB_COMP_ARGS_OSTREE="
+_TCBCOMP_ARGS_OSTREE="
     --help
     serve
 "
 
-TCB_COMP_ARGS_OSTREE_SERVE="
+_TCBCOMP_ARGS_OSTREE_SERVE="
     --help
     --ostree-repo-directory
 "
 
-TCB_COMP_ARGS_PLATFORM="
+_TCBCOMP_ARGS_PLATFORM="
     --help
     lockbox
     provisioning-data
     push
 "
 
-TCB_COMP_ARGS_PLATFORM_LOCKBOX="
+_TCBCOMP_ARGS_PLATFORM_LOCKBOX="
     --help
     --credentials
     --force
@@ -264,9 +264,9 @@ TCB_COMP_ARGS_PLATFORM_LOCKBOX="
     --output-directory
 "
 
-TCB_COMP_ARGS_PLATFORM_LOCKBOX_PLATFORM="$TCB_COMP_ARGS_BUNDLE_PLATFORM"
+_TCBCOMP_ARGS_PLATFORM_LOCKBOX_PLATFORM="$_TCBCOMP_ARGS_BUNDLE_PLATFORM"
 
-TCB_COMP_ARGS_PLATFORM_PROVDATA="
+_TCBCOMP_ARGS_PLATFORM_PROVDATA="
     --help
     --credentials
     --force
@@ -274,7 +274,7 @@ TCB_COMP_ARGS_PLATFORM_PROVDATA="
     --online-data
 "
 
-TCB_COMP_ARGS_PUSH="
+_TCBCOMP_ARGS_PUSH="
     --help
     --credentials
     --repo
@@ -288,11 +288,11 @@ TCB_COMP_ARGS_PUSH="
     --verbose
 "
 
-TCB_COMP_ARGS_SPLASH="
+_TCBCOMP_ARGS_SPLASH="
     --help
 "
 
-TCB_COMP_ARGS_UNION="
+_TCBCOMP_ARGS_UNION="
     --help
     --changes-directory
     --subject
@@ -300,38 +300,38 @@ TCB_COMP_ARGS_UNION="
 "
 
 # default value to complete parameters
-TCB_COMP_ARGS_DEF_PASSWORD="_TYPE_HERE_PASSWORD_"
-TCB_COMP_ARGS_DEF_USERNAME="_TYPE_HERE_USERNAME_"
-TCB_COMP_ARGS_DEF_REGISTRY="_TYPE_HERE_REGISTRY_"
-TCB_COMP_ARGS_DEF_CERT="_TYPE_HERE_CERT_"
-TCB_COMP_ARGS_DEF_DIND_PARAM="_TYPE_HERE_DIND_PARAM_"
-TCB_COMP_ARGS_DEF_DIND_ENV="ENV1=VAL1"
-TCB_COMP_ARGS_DEF_IMAGE_NAME="_TYPE_HERE_IMAGE_NAME_"
-TCB_COMP_ARGS_DEF_IMAGE_DESCRIPTION="_TYPE_HERE_IMAGE_DESCRIPTION_"
-TCB_COMP_ARGS_DEF_REMOTE_HOST="_TYPE_HERE_REMOTE_HOST_"
-TCB_COMP_ARGS_DEF_REMOTE_USERNAME="torizon"
-TCB_COMP_ARGS_DEF_REMOTE_PASSWORD="_TYPE_HERE_PASSWORD_"
-TCB_COMP_ARGS_DEF_REMOTE_PORT="_TYPE_HERE_REMOTE_PORT_"
-TCB_COMP_ARGS_DEF_MDNS_SOURCE="_TYPE_HERE_MDNS_SOURCE_"
-TCB_COMP_ARGS_DEF_KERNEL_ARGS="ARG1=VAL1"
-TCB_COMP_ARGS_DEF_HARDWAREID="_TYPE_HERE_HARDWARE_ID_"
-TCB_COMP_ARGS_DEF_SUBJECT="_TYPE_HERE_COMMIT_SUBJECT_"
-TCB_COMP_ARGS_DEF_BODY="_TYPE_HERE_COMMIT_BODY_"
-TCB_COMP_ARGS_DEF_OSTREE_REF="_TYPE_HERE_OSTREE_REF_OR_COMPOSE_FILE_NAME_"
-TCB_COMP_ARGS_DEF_UNION_BRANCH="_TYPE_HERE_UNION_BRANCH_"
-TCB_COMP_ARGS_DEF_PACKAGE_NAME="_TYPE_HERE_PACKAGE_NAME_"
-TCB_COMP_ARGS_DEF_PACKAGE_VERSION="_TYPE_HERE_PACKAGE_VERSION_"
-TCB_COMP_ARGS_DEF_ONLINE_PROVDATA="_TYPE_HERE_ONLINE_PROVISIONING_STRING_"
-TCB_COMP_ARGS_DEF_LOCKBOX_NAME="_TYPE_HERE_LOCKBOX_NAME_"
-TCB_COMP_ARGS_DEF_SHARED_DATA="_TYPE_HERE_SHARED_DATA_FILE_NAME_"
-TCB_COMP_ARGS_DEF_CLIENT_NAME="_TYPE_HERE_API_CLIENT_NAME_"
+_TCBCOMP_ARGS_DEF_PASSWORD="_TYPE_HERE_PASSWORD_"
+_TCBCOMP_ARGS_DEF_USERNAME="_TYPE_HERE_USERNAME_"
+_TCBCOMP_ARGS_DEF_REGISTRY="_TYPE_HERE_REGISTRY_"
+_TCBCOMP_ARGS_DEF_CERT="_TYPE_HERE_CERT_"
+_TCBCOMP_ARGS_DEF_DIND_PARAM="_TYPE_HERE_DIND_PARAM_"
+_TCBCOMP_ARGS_DEF_DIND_ENV="ENV1=VAL1"
+_TCBCOMP_ARGS_DEF_IMAGE_NAME="_TYPE_HERE_IMAGE_NAME_"
+_TCBCOMP_ARGS_DEF_IMAGE_DESCRIPTION="_TYPE_HERE_IMAGE_DESCRIPTION_"
+_TCBCOMP_ARGS_DEF_REMOTE_HOST="_TYPE_HERE_REMOTE_HOST_"
+_TCBCOMP_ARGS_DEF_REMOTE_USERNAME="torizon"
+_TCBCOMP_ARGS_DEF_REMOTE_PASSWORD="_TYPE_HERE_PASSWORD_"
+_TCBCOMP_ARGS_DEF_REMOTE_PORT="_TYPE_HERE_REMOTE_PORT_"
+_TCBCOMP_ARGS_DEF_MDNS_SOURCE="_TYPE_HERE_MDNS_SOURCE_"
+_TCBCOMP_ARGS_DEF_KERNEL_ARGS="ARG1=VAL1"
+_TCBCOMP_ARGS_DEF_HARDWAREID="_TYPE_HERE_HARDWARE_ID_"
+_TCBCOMP_ARGS_DEF_SUBJECT="_TYPE_HERE_COMMIT_SUBJECT_"
+_TCBCOMP_ARGS_DEF_BODY="_TYPE_HERE_COMMIT_BODY_"
+_TCBCOMP_ARGS_DEF_OSTREE_REF="_TYPE_HERE_OSTREE_REF_OR_COMPOSE_FILE_NAME_"
+_TCBCOMP_ARGS_DEF_UNION_BRANCH="_TYPE_HERE_UNION_BRANCH_"
+_TCBCOMP_ARGS_DEF_PACKAGE_NAME="_TYPE_HERE_PACKAGE_NAME_"
+_TCBCOMP_ARGS_DEF_PACKAGE_VERSION="_TYPE_HERE_PACKAGE_VERSION_"
+_TCBCOMP_ARGS_DEF_ONLINE_PROVDATA="_TYPE_HERE_ONLINE_PROVISIONING_STRING_"
+_TCBCOMP_ARGS_DEF_LOCKBOX_NAME="_TYPE_HERE_LOCKBOX_NAME_"
+_TCBCOMP_ARGS_DEF_SHARED_DATA="_TYPE_HERE_SHARED_DATA_FILE_NAME_"
+_TCBCOMP_ARGS_DEF_CLIENT_NAME="_TYPE_HERE_API_CLIENT_NAME_"
 
 # return in $COMPREPLY a list of files and directories starting from the
 # current working directory. The first parameter can be used to filter
 # the output files (e.g. *.txt), and if not passed, only directories are
 # returned. The second parameter, if true, can be used in conjuction with the first
 # to exclude the directories from the results
-_torizoncore-builder_completions_helper_filter_files_and_dirs() {
+_tcbcomp_helper_filter_files_and_dirs() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local filterpath="$1"
 
@@ -366,19 +366,19 @@ _torizoncore-builder_completions_helper_filter_files_and_dirs() {
     fi
 }
 
-_torizoncore-builder_completions_helper_filter_files() {
-    _torizoncore-builder_completions_helper_filter_files_and_dirs "$1" true
+_tcbcomp_helper_filter_files() {
+    _tcbcomp_helper_filter_files_and_dirs "$1" true
 }
 
 # return in $COMPREPLY a list of directories starting from the current
 # working directory.
-_torizoncore-builder_completions_helper_filter_dirs() {
-    _torizoncore-builder_completions_helper_filter_files_and_dirs ""
+_tcbcomp_helper_filter_dirs() {
+    _tcbcomp_helper_filter_files_and_dirs ""
 }
 
 # return in $COMPREPLY a list of static options passed as a parameter
 # to this function, removing the list the last typed word
-_torizoncore-builder_completions_helper_static_options() {
+_tcbcomp_helper_static_options() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
     local opts=($(compgen_compat -W "$@" -- ${cur}))
@@ -392,7 +392,7 @@ _torizoncore-builder_completions_helper_static_options() {
 
 # given the current command line, return the current subcommand being processed.
 # For example, 'torizoncore-builder images unpack' will return 'unpack'
-_torizoncore-builder_completions_helper_find_subcmd() {
+_tcbcomp_helper_find_subcmd() {
     local cmd=$1
     local opts=$2
 
@@ -421,24 +421,24 @@ _torizoncore-builder_completions_helper_find_subcmd() {
 }
 
 # 'build' command
-_torizoncore-builder_completions_build() {
+_tcbcomp_build() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         --file)
-            _torizoncore-builder_completions_helper_filter_files_and_dirs "*.y*ml"
+            _tcbcomp_helper_filter_files_and_dirs "*.y*ml"
             ;;
         --set)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_BUILD_SET"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_BUILD_SET"
             ;;
         *)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_BUILD"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_BUILD"
             ;;
     esac
 }
 
 # 'bundle' command
-_torizoncore-builder_completions_bundle() {
+_tcbcomp_bundle() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev1="${COMP_WORDS[COMP_CWORD-1]}"
     local prev2="${COMP_WORDS[COMP_CWORD-2]}"
@@ -446,542 +446,542 @@ _torizoncore-builder_completions_bundle() {
 
     case "$prev3" in
         --login-to)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_PASSWORD"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_PASSWORD"
             return
             ;;
     esac
 
     case "$prev2" in
         --login)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_PASSWORD"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_PASSWORD"
             return
             ;;
         --login-to)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_USERNAME"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_USERNAME"
             return
             ;;
         --cacert-to)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_CERT"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_CERT"
             ;;
     esac
 
     case "$prev1" in
         --bundle-directory)
-            _torizoncore-builder_completions_helper_filter_dirs
+            _tcbcomp_helper_filter_dirs
             ;;
         --platform)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_BUNDLE_PLATFORM"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_BUNDLE_PLATFORM"
             ;;
         --login)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_USERNAME"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_USERNAME"
             ;;
         --login-to)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REGISTRY"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REGISTRY"
             ;;
         --cacert-to)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REGISTRY"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REGISTRY"
             ;;
         --dind-param)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_DIND_PARAM"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_DIND_PARAM"
             ;;
         --dind-env)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_DIND_ENV"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_DIND_ENV"
             ;;
         *)
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_BUNDLE"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_BUNDLE"
             fi
             if [ -z "$COMPREPLY" ]; then
-                _torizoncore-builder_completions_helper_filter_files_and_dirs "*.y*ml"
+                _tcbcomp_helper_filter_files_and_dirs "*.y*ml"
             fi
             ;;
     esac
 }
 
 # 'combine' command
-_torizoncore-builder_completions_combine() {
+_tcbcomp_combine() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         --bundle-directory)
-            _torizoncore-builder_completions_helper_filter_dirs
+            _tcbcomp_helper_filter_dirs
             ;;
         --image-name)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_IMAGE_NAME"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_IMAGE_NAME"
             ;;
         --image-description)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_IMAGE_DESCRIPTION"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_IMAGE_DESCRIPTION"
             ;;
         --image-licence|--image-release-notes)
-            _torizoncore-builder_completions_helper_filter_files_and_dirs "*"
+            _tcbcomp_helper_filter_files_and_dirs "*"
             ;;
         *)
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_COMBINE"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_COMBINE"
             fi
             if [ -z "$COMPREPLY" ]; then
-                _torizoncore-builder_completions_helper_filter_dirs
+                _tcbcomp_helper_filter_dirs
             fi
             ;;
     esac
 }
 
 # 'deploy' command
-_torizoncore-builder_completions_deploy() {
+_tcbcomp_deploy() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         --bundle-directory|--output-directory|--deploy-sysroot-directory)
-            _torizoncore-builder_completions_helper_filter_dirs
+            _tcbcomp_helper_filter_dirs
             ;;
         --image-name)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_IMAGE_NAME"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_IMAGE_NAME"
             ;;
         --image-description)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_IMAGE_DESCRIPTION"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_IMAGE_DESCRIPTION"
             ;;
         --remote-host)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_HOST"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_HOST"
             ;;
         --remote-username)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_USERNAME"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_USERNAME"
             ;;
         --remote-password)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_PASSWORD"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_PASSWORD"
             ;;
         --remote-port)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_PORT"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_PORT"
             ;;
         --mdns-source)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_MDNS_SOURCE"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_MDNS_SOURCE"
             ;;
         --image-licence|--image-release-notes)
-            _torizoncore-builder_completions_helper_filter_files_and_dirs "*"
+            _tcbcomp_helper_filter_files_and_dirs "*"
             ;;
         *)
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEPLOY"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEPLOY"
             fi
             if [ -z "$COMPREPLY" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_OSTREE_REF"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_OSTREE_REF"
             fi
             ;;
     esac
 }
 
 # 'dt apply' command
-_torizoncore-builder_completions_dt_apply() {
+_tcbcomp_dt_apply() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         --include-dir)
-            _torizoncore-builder_completions_helper_filter_dirs
+            _tcbcomp_helper_filter_dirs
             ;;
         *.dts)
             ;;
         *)
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DT_APPLY"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DT_APPLY"
             fi
             if [ -z "$COMPREPLY" ]; then
-                _torizoncore-builder_completions_helper_filter_files_and_dirs "*.dts"
+                _tcbcomp_helper_filter_files_and_dirs "*.dts"
             fi
             ;;
     esac
 }
 
 # 'dt' command
-_torizoncore-builder_completions_dt() {
+_tcbcomp_dt() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-    local cmd=$(_torizoncore-builder_completions_helper_find_subcmd "dt" "$TCB_COMP_ARGS_DT")
+    local cmd=$(_tcbcomp_helper_find_subcmd "dt" "$_TCBCOMP_ARGS_DT")
 
     case "$cmd" in
         status)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DT_STATUS"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DT_STATUS"
             ;;
         checkout)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DT_CHECKOUT"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DT_CHECKOUT"
             ;;
         apply)
-            _torizoncore-builder_completions_dt_apply
+            _tcbcomp_dt_apply
             ;;
         *)
             if [ "$prev" = "dt" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DT"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DT"
             fi
             ;;
     esac
 }
 
 # 'dto apply' command
-_torizoncore-builder_completions_dto_apply() {
+_tcbcomp_dto_apply() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
     local prev2="${COMP_WORDS[COMP_CWORD-2]}"
 
     case "$prev" in
         --include-dir)
-            _torizoncore-builder_completions_helper_filter_dirs
+            _tcbcomp_helper_filter_dirs
             ;;
         --device-tree)
-            _torizoncore-builder_completions_helper_filter_files_and_dirs "*.dts"
+            _tcbcomp_helper_filter_files_and_dirs "*.dts"
             ;;
         *.dts)
             if [ "$prev2" != "--device-tree" ]; then
                 return;
             fi
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DTO_APPLY"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DTO_APPLY"
             fi
             if [ -z "$COMPREPLY" ]; then
-                _torizoncore-builder_completions_helper_filter_files_and_dirs "*.dts"
+                _tcbcomp_helper_filter_files_and_dirs "*.dts"
             fi
             ;;
         *)
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DTO_APPLY"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DTO_APPLY"
             fi
             if [ -z "$COMPREPLY" ]; then
-                _torizoncore-builder_completions_helper_filter_files_and_dirs "*.dts"
+                _tcbcomp_helper_filter_files_and_dirs "*.dts"
             fi
             ;;
     esac
 }
 
 # 'dto list' command
-_torizoncore-builder_completions_dto_list() {
+_tcbcomp_dto_list() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         --device-tree)
-            _torizoncore-builder_completions_helper_filter_files_and_dirs "*.dts"
+            _tcbcomp_helper_filter_files_and_dirs "*.dts"
             ;;
         *)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DTO_LIST"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DTO_LIST"
             ;;
     esac
 }
 
 # 'dto remove' command
-_torizoncore-builder_completions_dto_remove() {
+_tcbcomp_dto_remove() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         *.dtbo)
             ;;
         *)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DTO_REMOVE"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DTO_REMOVE"
             ;;
     esac
 }
 
 # 'dto deploy' command
-_torizoncore-builder_completions_dto_deploy() {
+_tcbcomp_dto_deploy() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
     local prev2="${COMP_WORDS[COMP_CWORD-2]}"
 
     case "$prev" in
         --include-dir)
-            _torizoncore-builder_completions_helper_filter_dirs
+            _tcbcomp_helper_filter_dirs
             ;;
         --device-tree)
-            _torizoncore-builder_completions_helper_filter_files_and_dirs "*.dts"
+            _tcbcomp_helper_filter_files_and_dirs "*.dts"
             ;;
         --remote-host)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_HOST"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_HOST"
             ;;
         --remote-username)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_USERNAME"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_USERNAME"
             ;;
         --remote-password)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_PASSWORD"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_PASSWORD"
             ;;
         --remote-port)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_PORT"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_PORT"
             ;;
         --mdns-source)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_MDNS_SOURCE"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_MDNS_SOURCE"
             ;;
         *.dts)
             if [ "$prev2" != "--device-tree" ]; then
                 return;
             fi
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DTO_DEPLOY"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DTO_DEPLOY"
             fi
             if [ -z "$COMPREPLY" ]; then
-                _torizoncore-builder_completions_helper_filter_files_and_dirs "*.dts"
+                _tcbcomp_helper_filter_files_and_dirs "*.dts"
             fi
             ;;
         *)
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DTO_DEPLOY"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DTO_DEPLOY"
             fi
             if [ -z "$COMPREPLY" ]; then
-                _torizoncore-builder_completions_helper_filter_files_and_dirs "*.dts"
+                _tcbcomp_helper_filter_files_and_dirs "*.dts"
             fi
             ;;
     esac
 }
 
 # 'dto' command
-_torizoncore-builder_completions_dto() {
+_tcbcomp_dto() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
-    local cmd=$(_torizoncore-builder_completions_helper_find_subcmd "dto" "$TCB_COMP_ARGS_DTO")
+    local cmd=$(_tcbcomp_helper_find_subcmd "dto" "$_TCBCOMP_ARGS_DTO")
 
     case "$cmd" in
         apply)
-            _torizoncore-builder_completions_dto_apply
+            _tcbcomp_dto_apply
             ;;
         list)
-            _torizoncore-builder_completions_dto_list
+            _tcbcomp_dto_list
             ;;
         status)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DTO_STATUS"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DTO_STATUS"
             ;;
         remove)
-            _torizoncore-builder_completions_dto_remove
+            _tcbcomp_dto_remove
             ;;
         deploy)
-            _torizoncore-builder_completions_dto_deploy
+            _tcbcomp_dto_deploy
             ;;
         *)
             if [ "$prev" = "dto" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DTO"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DTO"
             fi
             ;;
     esac
 }
 
 # 'images unpack' command
-_torizoncore-builder_completions_images_unpack() {
+_tcbcomp_images_unpack() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         *)
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_IMAGES_UNPACK"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_IMAGES_UNPACK"
             fi
             if [ -z "$COMPREPLY" ]; then
-                _torizoncore-builder_completions_helper_filter_files_and_dirs "*"
+                _tcbcomp_helper_filter_files_and_dirs "*"
             fi
             ;;
     esac
 }
 
 # 'images download' command
-_torizoncore-builder_completions_images_download() {
+_tcbcomp_images_download() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         --remote-host)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_HOST"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_HOST"
             ;;
         --remote-username)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_USERNAME"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_USERNAME"
             ;;
         --remote-password)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_PASSWORD"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_PASSWORD"
             ;;
         --remote-port)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_PORT"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_PORT"
             ;;
         --mdns-source)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_MDNS_SOURCE"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_MDNS_SOURCE"
             ;;
         *)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_IMAGES_DOWNLOAD"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_IMAGES_DOWNLOAD"
             ;;
     esac
 }
 
 # 'images provision' command
-_torizoncore-builder_completions_images_provision() {
+_tcbcomp_images_provision() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         --mode)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_IMAGES_PROVISION_MODES"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_IMAGES_PROVISION_MODES"
             ;;
         --shared-data)
-            _torizoncore-builder_completions_helper_filter_files_and_dirs "*.tar.gz"
+            _tcbcomp_helper_filter_files_and_dirs "*.tar.gz"
             ;;
         --online-data)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_ONLINE_PROVDATA"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_ONLINE_PROVDATA"
             ;;
         *)
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_IMAGES_PROVISION"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_IMAGES_PROVISION"
             fi
             if [ -z "$COMPREPLY" ]; then
-                _torizoncore-builder_completions_helper_filter_dirs
+                _tcbcomp_helper_filter_dirs
             fi
             ;;
     esac
 }
 
 # 'images serve' command
-_torizoncore-builder_completions_images_serve() {
+_tcbcomp_images_serve() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         *)
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_IMAGES_SERVE"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_IMAGES_SERVE"
             fi
             if [ -z "$COMPREPLY" ]; then
-                _torizoncore-builder_completions_helper_filter_dirs
+                _tcbcomp_helper_filter_dirs
             fi
             ;;
     esac
 }
 
 # 'images' command
-_torizoncore-builder_completions_images() {
-    local cmd=$(_torizoncore-builder_completions_helper_find_subcmd "images" "$TCB_COMP_ARGS_IMAGES")
+_tcbcomp_images() {
+    local cmd=$(_tcbcomp_helper_find_subcmd "images" "$_TCBCOMP_ARGS_IMAGES")
 
     case "$cmd" in
         download)
-            _torizoncore-builder_completions_images_download
+            _tcbcomp_images_download
             ;;
         provision)
-            _torizoncore-builder_completions_images_provision
+            _tcbcomp_images_provision
             ;;
         serve)
-            _torizoncore-builder_completions_images_serve
+            _tcbcomp_images_serve
             ;;
         unpack)
-            _torizoncore-builder_completions_images_unpack
+            _tcbcomp_images_unpack
             ;;
         *)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_IMAGES"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_IMAGES"
             ;;
     esac
 }
 
 # 'isolate' command
-_torizoncore-builder_completions_isolate() {
+_tcbcomp_isolate() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         --changes-directory)
-            _torizoncore-builder_completions_helper_filter_dirs
+            _tcbcomp_helper_filter_dirs
             ;;
         --remote-host)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_HOST"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_HOST"
             ;;
         --remote-username)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_USERNAME"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_USERNAME"
             ;;
         --remote-password)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_PASSWORD"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_PASSWORD"
             ;;
         --remote-port)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_PORT"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REMOTE_PORT"
             ;;
         --mdns-source)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_MDNS_SOURCE"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_MDNS_SOURCE"
             ;;
         *)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_ISOLATE"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_ISOLATE"
             ;;
     esac
 }
 
 # 'kernel build_module' command
-_torizoncore-builder_completions_kernel_build_module() {
+_tcbcomp_kernel_build_module() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         *)
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_KERNEL_BUILD_MODULE"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_KERNEL_BUILD_MODULE"
             fi
             if [ -z "$COMPREPLY" ]; then
-                _torizoncore-builder_completions_helper_filter_dirs "*"
+                _tcbcomp_helper_filter_dirs "*"
             fi
             ;;
     esac
 }
 
 # 'kernel set_custom_args' command
-_torizoncore-builder_completions_kernel_set_custom_args() {
+_tcbcomp_kernel_set_custom_args() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         set_custom_args)
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_KERNEL_SET_CUSTOM_ARGS"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_KERNEL_SET_CUSTOM_ARGS"
             fi
             if [ -z "$COMPREPLY" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_KERNEL_ARGS"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_KERNEL_ARGS"
             fi
             ;;
     esac
 }
 
 # 'kernel' command
-_torizoncore-builder_completions_kernel() {
-    local cmd=$(_torizoncore-builder_completions_helper_find_subcmd "kernel" "$TCB_COMP_ARGS_KERNEL")
+_tcbcomp_kernel() {
+    local cmd=$(_tcbcomp_helper_find_subcmd "kernel" "$_TCBCOMP_ARGS_KERNEL")
 
     case "$cmd" in
         build_module)
-            _torizoncore-builder_completions_kernel_build_module
+            _tcbcomp_kernel_build_module
             ;;
         set_custom_args)
-            _torizoncore-builder_completions_kernel_set_custom_args
+            _tcbcomp_kernel_set_custom_args
             ;;
         get_custom_args)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_KERNEL_GET_CUSTOM_ARGS"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_KERNEL_GET_CUSTOM_ARGS"
             ;;
         clear_custom_args)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_KERNEL_CLEAR_CUSTOM_ARGS"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_KERNEL_CLEAR_CUSTOM_ARGS"
             ;;
         *)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_KERNEL"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_KERNEL"
             ;;
     esac
 }
 
 # 'ostree serve' command
-_torizoncore-builder_completions_ostree_serve() {
+_tcbcomp_ostree_serve() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         --ostree-repo-directory)
-            _torizoncore-builder_completions_helper_filter_dirs
+            _tcbcomp_helper_filter_dirs
             ;;
         *)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_OSTREE_SERVE"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_OSTREE_SERVE"
             ;;
     esac
 }
 
 # 'ostree' command
-_torizoncore-builder_completions_ostree() {
+_tcbcomp_ostree() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
-    local cmd=$(_torizoncore-builder_completions_helper_find_subcmd "ostree" "$TCB_COMP_ARGS_OSTREE")
+    local cmd=$(_tcbcomp_helper_find_subcmd "ostree" "$_TCBCOMP_ARGS_OSTREE")
 
     case "$cmd" in
         serve)
-            _torizoncore-builder_completions_ostree_serve
+            _tcbcomp_ostree_serve
             ;;
         *)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_OSTREE"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_OSTREE"
             ;;
     esac
 }
 
-_torizoncore-builder_completions_platform_lockbox() {
+_tcbcomp_platform_lockbox() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev1="${COMP_WORDS[COMP_CWORD-1]}"
     local prev2="${COMP_WORDS[COMP_CWORD-2]}"
@@ -989,103 +989,103 @@ _torizoncore-builder_completions_platform_lockbox() {
 
     case "$prev3" in
         --login-to)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_PASSWORD"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_PASSWORD"
             return
             ;;
     esac
 
     case "$prev2" in
         --login)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_PASSWORD"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_PASSWORD"
             return
             ;;
         --login-to)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_USERNAME"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_USERNAME"
             return
             ;;
         --cacert-to)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_CERT"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_CERT"
             ;;
     esac
 
     case "$prev1" in
         --credentials)
-            _torizoncore-builder_completions_helper_filter_files_and_dirs "credentials.zip"
+            _tcbcomp_helper_filter_files_and_dirs "credentials.zip"
             ;;
         --platform)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_PLATFORM_LOCKBOX_PLATFORM"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_PLATFORM_LOCKBOX_PLATFORM"
             ;;
         --login)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_USERNAME"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_USERNAME"
             ;;
         --login-to)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REGISTRY"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REGISTRY"
             ;;
         --cacert-to)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REGISTRY"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_REGISTRY"
             ;;
         --dind-param)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_DIND_PARAM"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_DIND_PARAM"
             ;;
         --dind-env)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_DIND_ENV"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_DIND_ENV"
             ;;
         --output-directory)
-            _torizoncore-builder_completions_helper_filter_dirs
+            _tcbcomp_helper_filter_dirs
             ;;
         *)
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_PLATFORM_LOCKBOX"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_PLATFORM_LOCKBOX"
             fi
             if [ -z "$COMPREPLY" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_LOCKBOX_NAME"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_LOCKBOX_NAME"
             fi
             ;;
     esac
 }
 
-_torizoncore-builder_completions_platform_provisioning_data() {
+_tcbcomp_platform_provisioning_data() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         --credentials)
-            _torizoncore-builder_completions_helper_filter_files_and_dirs "credentials.zip"
+            _tcbcomp_helper_filter_files_and_dirs "credentials.zip"
             ;;
         --shared-data)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_SHARED_DATA"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_SHARED_DATA"
             ;;
         --online-data)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_CLIENT_NAME"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_CLIENT_NAME"
             ;;
         *)
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_PLATFORM_PROVDATA"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_PLATFORM_PROVDATA"
             fi
             ;;
     esac
 }
 
-_torizoncore-builder_completions_platform_push() {
-    _torizoncore-builder_completions_push "$@"
+_tcbcomp_platform_push() {
+    _tcbcomp_push "$@"
 }
 
 # 'platform' command
-_torizoncore-builder_completions_platform() {
-    local cmd=$(_torizoncore-builder_completions_helper_find_subcmd "platform" "$TCB_COMP_ARGS_PLATFORM")
+_tcbcomp_platform() {
+    local cmd=$(_tcbcomp_helper_find_subcmd "platform" "$_TCBCOMP_ARGS_PLATFORM")
 
     case "$cmd" in
         lockbox)
-            _torizoncore-builder_completions_platform_lockbox
+            _tcbcomp_platform_lockbox
             ;;
         provisioning-data)
-            _torizoncore-builder_completions_platform_provisioning_data
+            _tcbcomp_platform_provisioning_data
             ;;
         push)
-            _torizoncore-builder_completions_platform_push
+            _tcbcomp_platform_push
             ;;
         *)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_PLATFORM"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_PLATFORM"
             ;;
     esac
 }
@@ -1094,7 +1094,7 @@ _torizoncore-builder_completions_platform() {
 # a compose file ending with .yaml/yml or the list of references from
 # the ostree folder if the `--repo` argument is already present and it
 # points to a valid ostree folder.
-_torizoncore-builder_completions_push_reference() {
+_tcbcomp_push_reference() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local repo
 
@@ -1116,86 +1116,86 @@ _torizoncore-builder_completions_push_reference() {
         results=${results[@]/$refs_path/}
         COMPREPLY=($(compgen_compat -W "$results" -- ${cur}))
     else
-        _torizoncore-builder_completions_helper_filter_files "*.y*ml"
+        _tcbcomp_helper_filter_files "*.y*ml"
     fi
 
 }
 
 # 'push' command
-_torizoncore-builder_completions_push() {
+_tcbcomp_push() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         --credentials)
-            _torizoncore-builder_completions_helper_filter_files_and_dirs "credentials.zip"
+            _tcbcomp_helper_filter_files_and_dirs "credentials.zip"
             ;;
         --repo)
-            _torizoncore-builder_completions_helper_filter_dirs
+            _tcbcomp_helper_filter_dirs
             ;;
         --hardwareid)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_HARDWAREID"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_HARDWAREID"
             ;;
         --package-name)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_PACKAGE_NAME"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_PACKAGE_NAME"
             ;;
         --package-version)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_PACKAGE_VERSION"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_PACKAGE_VERSION"
             ;;
         *)
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_PUSH"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_PUSH"
             fi
             if [ -z "$COMPREPLY" ]; then
-                _torizoncore-builder_completions_push_reference
+                _tcbcomp_push_reference
             fi
             ;;
     esac
 }
 
 # 'splash' command
-_torizoncore-builder_completions_splash() {
+_tcbcomp_splash() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         *)
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_SPLASH"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SPLASH"
             fi
             if [ -z "$COMPREPLY" ]; then
-                _torizoncore-builder_completions_helper_filter_files_and_dirs "*"
+                _tcbcomp_helper_filter_files_and_dirs "*"
             fi
             ;;
     esac
 }
 
 # 'union' command
-_torizoncore-builder_completions_union() {
+_tcbcomp_union() {
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     case "$prev" in
         --changes-directory)
-            _torizoncore-builder_completions_helper_filter_dirs
+            _tcbcomp_helper_filter_dirs
             ;;
         --subject)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_SUBJECT"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_SUBJECT"
             ;;
         --body)
-            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_BODY"
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_BODY"
             ;;
         *)
             if [ -n "$cur" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_UNION"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_UNION"
             fi
             if [ -z "$COMPREPLY" ]; then
-                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_UNION_BRANCH"
+                _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_DEF_UNION_BRANCH"
             fi
             ;;
     esac
 }
 
 # 'main' command
-_torizoncore-builder_completions() {
+_tcbcomp() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local i=1 cmd
 
@@ -1207,7 +1207,7 @@ _torizoncore-builder_completions() {
         case "$s" in
             --log-level)
                 if [ "$i" -eq "$COMP_CWORD" ]; then
-                    _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_MAIN_LOGLEVEL"
+                    _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_MAIN_LOGLEVEL"
                     return
                 else
                     i=$((i + 1))
@@ -1215,7 +1215,7 @@ _torizoncore-builder_completions() {
                 ;;
             --log-file)
                 if [ "$i" -eq "$COMP_CWORD" ]; then
-                    _torizoncore-builder_completions_helper_filter_files_and_dirs "*"
+                    _tcbcomp_helper_filter_files_and_dirs "*"
                     return
                 else
                     i=$((i + 1))
@@ -1231,52 +1231,52 @@ _torizoncore-builder_completions() {
     done
 
     if [ -z "$cmd" ]; then
-        _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_MAIN"
+        _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_MAIN"
         return
     fi
 
     case "$cmd" in
         build)
-            _torizoncore-builder_completions_build
+            _tcbcomp_build
             ;;
         bundle)
-            _torizoncore-builder_completions_bundle
+            _tcbcomp_bundle
             ;;
         combine)
-            _torizoncore-builder_completions_combine
+            _tcbcomp_combine
             ;;
         deploy)
-            _torizoncore-builder_completions_deploy
+            _tcbcomp_deploy
             ;;
         dt)
-            _torizoncore-builder_completions_dt
+            _tcbcomp_dt
             ;;
         dto)
-            _torizoncore-builder_completions_dto
+            _tcbcomp_dto
             ;;
         images)
-            _torizoncore-builder_completions_images
+            _tcbcomp_images
             ;;
         isolate)
-            _torizoncore-builder_completions_isolate
+            _tcbcomp_isolate
             ;;
         kernel)
-            _torizoncore-builder_completions_kernel
+            _tcbcomp_kernel
             ;;
         ostree)
-            _torizoncore-builder_completions_ostree
+            _tcbcomp_ostree
             ;;
         platform)
-            _torizoncore-builder_completions_platform
+            _tcbcomp_platform
             ;;
         push)
-            _torizoncore-builder_completions_push
+            _tcbcomp_push
             ;;
         splash)
-            _torizoncore-builder_completions_splash
+            _tcbcomp_splash
             ;;
         union)
-            _torizoncore-builder_completions_union
+            _tcbcomp_union
             ;;
         *)
             ;;
@@ -1411,11 +1411,10 @@ _bash_complete_zsh () {
 }
 
 if [ -z "$ZSH_VERSION" ]; then
-  complete -o bashdefault -F _torizoncore-builder_completions torizoncore-builder
+  complete -o bashdefault -F _tcbcomp torizoncore-builder
 else
   setopt completealiases
   autoload bashcompinit && bashcompinit
-  _function=('-F' '_torizoncore-builder_completions')
+  _function=('-F' '_tcbcomp')
   compdef _bash_complete_zsh\ ${(j. .)${(q)_function}} torizoncore-builder
 fi
-

--- a/torizoncore-builder-completion.bash
+++ b/torizoncore-builder-completion.bash
@@ -1608,10 +1608,10 @@ _bash_complete_zsh () {
 }
 
 if [ -z "$ZSH_VERSION" ]; then
-    complete -o bashdefault -F _tcbcomp torizoncore-builder
+    complete -o bashdefault -F _tcbcomp ${TCB_FUNCTION_NAME:-torizoncore-builder}
 else
     setopt completealiases
     autoload bashcompinit && bashcompinit
     _function=('-F' '_tcbcomp')
-    compdef _bash_complete_zsh\ ${(j. .)${(q)_function}} torizoncore-builder
+    compdef _bash_complete_zsh\ ${(j. .)${(q)_function}} ${TCB_FUNCTION_NAME:-torizoncore-builder}
 fi

--- a/torizoncore-builder-completion.bash
+++ b/torizoncore-builder-completion.bash
@@ -1,0 +1,1421 @@
+#!/usr/bin/env bash
+
+TCB_COMP_ARGS_MAIN="
+    -h --help
+    --verbose
+    --log-level
+    --log-file
+    -v --version
+    build
+    bundle
+    combine
+    deploy
+    dt
+    dto
+    images
+    isolate
+    kernel
+    ostree
+    platform
+    push
+    splash
+    union
+"
+
+TCB_COMP_ARGS_MAIN_LOGLEVEL="
+    debug
+    info
+    warning
+    error
+    critical
+"
+
+TCB_COMP_ARGS_BUILD="
+    --help
+    --create-template
+    --file
+    --force
+    --set
+    --no-subst
+"
+
+TCB_COMP_ARGS_BUILD_SET="
+    VAR=\"value\"
+"
+
+TCB_COMP_ARGS_BUNDLE="
+    --help
+    --bundle-directory
+    --force
+    --platform
+    --keep-double-dollar-sign
+    --login
+    --login-to
+    --cacert-to
+    --dind-param
+    --dind-env
+"
+
+TCB_COMP_ARGS_BUNDLE_PLATFORM="
+    linux/arm/v7
+    linux/arm64
+"
+
+TCB_COMP_ARGS_COMBINE="
+    --help
+    --bundle-directory
+    --image-name
+    --image-description
+    --image-licence
+    --image-release-notes
+    --image-autoinstall
+    --image-autoreboot
+    --no-image-autoinstall
+    --no-image-autoreboot
+"
+
+TCB_COMP_ARGS_DEPLOY="
+    --help
+    --output-directory
+    --remote-host
+    --remote-username
+    --remote-password
+    --remote-port
+    --mdns-source
+    --reboot
+    --deploy-sysroot-directory
+    --image-name
+    --image-description
+    --image-licence
+    --image-release-notes
+    --image-autoinstall
+    --image-autoreboot
+    --no-image-autoinstall
+    --no-image-autoreboot
+"
+
+TCB_COMP_ARGS_DT="
+    --help
+    status
+    checkout
+    apply
+"
+
+TCB_COMP_ARGS_DT_STATUS="
+    --help
+"
+
+TCB_COMP_ARGS_DT_CHECKOUT="
+    --help
+    --update
+"
+
+TCB_COMP_ARGS_DT_APPLY="
+    --help
+    --include-dir
+"
+
+TCB_COMP_ARGS_DTO="
+    --help
+    apply
+    list
+    status
+    remove
+    deploy
+"
+
+TCB_COMP_ARGS_DTO_APPLY="
+    --help
+    --include-dir
+    --device-tree
+    --force
+"
+
+TCB_COMP_ARGS_DTO_LIST="
+    --help
+    --device-tree
+"
+
+TCB_COMP_ARGS_DTO_STATUS="
+    --help
+"
+
+TCB_COMP_ARGS_DTO_REMOVE="
+    --help
+    --all
+"
+
+TCB_COMP_ARGS_DTO_DEPLOY="
+    --help
+    --remote-host
+    --remote-username
+    --remote-password
+    --remote-port
+    --reboot
+    --mdns-source
+    --include-dir
+    --force
+    --device-tree
+    --clear
+"
+
+TCB_COMP_ARGS_IMAGES="
+    --help
+    --remove-storage
+    download
+    provision
+    serve
+    unpack
+"
+
+TCB_COMP_ARGS_IMAGES_DOWNLOAD="
+    --help
+    --remote-host
+    --remote-username
+    --remote-password
+    --remote-port
+    --mdns-source
+"
+
+TCB_COMP_ARGS_IMAGES_PROVISION="
+    --help
+    --mode
+    --force
+    --shared-data
+    --online-data
+"
+
+TCB_COMP_ARGS_IMAGES_PROVISION_MODES="
+    offline
+    online
+"
+
+TCB_COMP_ARGS_IMAGES_UNPACK="
+    --help
+"
+
+TCB_COMP_ARGS_IMAGES_SERVE="
+    --help
+"
+
+TCB_COMP_ARGS_ISOLATE="
+    --help
+    --changes-directory
+    --force
+    --remote-host
+    --remote-username
+    --remote-password
+    --remote-port
+    --mdns-source
+"
+
+TCB_COMP_ARGS_KERNEL="
+    --help
+    build_module
+    set_custom_args
+    get_custom_args
+    clear_custom_args
+"
+
+TCB_COMP_ARGS_KERNEL_BUILD_MODULE="
+    --help
+    --autoload
+"
+
+TCB_COMP_ARGS_KERNEL_SET_CUSTOM_ARGS="
+    --help
+"
+
+TCB_COMP_ARGS_KERNEL_GET_CUSTOM_ARGS="
+    --help
+"
+
+TCB_COMP_ARGS_KERNEL_CLEAR_CUSTOM_ARGS="
+    --help
+"
+
+TCB_COMP_ARGS_OSTREE="
+    --help
+    serve
+"
+
+TCB_COMP_ARGS_OSTREE_SERVE="
+    --help
+    --ostree-repo-directory
+"
+
+TCB_COMP_ARGS_PLATFORM="
+    --help
+    lockbox
+    provisioning-data
+    push
+"
+
+TCB_COMP_ARGS_PLATFORM_LOCKBOX="
+    --help
+    --credentials
+    --force
+    --platform
+    --login
+    --login-to
+    --cacert-to
+    --dind-param
+    --dind-env
+    --output-directory
+"
+
+TCB_COMP_ARGS_PLATFORM_LOCKBOX_PLATFORM="$TCB_COMP_ARGS_BUNDLE_PLATFORM"
+
+TCB_COMP_ARGS_PLATFORM_PROVDATA="
+    --help
+    --credentials
+    --force
+    --shared-data
+    --online-data
+"
+
+TCB_COMP_ARGS_PUSH="
+    --help
+    --credentials
+    --repo
+    --hardwareid
+    --canonicalize
+    --no-canonicalize
+    --canonicalize-only
+    --package-name
+    --package-version
+    --force
+    --verbose
+"
+
+TCB_COMP_ARGS_SPLASH="
+    --help
+"
+
+TCB_COMP_ARGS_UNION="
+    --help
+    --changes-directory
+    --subject
+    --body
+"
+
+# default value to complete parameters
+TCB_COMP_ARGS_DEF_PASSWORD="_TYPE_HERE_PASSWORD_"
+TCB_COMP_ARGS_DEF_USERNAME="_TYPE_HERE_USERNAME_"
+TCB_COMP_ARGS_DEF_REGISTRY="_TYPE_HERE_REGISTRY_"
+TCB_COMP_ARGS_DEF_CERT="_TYPE_HERE_CERT_"
+TCB_COMP_ARGS_DEF_DIND_PARAM="_TYPE_HERE_DIND_PARAM_"
+TCB_COMP_ARGS_DEF_DIND_ENV="ENV1=VAL1"
+TCB_COMP_ARGS_DEF_IMAGE_NAME="_TYPE_HERE_IMAGE_NAME_"
+TCB_COMP_ARGS_DEF_IMAGE_DESCRIPTION="_TYPE_HERE_IMAGE_DESCRIPTION_"
+TCB_COMP_ARGS_DEF_REMOTE_HOST="_TYPE_HERE_REMOTE_HOST_"
+TCB_COMP_ARGS_DEF_REMOTE_USERNAME="torizon"
+TCB_COMP_ARGS_DEF_REMOTE_PASSWORD="_TYPE_HERE_PASSWORD_"
+TCB_COMP_ARGS_DEF_REMOTE_PORT="_TYPE_HERE_REMOTE_PORT_"
+TCB_COMP_ARGS_DEF_MDNS_SOURCE="_TYPE_HERE_MDNS_SOURCE_"
+TCB_COMP_ARGS_DEF_KERNEL_ARGS="ARG1=VAL1"
+TCB_COMP_ARGS_DEF_HARDWAREID="_TYPE_HERE_HARDWARE_ID_"
+TCB_COMP_ARGS_DEF_SUBJECT="_TYPE_HERE_COMMIT_SUBJECT_"
+TCB_COMP_ARGS_DEF_BODY="_TYPE_HERE_COMMIT_BODY_"
+TCB_COMP_ARGS_DEF_OSTREE_REF="_TYPE_HERE_OSTREE_REF_OR_COMPOSE_FILE_NAME_"
+TCB_COMP_ARGS_DEF_UNION_BRANCH="_TYPE_HERE_UNION_BRANCH_"
+TCB_COMP_ARGS_DEF_PACKAGE_NAME="_TYPE_HERE_PACKAGE_NAME_"
+TCB_COMP_ARGS_DEF_PACKAGE_VERSION="_TYPE_HERE_PACKAGE_VERSION_"
+TCB_COMP_ARGS_DEF_ONLINE_PROVDATA="_TYPE_HERE_ONLINE_PROVISIONING_STRING_"
+TCB_COMP_ARGS_DEF_LOCKBOX_NAME="_TYPE_HERE_LOCKBOX_NAME_"
+TCB_COMP_ARGS_DEF_SHARED_DATA="_TYPE_HERE_SHARED_DATA_FILE_NAME_"
+TCB_COMP_ARGS_DEF_CLIENT_NAME="_TYPE_HERE_API_CLIENT_NAME_"
+
+# return in $COMPREPLY a list of files and directories starting from the
+# current working directory. The first parameter can be used to filter
+# the output files (e.g. *.txt), and if not passed, only directories are
+# returned. The second parameter, if true, can be used in conjuction with the first
+# to exclude the directories from the results
+_torizoncore-builder_completions_helper_filter_files_and_dirs() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local filterpath="$1"
+
+    local IFS=$'\n'
+    local LASTCHAR=' '
+
+    local arg=(-o plusdirs)
+
+    if [ "$2" = "true" ]; then
+        arg=()
+    fi
+
+    if [ -z "$ZSH_VERSION" ]; then
+      compopt -o nospace
+    fi
+
+    if [ -z "$filterpath" ]; then
+        COMPREPLY=($(compgen_compat -d -- ${cur}))
+    else
+        COMPREPLY=($(compgen_compat ${arg[@]} -f -X "!$filterpath" -- ${cur}))
+    fi
+
+    if [ ${#COMPREPLY[@]} = 1 ]; then
+        [ -d "$COMPREPLY" ] && LASTCHAR=/
+        [ -z "$ZSH_VERSION" ] && \
+        COMPREPLY=$(printf %q%s "$COMPREPLY" "$LASTCHAR")
+    else
+        for ((i=0; i < ${#COMPREPLY[@]}; i++)); do
+            [ -z "$ZSH_VERSION" ] && [ -d "${COMPREPLY[$i]}" ] && \
+            COMPREPLY[$i]=${COMPREPLY[$i]}/
+        done
+    fi
+}
+
+_torizoncore-builder_completions_helper_filter_files() {
+    _torizoncore-builder_completions_helper_filter_files_and_dirs "$1" true
+}
+
+# return in $COMPREPLY a list of directories starting from the current
+# working directory.
+_torizoncore-builder_completions_helper_filter_dirs() {
+    _torizoncore-builder_completions_helper_filter_files_and_dirs ""
+}
+
+# return in $COMPREPLY a list of static options passed as a parameter
+# to this function, removing the list the last typed word
+_torizoncore-builder_completions_helper_static_options() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+    local opts=($(compgen_compat -W "$@" -- ${cur}))
+    local i=0
+    for opt in "${opts[@]}"; do
+      [ "$opt" = "$prev" ] && unset opts["$i"]
+      ((++i))
+    done
+    COMPREPLY=(${opts[@]})
+}
+
+# given the current command line, return the current subcommand being processed.
+# For example, 'torizoncore-builder images unpack' will return 'unpack'
+_torizoncore-builder_completions_helper_find_subcmd() {
+    local cmd=$1
+    local opts=$2
+
+    local cmd_found=0
+    local i=1
+
+    while [ $i -lt $((COMP_CWORD+1)) ]; do
+        local word="${COMP_WORDS[i]}"
+        local opt=""
+
+        first_chars=$(echo $word | cut -c1-2)
+
+        if [ "$word" == "$cmd" ]; then
+            cmd_found=1
+        elif [ "$cmd_found" == "1" -a "$first_chars" != "--" ]; then
+            for opt in $opts; do
+                if [ "$word" == "$opt" ]; then
+                    echo $word
+                    return
+                fi
+            done
+        fi
+
+        i=$((i + 1))
+    done
+}
+
+# 'build' command
+_torizoncore-builder_completions_build() {
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        --file)
+            _torizoncore-builder_completions_helper_filter_files_and_dirs "*.y*ml"
+            ;;
+        --set)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_BUILD_SET"
+            ;;
+        *)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_BUILD"
+            ;;
+    esac
+}
+
+# 'bundle' command
+_torizoncore-builder_completions_bundle() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev1="${COMP_WORDS[COMP_CWORD-1]}"
+    local prev2="${COMP_WORDS[COMP_CWORD-2]}"
+    local prev3="${COMP_WORDS[COMP_CWORD-3]}"
+
+    case "$prev3" in
+        --login-to)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_PASSWORD"
+            return
+            ;;
+    esac
+
+    case "$prev2" in
+        --login)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_PASSWORD"
+            return
+            ;;
+        --login-to)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_USERNAME"
+            return
+            ;;
+        --cacert-to)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_CERT"
+            ;;
+    esac
+
+    case "$prev1" in
+        --bundle-directory)
+            _torizoncore-builder_completions_helper_filter_dirs
+            ;;
+        --platform)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_BUNDLE_PLATFORM"
+            ;;
+        --login)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_USERNAME"
+            ;;
+        --login-to)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REGISTRY"
+            ;;
+        --cacert-to)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REGISTRY"
+            ;;
+        --dind-param)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_DIND_PARAM"
+            ;;
+        --dind-env)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_DIND_ENV"
+            ;;
+        *)
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_BUNDLE"
+            fi
+            if [ -z "$COMPREPLY" ]; then
+                _torizoncore-builder_completions_helper_filter_files_and_dirs "*.y*ml"
+            fi
+            ;;
+    esac
+}
+
+# 'combine' command
+_torizoncore-builder_completions_combine() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        --bundle-directory)
+            _torizoncore-builder_completions_helper_filter_dirs
+            ;;
+        --image-name)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_IMAGE_NAME"
+            ;;
+        --image-description)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_IMAGE_DESCRIPTION"
+            ;;
+        --image-licence|--image-release-notes)
+            _torizoncore-builder_completions_helper_filter_files_and_dirs "*"
+            ;;
+        *)
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_COMBINE"
+            fi
+            if [ -z "$COMPREPLY" ]; then
+                _torizoncore-builder_completions_helper_filter_dirs
+            fi
+            ;;
+    esac
+}
+
+# 'deploy' command
+_torizoncore-builder_completions_deploy() {
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        --bundle-directory|--output-directory|--deploy-sysroot-directory)
+            _torizoncore-builder_completions_helper_filter_dirs
+            ;;
+        --image-name)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_IMAGE_NAME"
+            ;;
+        --image-description)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_IMAGE_DESCRIPTION"
+            ;;
+        --remote-host)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_HOST"
+            ;;
+        --remote-username)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_USERNAME"
+            ;;
+        --remote-password)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_PASSWORD"
+            ;;
+        --remote-port)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_PORT"
+            ;;
+        --mdns-source)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_MDNS_SOURCE"
+            ;;
+        --image-licence|--image-release-notes)
+            _torizoncore-builder_completions_helper_filter_files_and_dirs "*"
+            ;;
+        *)
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEPLOY"
+            fi
+            if [ -z "$COMPREPLY" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_OSTREE_REF"
+            fi
+            ;;
+    esac
+}
+
+# 'dt apply' command
+_torizoncore-builder_completions_dt_apply() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        --include-dir)
+            _torizoncore-builder_completions_helper_filter_dirs
+            ;;
+        *.dts)
+            ;;
+        *)
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DT_APPLY"
+            fi
+            if [ -z "$COMPREPLY" ]; then
+                _torizoncore-builder_completions_helper_filter_files_and_dirs "*.dts"
+            fi
+            ;;
+    esac
+}
+
+# 'dt' command
+_torizoncore-builder_completions_dt() {
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    local cmd=$(_torizoncore-builder_completions_helper_find_subcmd "dt" "$TCB_COMP_ARGS_DT")
+
+    case "$cmd" in
+        status)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DT_STATUS"
+            ;;
+        checkout)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DT_CHECKOUT"
+            ;;
+        apply)
+            _torizoncore-builder_completions_dt_apply
+            ;;
+        *)
+            if [ "$prev" = "dt" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DT"
+            fi
+            ;;
+    esac
+}
+
+# 'dto apply' command
+_torizoncore-builder_completions_dto_apply() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+    local prev2="${COMP_WORDS[COMP_CWORD-2]}"
+
+    case "$prev" in
+        --include-dir)
+            _torizoncore-builder_completions_helper_filter_dirs
+            ;;
+        --device-tree)
+            _torizoncore-builder_completions_helper_filter_files_and_dirs "*.dts"
+            ;;
+        *.dts)
+            if [ "$prev2" != "--device-tree" ]; then
+                return;
+            fi
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DTO_APPLY"
+            fi
+            if [ -z "$COMPREPLY" ]; then
+                _torizoncore-builder_completions_helper_filter_files_and_dirs "*.dts"
+            fi
+            ;;
+        *)
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DTO_APPLY"
+            fi
+            if [ -z "$COMPREPLY" ]; then
+                _torizoncore-builder_completions_helper_filter_files_and_dirs "*.dts"
+            fi
+            ;;
+    esac
+}
+
+# 'dto list' command
+_torizoncore-builder_completions_dto_list() {
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        --device-tree)
+            _torizoncore-builder_completions_helper_filter_files_and_dirs "*.dts"
+            ;;
+        *)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DTO_LIST"
+            ;;
+    esac
+}
+
+# 'dto remove' command
+_torizoncore-builder_completions_dto_remove() {
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        *.dtbo)
+            ;;
+        *)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DTO_REMOVE"
+            ;;
+    esac
+}
+
+# 'dto deploy' command
+_torizoncore-builder_completions_dto_deploy() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+    local prev2="${COMP_WORDS[COMP_CWORD-2]}"
+
+    case "$prev" in
+        --include-dir)
+            _torizoncore-builder_completions_helper_filter_dirs
+            ;;
+        --device-tree)
+            _torizoncore-builder_completions_helper_filter_files_and_dirs "*.dts"
+            ;;
+        --remote-host)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_HOST"
+            ;;
+        --remote-username)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_USERNAME"
+            ;;
+        --remote-password)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_PASSWORD"
+            ;;
+        --remote-port)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_PORT"
+            ;;
+        --mdns-source)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_MDNS_SOURCE"
+            ;;
+        *.dts)
+            if [ "$prev2" != "--device-tree" ]; then
+                return;
+            fi
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DTO_DEPLOY"
+            fi
+            if [ -z "$COMPREPLY" ]; then
+                _torizoncore-builder_completions_helper_filter_files_and_dirs "*.dts"
+            fi
+            ;;
+        *)
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DTO_DEPLOY"
+            fi
+            if [ -z "$COMPREPLY" ]; then
+                _torizoncore-builder_completions_helper_filter_files_and_dirs "*.dts"
+            fi
+            ;;
+    esac
+}
+
+# 'dto' command
+_torizoncore-builder_completions_dto() {
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+    local cmd=$(_torizoncore-builder_completions_helper_find_subcmd "dto" "$TCB_COMP_ARGS_DTO")
+
+    case "$cmd" in
+        apply)
+            _torizoncore-builder_completions_dto_apply
+            ;;
+        list)
+            _torizoncore-builder_completions_dto_list
+            ;;
+        status)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DTO_STATUS"
+            ;;
+        remove)
+            _torizoncore-builder_completions_dto_remove
+            ;;
+        deploy)
+            _torizoncore-builder_completions_dto_deploy
+            ;;
+        *)
+            if [ "$prev" = "dto" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DTO"
+            fi
+            ;;
+    esac
+}
+
+# 'images unpack' command
+_torizoncore-builder_completions_images_unpack() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        *)
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_IMAGES_UNPACK"
+            fi
+            if [ -z "$COMPREPLY" ]; then
+                _torizoncore-builder_completions_helper_filter_files_and_dirs "*"
+            fi
+            ;;
+    esac
+}
+
+# 'images download' command
+_torizoncore-builder_completions_images_download() {
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        --remote-host)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_HOST"
+            ;;
+        --remote-username)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_USERNAME"
+            ;;
+        --remote-password)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_PASSWORD"
+            ;;
+        --remote-port)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_PORT"
+            ;;
+        --mdns-source)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_MDNS_SOURCE"
+            ;;
+        *)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_IMAGES_DOWNLOAD"
+            ;;
+    esac
+}
+
+# 'images provision' command
+_torizoncore-builder_completions_images_provision() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        --mode)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_IMAGES_PROVISION_MODES"
+            ;;
+        --shared-data)
+            _torizoncore-builder_completions_helper_filter_files_and_dirs "*.tar.gz"
+            ;;
+        --online-data)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_ONLINE_PROVDATA"
+            ;;
+        *)
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_IMAGES_PROVISION"
+            fi
+            if [ -z "$COMPREPLY" ]; then
+                _torizoncore-builder_completions_helper_filter_dirs
+            fi
+            ;;
+    esac
+}
+
+# 'images serve' command
+_torizoncore-builder_completions_images_serve() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        *)
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_IMAGES_SERVE"
+            fi
+            if [ -z "$COMPREPLY" ]; then
+                _torizoncore-builder_completions_helper_filter_dirs
+            fi
+            ;;
+    esac
+}
+
+# 'images' command
+_torizoncore-builder_completions_images() {
+    local cmd=$(_torizoncore-builder_completions_helper_find_subcmd "images" "$TCB_COMP_ARGS_IMAGES")
+
+    case "$cmd" in
+        download)
+            _torizoncore-builder_completions_images_download
+            ;;
+        provision)
+            _torizoncore-builder_completions_images_provision
+            ;;
+        serve)
+            _torizoncore-builder_completions_images_serve
+            ;;
+        unpack)
+            _torizoncore-builder_completions_images_unpack
+            ;;
+        *)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_IMAGES"
+            ;;
+    esac
+}
+
+# 'isolate' command
+_torizoncore-builder_completions_isolate() {
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        --changes-directory)
+            _torizoncore-builder_completions_helper_filter_dirs
+            ;;
+        --remote-host)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_HOST"
+            ;;
+        --remote-username)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_USERNAME"
+            ;;
+        --remote-password)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_PASSWORD"
+            ;;
+        --remote-port)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REMOTE_PORT"
+            ;;
+        --mdns-source)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_MDNS_SOURCE"
+            ;;
+        *)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_ISOLATE"
+            ;;
+    esac
+}
+
+# 'kernel build_module' command
+_torizoncore-builder_completions_kernel_build_module() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        *)
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_KERNEL_BUILD_MODULE"
+            fi
+            if [ -z "$COMPREPLY" ]; then
+                _torizoncore-builder_completions_helper_filter_dirs "*"
+            fi
+            ;;
+    esac
+}
+
+# 'kernel set_custom_args' command
+_torizoncore-builder_completions_kernel_set_custom_args() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        set_custom_args)
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_KERNEL_SET_CUSTOM_ARGS"
+            fi
+            if [ -z "$COMPREPLY" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_KERNEL_ARGS"
+            fi
+            ;;
+    esac
+}
+
+# 'kernel' command
+_torizoncore-builder_completions_kernel() {
+    local cmd=$(_torizoncore-builder_completions_helper_find_subcmd "kernel" "$TCB_COMP_ARGS_KERNEL")
+
+    case "$cmd" in
+        build_module)
+            _torizoncore-builder_completions_kernel_build_module
+            ;;
+        set_custom_args)
+            _torizoncore-builder_completions_kernel_set_custom_args
+            ;;
+        get_custom_args)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_KERNEL_GET_CUSTOM_ARGS"
+            ;;
+        clear_custom_args)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_KERNEL_CLEAR_CUSTOM_ARGS"
+            ;;
+        *)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_KERNEL"
+            ;;
+    esac
+}
+
+# 'ostree serve' command
+_torizoncore-builder_completions_ostree_serve() {
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        --ostree-repo-directory)
+            _torizoncore-builder_completions_helper_filter_dirs
+            ;;
+        *)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_OSTREE_SERVE"
+            ;;
+    esac
+}
+
+# 'ostree' command
+_torizoncore-builder_completions_ostree() {
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+    local cmd=$(_torizoncore-builder_completions_helper_find_subcmd "ostree" "$TCB_COMP_ARGS_OSTREE")
+
+    case "$cmd" in
+        serve)
+            _torizoncore-builder_completions_ostree_serve
+            ;;
+        *)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_OSTREE"
+            ;;
+    esac
+}
+
+_torizoncore-builder_completions_platform_lockbox() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev1="${COMP_WORDS[COMP_CWORD-1]}"
+    local prev2="${COMP_WORDS[COMP_CWORD-2]}"
+    local prev3="${COMP_WORDS[COMP_CWORD-3]}"
+
+    case "$prev3" in
+        --login-to)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_PASSWORD"
+            return
+            ;;
+    esac
+
+    case "$prev2" in
+        --login)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_PASSWORD"
+            return
+            ;;
+        --login-to)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_USERNAME"
+            return
+            ;;
+        --cacert-to)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_CERT"
+            ;;
+    esac
+
+    case "$prev1" in
+        --credentials)
+            _torizoncore-builder_completions_helper_filter_files_and_dirs "credentials.zip"
+            ;;
+        --platform)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_PLATFORM_LOCKBOX_PLATFORM"
+            ;;
+        --login)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_USERNAME"
+            ;;
+        --login-to)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REGISTRY"
+            ;;
+        --cacert-to)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_REGISTRY"
+            ;;
+        --dind-param)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_DIND_PARAM"
+            ;;
+        --dind-env)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_DIND_ENV"
+            ;;
+        --output-directory)
+            _torizoncore-builder_completions_helper_filter_dirs
+            ;;
+        *)
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_PLATFORM_LOCKBOX"
+            fi
+            if [ -z "$COMPREPLY" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_LOCKBOX_NAME"
+            fi
+            ;;
+    esac
+}
+
+_torizoncore-builder_completions_platform_provisioning_data() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        --credentials)
+            _torizoncore-builder_completions_helper_filter_files_and_dirs "credentials.zip"
+            ;;
+        --shared-data)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_SHARED_DATA"
+            ;;
+        --online-data)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_CLIENT_NAME"
+            ;;
+        *)
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_PLATFORM_PROVDATA"
+            fi
+            ;;
+    esac
+}
+
+_torizoncore-builder_completions_platform_push() {
+    _torizoncore-builder_completions_push "$@"
+}
+
+# 'platform' command
+_torizoncore-builder_completions_platform() {
+    local cmd=$(_torizoncore-builder_completions_helper_find_subcmd "platform" "$TCB_COMP_ARGS_PLATFORM")
+
+    case "$cmd" in
+        lockbox)
+            _torizoncore-builder_completions_platform_lockbox
+            ;;
+        provisioning-data)
+            _torizoncore-builder_completions_platform_provisioning_data
+            ;;
+        push)
+            _torizoncore-builder_completions_platform_push
+            ;;
+        *)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_PLATFORM"
+            ;;
+    esac
+}
+
+# return in $COMPREPLY a list of references. references can either be
+# a compose file ending with .yaml/yml or the list of references from
+# the ostree folder if the `--repo` argument is already present and it
+# points to a valid ostree folder.
+_torizoncore-builder_completions_push_reference() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local repo
+
+    for ((index=0; index < ${#COMP_WORDS[@]}; index++)); do
+        if [ "${COMP_WORDS[index]}" = "--repo" -a "${COMP_WORDS[index+1]}" = "=" ]; then
+            repo="${COMP_WORDS[index+2]}"
+        elif [[ "${COMP_WORDS[index]}" =~ ^--repo= ]]; then
+            repo=${COMP_WORDS[index]:7}
+        elif [ "${COMP_WORDS[index]}" = "--repo" ]; then
+            repo="${COMP_WORDS[index+1]}"
+        fi
+    done
+
+    repo=$(echo $repo | tr -d '"')
+    local refs_path="$PWD/$repo/refs/heads/"
+
+    if [ -d "$refs_path"  -a -n "$repo" ]; then
+        local results=($(find "$refs_path" -type f 2>/dev/null))
+        results=${results[@]/$refs_path/}
+        COMPREPLY=($(compgen_compat -W "$results" -- ${cur}))
+    else
+        _torizoncore-builder_completions_helper_filter_files "*.y*ml"
+    fi
+
+}
+
+# 'push' command
+_torizoncore-builder_completions_push() {
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        --credentials)
+            _torizoncore-builder_completions_helper_filter_files_and_dirs "credentials.zip"
+            ;;
+        --repo)
+            _torizoncore-builder_completions_helper_filter_dirs
+            ;;
+        --hardwareid)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_HARDWAREID"
+            ;;
+        --package-name)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_PACKAGE_NAME"
+            ;;
+        --package-version)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_PACKAGE_VERSION"
+            ;;
+        *)
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_PUSH"
+            fi
+            if [ -z "$COMPREPLY" ]; then
+                _torizoncore-builder_completions_push_reference
+            fi
+            ;;
+    esac
+}
+
+# 'splash' command
+_torizoncore-builder_completions_splash() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        *)
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_SPLASH"
+            fi
+            if [ -z "$COMPREPLY" ]; then
+                _torizoncore-builder_completions_helper_filter_files_and_dirs "*"
+            fi
+            ;;
+    esac
+}
+
+# 'union' command
+_torizoncore-builder_completions_union() {
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        --changes-directory)
+            _torizoncore-builder_completions_helper_filter_dirs
+            ;;
+        --subject)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_SUBJECT"
+            ;;
+        --body)
+            _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_BODY"
+            ;;
+        *)
+            if [ -n "$cur" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_UNION"
+            fi
+            if [ -z "$COMPREPLY" ]; then
+                _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_DEF_UNION_BRANCH"
+            fi
+            ;;
+    esac
+}
+
+# 'main' command
+_torizoncore-builder_completions() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local i=1 cmd
+
+    # find the subcommand
+    while [[ "$i" -lt "$COMP_CWORD" ]]
+    do
+        local s="${COMP_WORDS[i]}"
+        i=$((i + 1))
+        case "$s" in
+            --log-level)
+                if [ "$i" -eq "$COMP_CWORD" ]; then
+                    _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_MAIN_LOGLEVEL"
+                    return
+                else
+                    i=$((i + 1))
+                fi
+                ;;
+            --log-file)
+                if [ "$i" -eq "$COMP_CWORD" ]; then
+                    _torizoncore-builder_completions_helper_filter_files_and_dirs "*"
+                    return
+                else
+                    i=$((i + 1))
+                fi
+                ;;
+            -*)
+                ;;
+            *)
+                cmd="$s"
+                break
+                ;;
+        esac
+    done
+
+    if [ -z "$cmd" ]; then
+        _torizoncore-builder_completions_helper_static_options "$TCB_COMP_ARGS_MAIN"
+        return
+    fi
+
+    case "$cmd" in
+        build)
+            _torizoncore-builder_completions_build
+            ;;
+        bundle)
+            _torizoncore-builder_completions_bundle
+            ;;
+        combine)
+            _torizoncore-builder_completions_combine
+            ;;
+        deploy)
+            _torizoncore-builder_completions_deploy
+            ;;
+        dt)
+            _torizoncore-builder_completions_dt
+            ;;
+        dto)
+            _torizoncore-builder_completions_dto
+            ;;
+        images)
+            _torizoncore-builder_completions_images
+            ;;
+        isolate)
+            _torizoncore-builder_completions_isolate
+            ;;
+        kernel)
+            _torizoncore-builder_completions_kernel
+            ;;
+        ostree)
+            _torizoncore-builder_completions_ostree
+            ;;
+        platform)
+            _torizoncore-builder_completions_platform
+            ;;
+        push)
+            _torizoncore-builder_completions_push
+            ;;
+        splash)
+            _torizoncore-builder_completions_splash
+            ;;
+        union)
+            _torizoncore-builder_completions_union
+            ;;
+        *)
+            ;;
+    esac
+}
+
+compgen_compat() {
+  if [ -z "$ZSH_VERSION" ]; then
+      compgen "$@"
+  else
+      compgen_zsh "$@"
+  fi
+}
+
+# Mimics the results bash compgen function would output
+compgen_zsh() {
+  local R_PATH="*"
+  local CUR=".*"
+  local ARGS="-1"
+  local X
+  local WORD
+  local FILTER=";p"
+  local DIR_FILTER=";p"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --)
+        # Prevents unwanted output if nothing is passed after `--`
+        [ -n "$2" ] && shift || break;
+        CUR="$1"
+        ;;
+      -o)
+        shift
+        COMP_OPTION="$1"
+        ;;
+      -d)
+        # Filter only Directories
+        ARGS+='adp'
+        DIR_FILTER='/\/$/p'
+      ;;
+      -f)
+        ARGS+='adp'
+      ;;
+      -X)
+        shift
+        # Dumb parser to comply with regex. tested only with the patterns in this file.
+        X=$(tr -d '!' <<< "$1" | sed -En -e  's@^\*@\.\*@1; s@\*@.?@2; s@\.@\\.@2; p;')
+      ;;
+      -W)
+        shift
+        WORD="$1"
+      ;;
+      *)
+
+      ;;
+    esac
+    shift
+  done
+
+  if [ "$COMP_OPTION" = "plusdirs" ]; then
+    ARGS+='adp'
+  fi
+
+  if [ -n "$WORD" -a -n "$CUR" ]; then
+    echo "$WORD" | awk 'NF' | tr ' ' '\n' | sed -En "s;^($CUR.*)$;\1;p"
+    return
+  fi
+
+  # Update pattern to comply with compgen -X '<patter>'
+  if [ -n "$X" ]; then
+    if [ "$COMP_OPTION" = "plusdirs" ]; then
+      FILTER="/($X|.*\/)$/p;"
+    else
+      FILTER="/$X$/p;"
+    fi
+  fi
+
+  # Gets the base dir and add `(.*|*)`.
+  [ -d "$CUR" -a "$CUR" != '..' ] && R_PATH="$CUR(.*|*)"
+  if [ ! -d "$CUR" -a -n "$CUR" ]; then
+    [ $(dirname -- "$CUR") = '.' ] && R_PATH="(.*|*)" || \
+    R_PATH=$(dirname -- "$CUR" | sed -En -e 's@$@\/(.*|*)@p')
+  fi
+
+  # If either no arguments are passed or the target folder is empty, return nothing
+  [ "$ARGS" = "-1" -o $( (eval "ls -1d $R_PATH" 2>/dev/null) | wc -l) -eq 0 ] && return
+
+  eval "ls $ARGS $R_PATH | sed -En -e '$DIR_FILTER' | sed -En -e '$FILTER' | sed -En -e 's;^($CUR.*)$;\1;p'"
+}
+
+_bash_complete_zsh () {
+	local ret=1
+	local -a suf matches
+	local -x COMP_POINT COMP_CWORD
+	local -a COMP_WORDS COMPREPLY BASH_VERSINFO
+	local -x COMP_LINE="$words"
+	local -A savejobstates savejobtexts
+	(( COMP_POINT = 1 + ${#${(j. .)words[1,CURRENT-1]}} + $#QIPREFIX + $#IPREFIX + $#PREFIX ))
+	(( COMP_CWORD = CURRENT - 1))
+	COMP_WORDS=($words)
+	BASH_VERSINFO=(2 05b 0 1 release)
+	savejobstates=(${(kv)jobstates})
+	savejobtexts=(${(kv)jobtexts})
+	[[ ${argv[${argv[(I)nospace]:-0}-1]} = -o ]] && suf=(-S '')
+	matches=(${(f)"$(compgen $@ -- ${words[CURRENT]})"})
+	if [[ -n $matches ]]
+	then
+		if [[ ${argv[${argv[(I)filenames]:-0}-1]} = -o ]]
+		then
+			compset -P '*/' && matches=(${matches##*/})
+			compset -S '/*' && matches=(${matches%%/*})
+			compadd -Q -f "${suf[@]}" -a matches && ret=0
+		else
+			if [ ${#matches[@]} = 1 ] && [ -d "$matches" ]; then
+        compadd -Q -S '' "${suf[@]}" -a matches && ret=0
+      else
+        compadd -Q "${suf[@]}" -a matches && ret=0
+      fi
+		fi
+	fi
+	if (( ret ))
+	then
+		if [[ ${argv[${argv[(I)default]:-0}-1]} = -o ]]
+		then
+			_default "${suf[@]}" && ret=0
+		elif [[ ${argv[${argv[(I)dirnames]:-0}-1]} = -o ]]
+		then
+			_directories "${suf[@]}" && ret=0
+		fi
+	fi
+	return ret
+}
+
+if [ -z "$ZSH_VERSION" ]; then
+  complete -o bashdefault -F _torizoncore-builder_completions torizoncore-builder
+else
+  setopt completealiases
+  autoload bashcompinit && bashcompinit
+  _function=('-F' '_torizoncore-builder_completions')
+  compdef _bash_complete_zsh\ ${(j. .)${(q)_function}} torizoncore-builder
+fi
+

--- a/torizoncore-builder-completion.bash
+++ b/torizoncore-builder-completion.bash
@@ -19,6 +19,7 @@ _TCBCOMP_ARGS_MAIN="
     platform
     push
     splash
+    splash-config
     union
 "
 
@@ -291,6 +292,22 @@ _TCBCOMP_ARGS_PUSH="
 
 _TCBCOMP_ARGS_SPLASH="
     --help
+"
+
+_TCBCOMP_ARGS_SPLASH_CONFIG="
+    --help
+    set
+    dump
+"
+
+_TCBCOMP_ARGS_SPLASH_CONFIG_SET="
+    --help
+"
+
+_TCBCOMP_ARGS_SPLASH_CONFIG_DUMP="
+    --help
+    --file
+    --force
 "
 
 _TCBCOMP_ARGS_UNION="
@@ -1207,6 +1224,49 @@ _tcbcomp_union() {
     esac
 }
 
+# 'splash-config' command
+_tcbcomp_splash_config() {
+    local cmd=$(_tcbcomp_helper_find_subcmd "splash-config" "$_TCBCOMP_ARGS_SPLASH_CONFIG")
+
+    case "$cmd" in
+        set)
+            _tcbcomp_splash_config_set
+            ;;
+        dump)
+            _tcbcomp_splash_config_dump
+            ;;
+        *)
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SPLASH_CONFIG"
+            ;;
+    esac
+}
+
+# 'splash-config set' command
+_tcbcomp_splash_config_set() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+
+    if [ -n "$cur" ]; then
+        _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SPLASH_CONFIG_SET"
+    fi
+    if [ -z "$COMPREPLY" ]; then
+        _tcbcomp_helper_filter_files_and_dirs "*"
+    fi
+}
+
+# 'splash-config dump' command
+_tcbcomp_splash_config_dump() {
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        --file)
+            _tcbcomp_helper_filter_files_and_dirs "*"
+            ;;
+        *)
+            _tcbcomp_helper_static_options "$_TCBCOMP_ARGS_SPLASH_CONFIG_DUMP"
+            ;;
+    esac
+}
+
 # 'main' command
 _tcbcomp() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
@@ -1287,6 +1347,9 @@ _tcbcomp() {
             ;;
         splash)
             _tcbcomp_splash
+            ;;
+        splash-config)
+            _tcbcomp_splash_config
             ;;
         union)
             _tcbcomp_union

--- a/torizoncore-builder.Dockerfile
+++ b/torizoncore-builder.Dockerfile
@@ -441,6 +441,9 @@ COPY tezi /builder/tezi/
 COPY tcbuilder /builder/tcbuilder/
 COPY torizoncore-builder.py /builder/torizoncore-builder
 
+# Store completion script in the image so the setup script can extract/source it
+COPY torizoncore-builder-completion.bash /opt/torizoncore-builder/completion-scripts/
+
 # Workaround for failure when updating device-trees directory with the "dt checkout" command.
 RUN git config --global --add safe.directory '/workdir/device-trees'
 


### PR DESCRIPTION
This is a first step towards having a completion script that is always in sync with the version of TorizonCore Builder. Basically this copies the completion script from https://github.com/toradex/tcb-env-setup and stashes it into the container image. A newer version of the setup script will then source it from the image when available.

The completion script here has been modified to align it with the CLI changes/additions in TorizonCore Builder since December 2024 (when the setup script was last updated).
