### PR TITLE
Add ARM64 host support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -482,6 +482,36 @@ test-torizoncore:
     - TCB_REPORT=1 TCB_UNDER_CI=1 TCB_MACHINE=${BUILD_MACHINE} TCB_TESTCASE="$TCB_HOST_TESTS" ${T} ./run.sh
     - echo -e "\e[0Ksection_end:$(date +%s):test_section\r\e[0K"
 
+.test-base-arm64:
+  extends: .test-base
+  tags:
+    - arm64
+  variables:
+    IMAGE_NAME: torizoncore-builder-arm64
+    # List of all tests suites specific for arm64 test jobs
+    TCB_ARCH_SENSITIVE_TESTS: "kernel"
+  needs: ["build-arm64"]
+
+test-host-arm64-tc6-64bit-release:
+  extends: .test-base-arm64
+  variables:
+    YOCTO_BRANCH: "kirkstone-6.x.y"
+    TARGET_BUILD_TYPE: "release"
+    TCB_MACHINE: "apalis-imx8"
+  script:
+    - ./run_all.sh --machine $TCB_MACHINE --report --testcase "$TCB_ARCH_SENSITIVE_TESTS"
+      --tcb-custom-image "${TCB_IMAGE_UNDER_TEST}"
+
+test-host-arm64-tos7-64bit-nightly:
+  extends: .test-base-arm64
+  variables:
+    YOCTO_BRANCH: "scarthgap-7.x.y"
+    TARGET_BUILD_TYPE: "nightly"
+    TCB_MACHINE: "verdin-imx8mp"
+  script:
+    - ./run_all.sh --machine $TCB_MACHINE --report --testcase "$TCB_ARCH_SENSITIVE_TESTS"
+      --tcb-custom-image "${TCB_IMAGE_UNDER_TEST}"
+
 .aggregate-reports:
   stage: report
   image:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -169,11 +169,11 @@ build-amd64:
     IMAGE_NAME: torizoncore-builder-amd64
     DOCKERFILE_NAME: torizoncore-builder.Dockerfile
 
-# TODO: Consider removing arm64 completely.
 build-arm64:
   extends: .build-base
+  tags:
+    - arm64
   timeout: 5h
-  when: manual
   variables:
     IMAGE_ARCH: linux/arm64/v8
     IMAGE_NAME: torizoncore-builder-arm64
@@ -570,8 +570,14 @@ aggregate-reports-manual:
   script:
     - ${D} docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
     - ${D} docker pull "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_AMD64}:${GITLAB_DOCKERREGISTRY_SUFFIX}"
-    - ${D} docker manifest create "${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}" "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_AMD64}:${GITLAB_DOCKERREGISTRY_SUFFIX}"
-    - ${D} docker manifest annotate "${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}" "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_AMD64}:${GITLAB_DOCKERREGISTRY_SUFFIX}" --os linux --arch amd64
+    - ${D} docker pull "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_ARM64}:${GITLAB_DOCKERREGISTRY_SUFFIX}"
+    - ${D} docker manifest create "${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
+                                   "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_AMD64}:${GITLAB_DOCKERREGISTRY_SUFFIX}"
+                                   "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_ARM64}:${GITLAB_DOCKERREGISTRY_SUFFIX}"
+    - ${D} docker manifest annotate "${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
+                                    "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_AMD64}:${GITLAB_DOCKERREGISTRY_SUFFIX}" --os linux --arch amd64
+    - ${D} docker manifest annotate "${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
+                                    "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_ARM64}:${GITLAB_DOCKERREGISTRY_SUFFIX}" --os linux --arch arm64 --variant v8
     - ${D} docker manifest inspect -v "${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
     - ${D} docker manifest push "${CI_REGISTRY_IMAGE}/${IMAGE_NAME}:${GITLAB_DOCKERREGISTRY_SUFFIX_LATEST}"
 
@@ -582,6 +588,7 @@ aggregate-reports-manual:
   variables:
     IMAGE_NAME: torizoncore-builder
     IMAGE_NAME_AMD64: torizoncore-builder-amd64
+    IMAGE_NAME_ARM64: torizoncore-builder-arm64
   stage: build-multiarch
 
 build-multiarch-auto:
