### PR TITLE
Add support to add/remove custom kernel arguments for raw disk images using U-Boot

### DIFF
--- a/tcbuilder/backend/kernel.py
+++ b/tcbuilder/backend/kernel.py
@@ -28,6 +28,8 @@ OSTREE_KERNEL_SUBDIR_PATH = "usr/lib/modules/{kver}/"
 OSTREE_KERNEL_FILENAME = "vmlinuz"
 KERNEL_FIT_FILENAME = OSTREE_KERNEL_FILENAME
 
+KARGS_SUPPORTED_BOOTLOADERS = ["U-Boot"]
+
 # Name of the "function" in uEnv.txt responsible for handling boot arguments
 # passed by means of an overlay.
 SET_BOOTARGS_CUSTOM_RE = r'^\s*set_bootargs_custom='

--- a/tcbuilder/cli/kernel.py
+++ b/tcbuilder/cli/kernel.py
@@ -13,9 +13,11 @@ import libfdt
 from tcbuilder.errors import \
     (FileContentMissing, InvalidDataError, PathNotExistError, UnsupportedImageFeature)
 from tcbuilder.backend.common import \
-    (fail_on_raw_image, is_file_type_fit, get_branch_and_major_from_metadata,
-     get_storage_dir, get_tar_compress_program_options, images_unpack_executed,
-     get_arch_from_ostree)
+    (is_file_type_fit, get_branch_and_major_from_metadata, get_storage_dir,
+     get_tar_compress_program_options, images_unpack_executed,
+     get_arch_from_ostree, get_src_sysroot_dir)
+from tcbuilder.backend.deploy import get_image_bootloader
+
 from tcbuilder.backend import kernel, dt, dto
 from tcbuilder.backend.kernelfit import KernelFit
 from tcbuilder.cli import dto as dto_cli
@@ -365,7 +367,12 @@ def kernel_set_custom_args(kernel_args):
     """
 
     images_unpack_executed()
-    fail_on_raw_image(MSG_CUSTOMIZATION_NOT_SUPPORTED_FOR_WIC)
+    img_bootld = get_image_bootloader(get_src_sysroot_dir())
+    if img_bootld not in kernel.KARGS_SUPPORTED_BOOTLOADERS:
+        log.warning(f"Detected bootloader in unpacked image: {img_bootld}")
+        raise UnsupportedImageFeature(
+            f"Kernel argument customization is not supported for {img_bootld} "
+            "bootloader. Aborting.")
 
     kernel_path = kernel.find_kernel_in_sysroot()
     kernel_is_fit = is_file_type_fit(kernel_path)
@@ -492,7 +499,12 @@ def kernel_get_custom_args():
     """Run 'kernel get_custom_args" subcommand"""
 
     images_unpack_executed()
-    fail_on_raw_image(MSG_COMMAND_NOT_SUPPORTED_FOR_WIC)
+    img_bootld = get_image_bootloader(get_src_sysroot_dir())
+    if img_bootld not in kernel.KARGS_SUPPORTED_BOOTLOADERS:
+        log.warning(f"Detected bootloader in unpacked image: {img_bootld}")
+        raise UnsupportedImageFeature(
+            f"Kernel argument customization is not supported for {img_bootld} "
+            "bootloader. Aborting.")
 
     kernel_path = kernel.find_kernel_in_sysroot()
     kernel_is_fit = is_file_type_fit(kernel_path)
@@ -571,7 +583,12 @@ def kernel_clear_custom_args():
     """Run 'kernel clear_custom_args" subcommand"""
 
     images_unpack_executed()
-    fail_on_raw_image(MSG_CUSTOMIZATION_NOT_SUPPORTED_FOR_WIC)
+    img_bootld = get_image_bootloader(get_src_sysroot_dir())
+    if img_bootld not in kernel.KARGS_SUPPORTED_BOOTLOADERS:
+        log.warning(f"Detected bootloader in unpacked image: {img_bootld}")
+        raise UnsupportedImageFeature(
+            f"Kernel argument customization is not supported for {img_bootld} "
+            "bootloader. Aborting.")
 
     kernel_path = kernel.find_kernel_in_sysroot()
     kernel_is_fit = is_file_type_fit(kernel_path)

