### PR TITLE
backend: Suppress progress bar output when stdout is not a TTY

### DIFF
--- a/tcbuilder/backend/build.py
+++ b/tcbuilder/backend/build.py
@@ -6,7 +6,6 @@ import os
 import copy
 import logging
 import re
-import sys
 import shutil
 import tempfile
 
@@ -16,7 +15,7 @@ from urllib.request import urlretrieve
 import jsonschema
 import yaml
 
-from tcbuilder.backend.common import progress, get_file_sha256sum
+from tcbuilder.backend.common import download_progress, get_file_sha256sum
 from tcbuilder.backend.expandvars import expand
 from tcbuilder.errors import (PathNotExistError, InvalidDataError,
                               InvalidAssignmentError, OperationFailureError,
@@ -181,18 +180,13 @@ def fetch_remote(url, fname=None, cksum=None, download_dir=None):
     in_fname, is_temp = make_download_fname(fname)
 
     try:
-        # Show progress bar only when outputting to a terminal.
-        progress_hook = None
-        if sys.stdout.isatty():
-            print(f"Fetching URL '{url}' into '{in_fname}'")
-            progress_hook = progress
-        else:
-            log.info(f"Fetching URL '{url}' into '{in_fname}'")
+        log.info(f"Fetching URL '{url}' into '{in_fname}'")
 
         # Do actual download.
-        out_fname, headers = urlretrieve(
-            url, filename=in_fname, reporthook=progress_hook)
-        log.info("\nDownload Complete!")
+        with download_progress() as reporthook:
+            out_fname, headers = urlretrieve(url, filename=in_fname, reporthook=reporthook)
+
+        log.info("Download Complete!")
         # log.debug(f"Downloaded {out_fname}, headers: {headers}")
 
         # If we still haven't decided the name of the file, try to determine

--- a/tcbuilder/backend/common.py
+++ b/tcbuilder/backend/common.py
@@ -535,8 +535,11 @@ def checkout_dt_git_repo(*, git_repo=None, git_branch=None):
     repo_obj.close()
 
 
-def progress(blocknum, blocksiz, totsiz, totbarsiz=40):
-    if totsiz == -1:
+def _progress(blocknum, blocksiz, totsiz, totbarsiz=40):
+    if not sys.stdout.isatty():
+        return
+
+    if totsiz in [0, -1]:
         totread = (blocknum * blocksiz) // (1024*1024)
         sys.stdout.write(f"\rDownloading file: {totread} MB...")
         sys.stdout.flush()
@@ -544,6 +547,22 @@ def progress(blocknum, blocksiz, totsiz, totbarsiz=40):
         barsiz = int(min((blocknum * blocksiz) / (totsiz), 1.0) * totbarsiz)
         sys.stdout.write("\r[" + ("=" * barsiz) + ("." * (totbarsiz - barsiz)) + "] ")
         sys.stdout.flush()
+
+
+@contextmanager
+def download_progress():
+    """Context manager supplying a urlretrieve reporthook"""
+    is_tty = sys.stdout.isatty()
+    try:
+        yield _progress if is_tty else None
+    finally:
+        if is_tty:
+            try:
+                sys.stdout.write("\n")
+                sys.stdout.flush()
+            # pylint: disable-next=broad-exception-caught
+            except Exception:
+                pass
 
 
 def get_file_sha256sum(path):

--- a/tcbuilder/backend/kernel.py
+++ b/tcbuilder/backend/kernel.py
@@ -11,8 +11,8 @@ import urllib.request
 
 from tcbuilder.backend import ostree, dt
 from tcbuilder.backend.common import \
-    (get_tar_compress_program_options, get_storage_dir,
-     progress, set_output_ownership, OSTREE_ROOT_DEPLOY_PATH)
+    (download_progress, get_tar_compress_program_options, get_storage_dir,
+     set_output_ownership, OSTREE_ROOT_DEPLOY_PATH)
 from tcbuilder.errors import \
     (TorizonCoreBuilderError, PathNotExistError)
 
@@ -247,18 +247,20 @@ def download_toolchain(toolchain, toolchain_path, version_gcc):
         assert False, f"download_toolchain: unhandled toolchain {toolchain}"
     url = url_prefix + tarball
 
-    log.info("A toolchain is required to build the module.\n"
-             f"Downloading toolchain from {url}.\n"
-             "Please wait this could take a while...")
+    log.info("A toolchain is required to build the module.")
+    log.info(f"Downloading toolchain from {url}.")
+    log.info("Please wait this could take a while...")
 
     try:
-        urllib.request.urlretrieve(url, filename=tarball, reporthook=progress)
-        log.info("\nDownload Complete!\n")
+        with download_progress() as reporthook:
+            urllib.request.urlretrieve(url, filename=tarball, reporthook=reporthook)
     except Exception as exc:
         raise TorizonCoreBuilderError(
             "The requested toolchain could not be downloaded") from exc
 
-    log.info("Unpacking downloaded toolchain into storage")
+    log.info("Download Complete!")
+
+    log.info("Unpacking downloaded toolchain into storage.")
     os.makedirs(toolchain_path, exist_ok=True)
     tarcmd = [
         "tar",


### PR DESCRIPTION
When testing the new `tcb-env-setup` script in CI, I found that TCB was producing lots of output when downloading the toolchain. The reason was the output of a progress bar that send out characters to stdout with each status update from the `urlretrieve` function.

This PR solves the situation by creating a context manager to handle the progress information and using it in all invocations of `urlretrieve`. The manager basically only displays progress when the stdout is connected to a terminal.

Please see the commit message for further details.
