### PR TITLE
tcbuild.schema.yaml: Add lino-imx93 and toradex-osm-imx93 machines

### DIFF
--- a/tcbuilder/backend/tcbuild.schema.yaml
+++ b/tcbuilder/backend/tcbuild.schema.yaml
@@ -23,6 +23,8 @@ properties:
           - colibri-imx7-emmc
           - colibri-imx8x
           - colibri-imx8x-v10b
+          - lino-imx93
+          - toradex-osm-imx93
           - toradex-smarc-imx8mp
           - toradex-smarc-imx95
           - verdin-imx8mm


### PR DESCRIPTION
Related-to: TCB-888, TCB-889

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `lino-imx93` and `toradex-osm-imx93` device configurations when providing TorizonCore input settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->