@@ -599,7 +606,7 @@ build-multiarch-auto:
 
 build-multiarch-manual:
   extends: .build-multiarch
-  needs: [build-amd64]
+  needs: [build-amd64, build-arm64]
   rules:
     # Following condition is needed to avoid the execution of merge-request pipelines.
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
@@ -657,8 +664,13 @@ build-multiarch-manual:
         done
     - for tag in ${DOCKER_TAGS} ${DOCKER_TAGS_CHECK};
         do
-          ${D} docker manifest create "${DOCKER_HUB_REPOSITORY}/${IMAGE_NAME}:${tag}" "${DOCKER_HUB_REPOSITORY}/${IMAGE_NAME_AMD64}:${tag}";
-          ${D} docker manifest annotate "${DOCKER_HUB_REPOSITORY}/${IMAGE_NAME}:${tag}" "${DOCKER_HUB_REPOSITORY}/${IMAGE_NAME_AMD64}:${tag}" --os linux --arch amd64;
+          ${D} docker manifest create "${DOCKER_HUB_REPOSITORY}/${IMAGE_NAME}:${tag}"
+                                      "${DOCKER_HUB_REPOSITORY}/${IMAGE_NAME_AMD64}:${tag}"
+                                      "${DOCKER_HUB_REPOSITORY}/${IMAGE_NAME_ARM64}:${tag}";
+          ${D} docker manifest annotate "${DOCKER_HUB_REPOSITORY}/${IMAGE_NAME}:${tag}"
+                                        "${DOCKER_HUB_REPOSITORY}/${IMAGE_NAME_AMD64}:${tag}" --os linux --arch amd64;
+          ${D} docker manifest annotate "${DOCKER_HUB_REPOSITORY}/${IMAGE_NAME}:${tag}"
+                                        "${DOCKER_HUB_REPOSITORY}/${IMAGE_NAME_ARM64}:${tag}" --os linux --arch arm64 --variant v8;
           ${D} docker manifest inspect -v "${DOCKER_HUB_REPOSITORY}/${IMAGE_NAME}:${tag}";
           ${D} docker manifest push "${DOCKER_HUB_REPOSITORY}/${IMAGE_NAME}:${tag}";
         done
@@ -697,8 +709,13 @@ build-multiarch-manual:
         done
     - for tag in ${DOCKER_TAGS} ${DOCKER_TAGS_CHECK};
         do
-          ${D} docker manifest create "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_DEST}:${tag}" "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_AMD64}:${tag}";
-          ${D} docker manifest annotate "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_DEST}:${tag}" "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_AMD64}:${tag}" --os linux --arch amd64;
+          ${D} docker manifest create "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_DEST}:${tag}"
+                                      "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_AMD64}:${tag}"
+                                      "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_ARM64}:${tag}";
+          ${D} docker manifest annotate "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_DEST}:${tag}"
+                                        "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_AMD64}:${tag}" --os linux --arch amd64;
+          ${D} docker manifest annotate "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_DEST}:${tag}"
+                                        "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_ARM64}:${tag}" --os linux --arch arm64 --variant v8;
           ${D} docker manifest inspect -v "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_DEST}:${tag}";
           ${D} docker manifest push "${CI_REGISTRY_IMAGE}/${IMAGE_NAME_DEST}:${tag}";
         done
@@ -735,7 +752,7 @@ deploy-official-arm64-manual:
   extends: .deploy-dh-base
   stage: deploy
   needs: [build-multiarch-manual]
-  allow_failure: true
+  allow_failure: false
   rules:
     # Following condition is needed to avoid the execution of merge-request pipelines.
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
@@ -780,6 +797,7 @@ deploy-official-multiarch-manual:
   variables:
     IMAGE_NAME: torizoncore-builder
     IMAGE_NAME_AMD64: torizoncore-builder-amd64
+    IMAGE_NAME_ARM64: torizoncore-builder-arm64
 
 # ---
 # Early-access deployment to Docker Hub (used when RELEASE_TYPE is "early-access")
@@ -820,24 +838,40 @@ deploy-ea-amd64-manual:
       when: on_success
     - when: never
 