--- a/tests/integration/testcases/wic/kernel.bats
+++ b/tests/integration/testcases/wic/kernel.bats
@@ -26,8 +26,43 @@ setup_file() {
 
 setup() {
   if [ "${UNSUPPORTED_MACHINE}" = "1" ]; then
-    skip "DT/DTO customization is not supported for ${IMG_MACHINE}"
+    skip "Kernel customization is not supported for ${IMG_MACHINE}"
   fi
+}
+
+# Local helpers:
+find_uenv_txt_in_sysroot() {
+    # Get path:
+    run torizoncore-builder-shell "find /storage/sysroot/ostree/deploy/ -name uEnv.txt"
+    assert_success
+    local uenv_path="${output}"
+    # Sanity check:
+    run torizoncore-builder-shell "[ -f '${uenv_path}' ]"
+    assert_success
+    echo "${uenv_path}"
+}
+
+find_uenv_txt_in_chgsdir() {
+    # Get path:
+    run torizoncore-builder-shell \
+        "{ [ -d /storage/dt ] && find /storage/dt/ -name uEnv.txt; } ||" \
+        "{ [ -d /storage/kernel ] && find /storage/kernel/ -name uEnv.txt; }"
+    assert_success
+    local uenv_path="${output}"
+    # Sanity check:
+    run torizoncore-builder-shell "[ -f '${uenv_path}' ]"
+    assert_success
+    echo "${uenv_path}"
+}
+
+is_ovl_kargs_passing_supported() {
+    local uenv_path="${1?uEnv.txt path required}"
+    torizoncore-builder-shell "grep -q '^set_bootargs_custom=' ${uenv_path}"
+}
+
+is_uenv_kargs_passing_supported() {
+    local uenv_path="${1?uEnv.txt path required}"
+    torizoncore-builder-shell "grep -q '^set_bootargs_custom2=' ${uenv_path}"
 }
 
 @test "kernel: run without parameters" {
@@ -158,4 +193,171 @@ setup() {
         "[ \"\$(cat /storage/kernel/${moddirrel}/vmlinuz)\" = 'DUMMY_KERNEL' ] && " \
         "[ \"\$(cat /storage/kernel/${moddirrel}/dtb/overlays.txt)\" = 'DUMMY_OVERLAYS' ]"
     assert_success
+}
+
+@test "kernel {set,get,clear}_custom_args: check basic errors" {
+    torizoncore-builder-clean-storage
+
+    run torizoncore-builder kernel set_custom_args "arg1=val1" "arg2=val2"
+    assert_failure
+    assert_output --partial "Error: could not find an Easy Installer or WIC image in the storage"
+    assert_output --partial "Please use the 'images' command to unpack an image before running this command"
+
+    run torizoncore-builder kernel get_custom_args
+    assert_failure
+    assert_output --partial "Error: could not find an Easy Installer or WIC image in the storage"
+    assert_output --partial "Please use the 'images' command to unpack an image before running this command"
+
+    run torizoncore-builder kernel clear_custom_args
+    assert_failure
+    assert_output --partial "Error: could not find an Easy Installer or WIC image in the storage"
+    assert_output --partial "Please use the 'images' command to unpack an image before running this command"
+
+    torizoncore-builder images --remove-storage unpack "${DEFAULT_WIC_IMAGE}"
+
+    run torizoncore-builder kernel set_custom_args ""
+    assert_failure
+    assert_output --partial "Error: please pass a valid string for the custom kernel arguments"
+}
+
+@test "kernel {set,get,clear}_custom_args: check success cases" {
+    torizoncore-builder images --remove-storage unpack "${DEFAULT_WIC_IMAGE}"
+
+    local uenv_path
+    local ovl_kargs_supported
+    local uenv_kargs_supported
+
+    # Find uEnv.txt in storage:
+    uenv_path=$(find_uenv_txt_in_sysroot)
+    # Determine the supported bootargs passing methods:
+    ovl_kargs_supported=$(is_ovl_kargs_passing_supported "${uenv_path}" \
+                          && echo "1" || echo "0")
+    uenv_kargs_supported=$(is_uenv_kargs_passing_supported "${uenv_path}" \
+                           && echo "1" || echo "0")
+    # Show result (for debug):
+    echo "ovl_kargs_supported=${ovl_kargs_supported}"
+    echo "uenv_kargs_supported=${uenv_kargs_supported}"
+
+    # ---
+    # Test the "set" command:
+    # ---
+    echo "Try setting custom bootargs."
+    run torizoncore-builder --log-level debug kernel set_custom_args "arg1=val1" "arg2=val2"
+
+    if [ "${uenv_kargs_supported}" = "1" ]; then
+        echo "Checking output of setting custom kernel arguments via uenv method."
+        assert_success
+        assert_output --partial 'Kernel custom arguments successfully configured with "arg1=val1 arg2=val2"'
+        assert_output --partial "Setting bootargs (uenv method)"
+        assert_output --partial "Clearing bootargs (overlay method)"
+
+        # Check uEnv.txt to see if the arguments were actually set.
+        local uenv_path_chgsdir check_append
+        uenv_path_chgsdir=$(find_uenv_txt_in_chgsdir)
+        check_append="1"
+
+        if [ "${check_append}" = "1" ]; then
+            echo "Ensure new bootargs were appended to the existing ones."
+            if ! torizoncore-builder-shell \
+                 "grep -e '^torizon_bootargs_r=arg1=val1 arg2=val2' ${uenv_path_chgsdir}"; then
+                fail "New bootargs aren't present in 'torizon_bootargs_r'."
+            fi
+            if torizoncore-builder-shell \
+                   "grep -e '^torizon_bootargs_l=' ${uenv_path_chgsdir}"; then
+                fail "Variable 'torizon_bootargs_l' shouldn't be present in uEnv.txt."
+            fi
+        else
+            echo "Ensure new bootargs were prepended to the existing ones."
+            if ! torizoncore-builder-shell \
+                 "grep -e '^torizon_bootargs_l=arg1=val1 arg2=val2' ${uenv_path_chgsdir}"; then
+                fail "New bootargs aren't present in 'torizon_bootargs_l'."
+            fi
+            if torizoncore-builder-shell \
+                   "grep -e '^torizon_bootargs_r=' ${uenv_path_chgsdir}"; then
+                fail "Variable 'torizon_bootargs_r' shouldn't be present in uEnv.txt."
+            fi
+        fi
+
+    elif [ "${ovl_kargs_supported}" = "1" ]; then
+        echo "Checking output of setting custom kernel arguments via overlay method."
+        assert_success
+        assert_output --partial 'Kernel custom arguments successfully configured with "arg1=val1 arg2=val2"'
+        assert_output --partial "Setting bootargs (overlay method)"
+        assert_output --partial "Overlay custom-kargs_overlay.dtbo successfully applied"
+    else
+        # Images without support for custom bootargs should no longer be available;
+        # but handle them anyway.
+        assert_failure
+        assert_output --partial "Error: the Torizon OS image you are customizing does not support custom kernel arguments"
+        return
+    fi
+
+    # ---
+    # Test the "get" command:
+    # ---
+    echo "Try getting custom bootargs."
+    run torizoncore-builder --log-level debug kernel get_custom_args
+    echo "Checking output of getting custom kernel arguments."
+    assert_success
+    assert_output --partial 'Currently configured custom kernel arguments: "arg1=val1 arg2=val2"'
+
+    # ---
+    # Test the "clear" command:
+    # ---
+    echo "Try clearing custom bootargs."
+    run torizoncore-builder --log-level debug kernel clear_custom_args
+
+    if [ "${uenv_kargs_supported}" = "1" ]; then
+        echo "Checking output of clearing custom kernel arguments via uenv method."
+        assert_success
+        assert_output --partial 'Custom kernel arguments successfully cleared'
+        assert_output --partial "Clearing bootargs (uenv method)"
+
+        # Check uEnv.txt to see if the arguments variables are gone.
+        local uenv_path_chgsdir
+        uenv_path_chgsdir=$(find_uenv_txt_in_chgsdir)
+        echo "Ensure bootargs variables are not present in '${uenv_path_chgsdir}'."
+        if torizoncore-builder-shell "grep -e '^torizon_bootargs_l=' ${uenv_path_chgsdir}"; then
+            fail "Variable 'torizon_bootargs_l' is present in uEnv.txt after clearing."
+        fi
+        if torizoncore-builder-shell "grep -e '^torizon_bootargs_r=' ${uenv_path_chgsdir}"; then
+            fail "Variable 'torizon_bootargs_r' is present in uEnv.txt after clearing."
+        fi
+
+    elif [ "${ovl_kargs_supported}" = "1" ]; then
+        echo "Checking output of clearing custom kernel arguments via overlay method."
+        assert_success
+        assert_output --partial 'Custom kernel arguments successfully cleared'
+        assert_output --partial "Clearing bootargs (overlay method)"
+    else
+        # Images without support for custom bootargs should no longer be available;
+        # but handle them anyway.
+        assert_failure
+        assert_output --partial "Error: the Torizon OS image you are customizing does not support custom kernel arguments"
+        return
+    fi
+
+    # ---
+    # Check the "get" command after clearing:
+    # ---
+    echo "Try getting custom bootargs after clearing."
+    run torizoncore-builder --log-level debug kernel get_custom_args
+    echo "Checking output of getting custom kernel arguments after clearing."
+    assert_success
+    assert_output --partial 'No custom kernel arguments configured'
+
+    # ---
+    # Test the "clear" command again after clearing:
+    # ---
+    echo "Try clearing custom bootargs after clearing."
+    run torizoncore-builder --log-level debug kernel clear_custom_args
+    echo "Checking output of clearing custom kernel arguments after clearing."
+    assert_success
+    assert_output --partial 'No custom kernel arguments configured'
+
+    if [ "${uenv_kargs_supported}" = "1" ]; then
+        echo "Checking output of clearing custom kernel arguments again."
+        assert_success
+        assert_output --partial "Clearing bootargs (uenv method)"
+    fi
 }


### PR DESCRIPTION
Add support to add and remove custom kernel arguments for raw disk images that use U-Boot as bootloader. Adding custom kernel arguments is also supported using the `build` command via its respective option in the `tcbuild.yaml` file.

Test cases were also added for this new feature.

Related-to: TCB-868