### PR TITLE
Bump test pipeline DOCKER_VERSION to 29.7.0, plus fix Dockerfile linter stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ variables:
 
   DEBIAN_RELEASE: "trixie-slim"
   # This Docker version should be bumped to latest Docker version at the end of the release process
-  DOCKER_VERSION: "29.3.1"
+  DOCKER_VERSION: "29.7.0"
   # Pipeline Settings
   GIT_CLONE_PATH: $CI_BUILDS_DIR/$CI_CONCURRENT_ID/$CI_PROJECT_PATH
   GET_SOURCES_ATTEMPTS: 3

--- a/tests/integration/testcases/lib/registries.sh
+++ b/tests/integration/testcases/lib/registries.sh
@@ -16,7 +16,7 @@ export DIND_CONTAINER="dind-for-registries"
 
 export REGISTRIES_NETWORK="registry-network"
 
-export DOCKER_VERSION="29.3.1"
+export DOCKER_VERSION="29.7.0"
 
 
 _start-registries() {

--- a/torizoncore-builder.Dockerfile
+++ b/torizoncore-builder.Dockerfile
@@ -414,6 +414,7 @@ RUN apt-get -q -y update && \
     && \
     rm -rf /var/lib/apt/lists/*
 
+# hadolint ignore=DL3064
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID


### PR DESCRIPTION
As part of the release process of TorizonCore Builder, bump `DOCKER_VERSION` used in the test pipeline to the latest available version (29.7.0) after releasing a new version of TCB.

Also fix the Dockerfile linter stage of the CI/CD pipeline that started failing today due to a new rule in the Dockerfile linter.

See the commit messages for more details.

Related-to: TCB-892