-# NOTE: arm64 is not being built for early-access ATM.
-#deploy-ea-arm64:
-#  extends: .deploy-dh-base
-#  stage: deploy
-#  rules:
-#    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
-#      when: never
-#    # Following condition prevents execution with custom TorizonCore images (triggered by Jenkins).
-#    - if: $BUILD_MACHINE
-#      when: never
-#    - if: '$RELEASE_TYPE == "early-access"'
-#      when: on_success
-#    - when: never
-#  before_script:
-#    - export DOCKER_TAGS_CHECK=""
-#    - export DOCKER_TAGS="early-access"
-#  variables:
-#    IMAGE_NAME: torizoncore-builder-arm64
+.deploy-ea-arm64:
+  extends: .deploy-dh-base
+  stage: deploy
+  before_script:
+    - export DOCKER_TAGS_CHECK=""
+    - export DOCKER_TAGS="early-access"
+  variables:
+    IMAGE_NAME: torizoncore-builder-arm64
+
+deploy-ea-arm64-auto:
+  extends: .deploy-ea-arm64
+  needs: [build-multiarch-auto]
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    # Following condition prevents execution with custom TorizonCore images (triggered by Jenkins).
+    - if: $BUILD_MACHINE
+      when: never
+    - if: '$RELEASE_TYPE == "early-access"'
+      when: on_success
+    - when: never
+
+deploy-ea-arm64-manual:
+  extends: .deploy-ea-arm64
+  needs: [build-multiarch-manual]
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    # Following condition prevents execution with custom TorizonCore images (triggered by Jenkins).
+    - if: $BUILD_MACHINE
+      when: never
+    - if: '$RELEASE_TYPE == "early-access"'
+      when: on_success
+    - when: never
 
 .deploy-ea-multiarch:
   extends: .deploy-dh-multiarch-base
@@ -848,10 +882,11 @@ deploy-ea-amd64-manual:
   variables:
     IMAGE_NAME: torizoncore-builder
     IMAGE_NAME_AMD64: torizoncore-builder-amd64
+    IMAGE_NAME_ARM64: torizoncore-builder-arm64
 
 deploy-ea-multiarch-auto:
   extends: .deploy-ea-multiarch
-  needs: [deploy-ea-amd64-auto]
+  needs: [deploy-ea-amd64-auto, deploy-ea-arm64-auto]
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: never
@@ -864,7 +899,7 @@ deploy-ea-multiarch-auto:
 
 deploy-ea-multiarch-manual:
   extends: .deploy-ea-multiarch
-  needs: [deploy-ea-amd64-manual]
+  needs: [deploy-ea-amd64-manual, deploy-ea-arm64-manual]
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: never
@@ -899,31 +934,30 @@ deploy-int-amd64-manual:
     IMAGE_NAME: torizoncore-builder-amd64
     IMAGE_NAME_DEST: torizoncore-builder-internal-amd64
 
-# NOTE: arm64 is not being built for internal ATM.
-# deploy-int-arm64-manual:
-#  extends: .deploy-int-base
-#  stage: deploy
-#  needs: [build-multiarch-manual]
-#  rules:
-#    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
-#      when: never
-#    # Following condition prevents execution with custom TorizonCore images (triggered by Jenkins).
-#    - if: $BUILD_MACHINE
-#      when: never
-#    - if: '$RELEASE_TYPE == "internal"'
-#      when: on_success
-#    - when: never
-#  before_script:
-#    - export DOCKER_TAGS_CHECK=""
-#    - export DOCKER_TAGS="${TORIZONCORE_BUILDER_MAJOR} ${TORIZONCORE_BUILDER_MAJOR}-latest"
-#  variables:
-#    IMAGE_NAME: torizoncore-builder-arm64
-#    IMAGE_NAME_DEST: torizoncore-builder-internal-arm64
+deploy-int-arm64-manual:
+  extends: .deploy-int-base
+  stage: deploy
+  needs: [build-multiarch-manual]
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    # Following condition prevents execution with custom TorizonCore images (triggered by Jenkins).
+    - if: $BUILD_MACHINE
+      when: never
+    - if: '$RELEASE_TYPE == "internal"'
+      when: on_success
+    - when: never
+  before_script:
+    - export DOCKER_TAGS_CHECK=""
+    - export DOCKER_TAGS="${TORIZONCORE_BUILDER_MAJOR} ${TORIZONCORE_BUILDER_MAJOR}-latest"
+  variables:
+    IMAGE_NAME: torizoncore-builder-arm64
+    IMAGE_NAME_DEST: torizoncore-builder-internal-arm64
 
 deploy-int-multiarch-manual:
   extends: .deploy-int-multiarch-base
   stage: deploy-multiarch
