### PR TITLE
gitlab-ci: Allow failure of deploy-official-arm64-manual job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -735,6 +735,7 @@ deploy-official-arm64-manual:
   extends: .deploy-dh-base
   stage: deploy
   needs: [build-multiarch-manual]
+  allow_failure: true
   rules:
     # Following condition is needed to avoid the execution of merge-request pipelines.
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'


### PR DESCRIPTION
If deploy-official-arm64-manual fails, the following job that needs it, deploy-official-multiarch-manual, is skipped and the whole pipeline is halted.

Right now deploy-official-arm64-manual will always fail as there's no arm64 build of TCB. This effectively hinders the release of a new version of TCB until arm64 builds are available.

Allow deploy-official-arm64-manual to fail to keep the release pipeline running and able to deploy an official release.

Related-to: TCB-892