-  needs: [deploy-int-amd64-manual]
+  needs: [deploy-int-amd64-manual, deploy-int-arm64-manual]
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: never
@@ -940,6 +974,7 @@ deploy-int-multiarch-manual:
     #IMAGE_NAME: torizoncore-builder
     IMAGE_NAME_DEST: torizoncore-builder-internal
     IMAGE_NAME_AMD64: torizoncore-builder-internal-amd64
+    IMAGE_NAME_ARM64: torizoncore-builder-internal-arm64
 
 # ---
 # Git tagging

--- a/tcbuilder/backend/kernel.py
+++ b/tcbuilder/backend/kernel.py
@@ -147,7 +147,7 @@ def _get_toolchain(image_major_version, linux_src):
 
     # Download toolchain if needed
     if not os.path.exists(toolchain):
-        download_toolchain(c_c, toolchain_path, version_gcc)
+        download_toolchain(toolchain_path, version_gcc, host_arch, target_triple)
 
     return (toolchain, target_arch, c_c)
 
@@ -266,28 +266,62 @@ def autoload_module(module, kernel_changes_dir):
         cnfh.writelines(conf_lines)
 
 
-def download_toolchain(toolchain, toolchain_path, version_gcc):
+def _try_download(url, dest):
+    """Attempt to download *url* to *dest*.
+
+    Returns True on success, False when the server is unreachable or returns
+    an error.
+    """
+    log.info(f"Downloading toolchain from {url}.")
+    log.info("Please wait this could take a while...")
+    try:
+        with download_progress() as reporthook:
+            urllib.request.urlretrieve(url, filename=dest, reporthook=reporthook)
+        return True
+    # pylint: disable-next=broad-exception-caught
+    except Exception as exc:
+        log.debug("Download from %s failed: %s", url, exc)
+        return False
+
+
+def _toolchain_fallback_url(version_gcc, tarball):
+    """Return the developer.arm.com URL for a given toolchain build.
+
+    Only "arm-gnu-toolchain-*" releases are mirrored there; the legacy
+    "gcc-arm-*" releases have no equivalent fallback.
+    """
+    if not version_gcc.startswith("arm-gnu-toolchain-"):
+        return None
+
+    ver_suffix = version_gcc[len("arm-gnu-toolchain-"):]
+    return (f"https://developer.arm.com/-/media/Files/downloads/gnu"
+            f"/{ver_suffix}/binrel/{tarball}")
+
+
+def download_toolchain(toolchain_path, version_gcc, host_arch, target_triple):
     """Download toolchain from online if it doesn't already exist"""
 
     url_prefix = "https://sources.toradex.com/tcb/toolchains/"
-    if toolchain == "arm-none-linux-gnueabihf-":
-        tarball = f"{version_gcc}-x86_64-arm-none-linux-gnueabihf.tar.xz"
-    elif toolchain == "aarch64-none-linux-gnu-":
-        tarball = f"{version_gcc}-x86_64-aarch64-none-linux-gnu.tar.xz"
-    else:
-        assert False, f"download_toolchain: unhandled toolchain {toolchain}"
-    url = url_prefix + tarball
+
+    if target_triple not in TARGET_TRIPLES.values():
+        assert False, f"download_toolchain: unhandled toolchain {target_triple}"
+    tarball = f"{version_gcc}-{host_arch}-{target_triple}.tar.xz"
+
+    primary_url = url_prefix + tarball
+    fallback_url = _toolchain_fallback_url(version_gcc, tarball)
 
     log.info("A toolchain is required to build the module.")
-    log.info(f"Downloading toolchain from {url}.")
-    log.info("Please wait this could take a while...")
 
-    try:
-        with download_progress() as reporthook:
-            urllib.request.urlretrieve(url, filename=tarball, reporthook=reporthook)
-    except Exception as exc:
+    downloaded = _try_download(primary_url, tarball)
+    if not downloaded and fallback_url is not None:
+        log.info("Primary download failed; trying fallback source.")
+        downloaded = _try_download(fallback_url, tarball)
+
+    if not downloaded:
+        tried = primary_url if fallback_url is None \
+                                 else f"{primary_url} and {fallback_url}"
         raise TorizonCoreBuilderError(
-            "The requested toolchain could not be downloaded") from exc
+            f"The requested toolchain could not be downloaded. URLs tried: {tried}")
 
     log.info("Download Complete!")
 

--- a/tcbuilder/backend/kernel.py
+++ b/tcbuilder/backend/kernel.py
@@ -19,10 +19,27 @@ from tcbuilder.errors import \
 
 log = logging.getLogger("torizon." + __name__)
 
-IMAGE_MAJOR_TO_GCC_MAP = {
-    5: "gcc-arm-9.2-2019.12",
-    6: "arm-gnu-toolchain-11.3.rel1",
-    7: "arm-gnu-toolchain-13.3.rel1"
+
+TARGET_TRIPLES = {
+    "arm": "arm-none-linux-gnueabihf",
+    "arm64": "aarch64-none-linux-gnu",
+}
+
+# ("<host-arch>", "<target-arch>", "<image-major-version>") : "<gcc_version>"
+CROSS_COMPILERS = {
+    # x86_64
+    ("x86_64", "arm", 5): "gcc-arm-9.2-2019.12",
+    ("x86_64", "arm64", 5): "gcc-arm-9.2-2019.12",
+    ("x86_64", "arm", 6): "arm-gnu-toolchain-11.3.rel1",
+    ("x86_64", "arm64", 6): "arm-gnu-toolchain-11.3.rel1",
+    ("x86_64", "arm", 7): "arm-gnu-toolchain-13.3.rel1",
+    ("x86_64", "arm64", 7): "arm-gnu-toolchain-13.3.rel1",
+    # aarch64
+    ("aarch64", "arm", 6): "arm-gnu-toolchain-11.3.rel1",
+    ("aarch64", "arm64", 6): "arm-gnu-toolchain-14.2.rel1",
+    ("aarch64", "arm", 7): "arm-gnu-toolchain-13.3.rel1",
+    ("aarch64", "arm64", 7): "arm-gnu-toolchain-14.2.rel1",
+
 }
 
 OSTREE_KERNEL_SUBDIR_PATH = "usr/lib/modules/{kver}/"
@@ -43,6 +60,16 @@ SET_BOOTARGS_CUSTOM2_RE = r'^\s*set_bootargs_custom2='
 # copied from sysroot to the changes directory when preparing the latter for
 # building modules.
 MOD_DIR_COPY_EXCLUDE_SET = {"dtb"}
+
+
+def _host_arch():
+    """Return the host architecture prefix for toolchain names."""
+    machine = os.uname().machine
+    if machine == "x86_64":
+        return "x86_64"
+    if machine in ("aarch64", "arm64"):
+        return "aarch64"
+    raise TorizonCoreBuilderError(f"Unsupported host architecture: {machine}")
 
 
 def get_kernel_changes_dir():
@@ -99,28 +126,30 @@ def _amend_makefile(linux_src):
 
 
 def _get_toolchain(image_major_version, linux_src):
-    arch = _kernel_arch_from_source(linux_src)
-    version_gcc = IMAGE_MAJOR_TO_GCC_MAP.get(image_major_version)
-    assert version_gcc, "Unable to determine the GCC toolchain version"
-
     # Set CROSS_COMPILE and toolchain based on ARCH
     toolchain_path = os.path.join(os.path.dirname(linux_src), "toolchain")
-    if arch == "arm":
-        c_c = "arm-none-linux-gnueabihf-"
-        toolchain = os.path.join(
-            toolchain_path, f"{version_gcc}-x86_64-arm-none-linux-gnueabihf/bin")
-    elif arch == "arm64":
-        c_c = "aarch64-none-linux-gnu-"
-        toolchain = os.path.join(
-            toolchain_path, f"{version_gcc}-x86_64-aarch64-none-linux-gnu/bin")
-    else:
-        assert False, "build_module: Unhandled architecture"
+    target_arch = _kernel_arch_from_source(linux_src)
+    host_arch = _host_arch()
+
+    version_gcc = CROSS_COMPILERS.get((host_arch, target_arch, image_major_version))
+    assert version_gcc, (
+        "Unable to determine the GCC toolchain version for "
+        f"values ({host_arch}, {target_arch}, {image_major_version})"
+    )
+
+    target_triple = TARGET_TRIPLES.get(target_arch)
+    assert target_triple, \
+        f"{target_arch} is not supported as a target architecture"
+
+    c_c = f"{target_triple}-"
+    toolchain = os.path.join(
+        toolchain_path, f"{version_gcc}-{host_arch}-{target_triple}/bin")
 
     # Download toolchain if needed
     if not os.path.exists(toolchain):
         download_toolchain(c_c, toolchain_path, version_gcc)
 
-    return (toolchain, arch, c_c)
+    return (toolchain, target_arch, c_c)
 
 
 def _prep_linux_src_for_modules_install(src_ostree_archive_dir, linux_src):

--- a/torizoncore-builder.Dockerfile
+++ b/torizoncore-builder.Dockerfile
@@ -1,3 +1,4 @@
+# For arm64 use: --build-arg IMAGE_ARCH=linux/arm64/v8
 ARG IMAGE_ARCH=linux/amd64
 ARG IMAGE_TAG=trixie-slim
 ARG UPTANE_SIGN_VER=3.2.6
@@ -159,11 +160,17 @@ FROM builder-base AS skopeo-builder
 
 WORKDIR /root
 
+ARG IMAGE_ARCH 
+
 RUN echo "Installing Go..." && \
-    wget https://go.dev/dl/go1.24.3.linux-amd64.tar.gz && \
+    case "${IMAGE_ARCH}" in \
+      linux/arm64*) GO_ARCH="arm64" ;; \
+      *)            GO_ARCH="amd64" ;; \
+    esac && \
+    wget "https://go.dev/dl/go1.24.3.linux-${GO_ARCH}.tar.gz" && \
     rm -rf /usr/local/go && \
-    tar -C /usr/local -xzf go1.24.3.linux-amd64.tar.gz && \
-    rm go1.24.3.linux-amd64.tar.gz
+    tar -C /usr/local -xzf "go1.24.3.linux-${GO_ARCH}.tar.gz" && \
+    rm "go1.24.3.linux-${GO_ARCH}.tar.gz"
 
 ENV PATH=/usr/local/go/bin:$PATH
 ENV GOPATH=/root/go


### PR DESCRIPTION
## What changed
- Dockerfile: Added IMAGE_ARCH usage comment and fixed Go binary download in skopeo-builder to use the correct architecture.
- Kernel backend: Added ARM64 host support for building kernel modules. For ARM64→ARM64 builds, the arm-gnu-toolchain-14.2 variant is always used, disregarding Torizon Image major versions. For ARM64→ARM32, the 13.3 variant is used for Torizon 7 and the 11.3 variant is used for Torizon 6. In cases where the toolchain download from Toradex sources fails, a new code logic was added so the download falls back to official Arm sources.
- GitLab CI/CD: Extended pipeline to build, deploy, and publish the ARM64 variant.

## What changed from the previous version of this PR
- Correct toolchains versions for each (host_arch, target_arch, torizon_major_version) combination
- A new download fallback to Arm sources
- A new logic to decide the toolchain version using the CROSS_COMPILERS map, in order to make the code more declarative and avoid long if/elif statements.
- All linters and test jobs that just mirrored the amd64 jobs and didn't add much value were removed.

## Testing
All the new toolchains were tested in a verdin-imx8mp as a host machine (in a docker dind container). The tests focus mainly on Kernel Build functionality, using two kernel modules as examples: https://github.com/toradex/hello-mod and https://github.com/vi/virtual_touchscreen.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added arm64 support across image building, testing, and deployment pipelines.
  * Multi-architecture images now include both amd64 and arm64 variants.
  * Added automated arm64 testing and deployment options for early-access and internal releases.
  * Kernel module builds now support aarch64 hosts and cross-compilation.
  * Improved toolchain downloads with a fallback source and clearer download errors.
  * Updated container tooling to support arm64 environments.
* **Bug Fixes**
  * Official arm64 deployments now fail clearly when unsuccessful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->