### PR TITLE
build: Add support for inserting fusing data into image

### DIFF
--- a/tcbuilder/backend/common.py
+++ b/tcbuilder/backend/common.py
@@ -140,6 +140,8 @@ OSTREE_ROOT_DEPLOY_PATH = "ostree/deploy/torizon/deploy/{csum}"
 
 OSTREE_SOTA_DIR_PATH = "/ostree/deploy/torizon/var/sota"
 
+FUSE_CMD_TXT_NAME = "fuse-cmds.txt"
+
 
 def get_storage_dir():
     """Get the absolute path of the "storage" directory."""

--- a/tcbuilder/backend/deploy.py
+++ b/tcbuilder/backend/deploy.py
@@ -21,9 +21,8 @@ from tcbuilder.backend import ostree
 from tcbuilder.backend.common import (get_rootfs_tarball, resolve_remote_host,
                                       run_with_loading_animation, open_disk_image,
                                       REMOTE_CMD_TIMEOUT, SECBOOT_ARTIFACTS_DIR,
-                                      DEFAULT_RAW_SECTOR_SIZE)
+                                      DEFAULT_RAW_SECTOR_SIZE, FUSE_CMD_TXT_NAME)
 from tcbuilder.backend.rforward import reverse_forward_tunnel, request_port_forward
-from tcbuilder.backend.secboot import FUSE_CMD_TXT_NAME
 from tcbuilder.errors import TorizonCoreBuilderError, InvalidDataError
 from tezi.utils import find_rootfs_content
 # pylint: enable=wrong-import-position

--- a/tcbuilder/backend/platform.py
+++ b/tcbuilder/backend/platform.py
@@ -1881,6 +1881,23 @@ def push_fuse(credentials, target, version, fuse_file, hardwareids, *,
         update_description(description, target, version, credentials)
 
 
+def fuse_count_for_tech(tech):
+    """Determine the number of fuses based on the secure-boot technology
+
+    :param tech: The secure-boot technology being used.
+    :returns: An int with the number of fuses
+    """
+
+    if tech == "hab":
+        fuse_num = 8
+    elif tech == "ahab":
+        fuse_num = 16
+    else:
+        assert False, f"Unhandled Secure Boot technology '{tech}'."
+
+    return fuse_num
+
+
 def fuse_hwid_to_machine(hwid):
     """Translate a fuse hwid to a machine name."""
     if not hwid.endswith(FUSE_HWID_SUFFIX):
@@ -1915,12 +1932,7 @@ def validate_fuse_file(fuse_file, hardwareids):
             f"Provided hardware ids: {hardwareids} are associated with different"
             " Secure Boot technologies which is not possible in one fuse type package.")
 
-    if "hab" in secboot_techs:
-        fuse_num = 8
-    elif "ahab" in secboot_techs:
-        fuse_num = 16
-    else:
-        assert False, f"Unhandled Secure Boot technology '{secboot_techs}'."
+    fuse_num = fuse_count_for_tech(next(iter(secboot_techs)))
 
     # Next check overall layout against schema
     parsed_file = parse_config_file(fuse_file, schema_path=FUSE_SCHEMA_FILE)

--- a/tcbuilder/backend/secboot.py
+++ b/tcbuilder/backend/secboot.py
@@ -13,7 +13,7 @@ from tcbuilder.backend import kernel
 from tcbuilder.backend.common import \
     (check_if_file_exists, get_tar_compress_program_options, get_storage_dir,
      get_tezi_image_version, is_file_type_fit, is_tcb_container_64bit,
-     set_output_ownership)
+     set_output_ownership, FUSE_CMD_TXT_NAME)
 from tcbuilder.backend.initramfs import UnpackedInitramfs
 from tcbuilder.backend.ubootenv import get_env_filename, find_board
 from tcbuilder.backend.platform import SECBOOT_TECH_PER_MACHINE
@@ -63,8 +63,6 @@ HAB_SIGNING_SUPPORTED_MACHINES = {
 SECURE_BOOT_FILES_DIR = "/builder/tcbuilder/secure_boot_files"
 COPY_SIG_NODE_SCRIPT = "copy_signature_node_to_fdts.sh"
 UPDATE_FIT_CONFIGS_KEYNAME_SCRIPT = "update_fit_configs_keyname.sh"
-
-FUSE_CMD_TXT_NAME = "fuse-cmds.txt"
 
 # Path to the OSTree root binding inside the initramfs (ramdisk).
 OSTREE_ROOT_BINDING_KEY_PATH = "etc/ostree/initramfs-root-binding.key"

--- a/tcbuilder/backend/tcbuild.schema.yaml
+++ b/tcbuilder/backend/tcbuild.schema.yaml
@@ -629,6 +629,24 @@ properties:
                 $ref: '#/properties/output/definitions/provisioning'
               bundle:
                 $ref: '#/properties/output/definitions/bundle'
+              fusing:
+                type: object
+                description: "Automatic fusing configuration"
+                properties:
+                  auto-programming:
+                    type: boolean
+                    description: "Whether to enable auto-fusing or not"
+                  close-device:
+                    type: boolean
+                    description: "Whether to set closing fuse during auto-fusing"
+                  fuse-file:
+                    type: string
+                    description: "Name of file to create containing fusing information for Torizon Cloud"
+                    pattern: '\.ya?ml$'
+                required:
+                  - auto-programming
+                  - close-device
+                additionalProperties: false
             required: [local]
             # No extra props inside 'easy-installer'
             additionalProperties: false

--- a/tcbuilder/backend/ubootenv.py
+++ b/tcbuilder/backend/ubootenv.py
@@ -6,11 +6,13 @@ import os
 import logging
 import re
 import shutil
+import tempfile
 
 from tcbuilder.backend.common import \
-    (set_output_ownership, get_tezi_image_version)
+    (set_output_ownership, get_tezi_image_version, FUSE_CMD_TXT_NAME)
 from tcbuilder.backend.platform import \
-    (validate_fuse_file, FUSE_HARDWAREIDS, restore_hex)
+    (validate_fuse_file, FUSE_HARDWAREIDS, restore_hex,
+     SECBOOT_TECH_PER_MACHINE, fuse_count_for_tech)
 from tcbuilder.errors import \
     (FileContentMissing, TorizonCoreBuilderError, InvalidStateError,
      PathNotExistError)
@@ -40,22 +42,7 @@ def env_fuses(input_dir, output_dir, fuse_file, force=False):
                     "OS before 7.2.0. Proceeding anyways, but this will most likely not "
                     "do anything.")
 
-    initial_env_filename = get_env_filename(input_dir)
-    initial_env = os.path.join(input_dir, initial_env_filename)
-
-    with open(initial_env, "r", encoding="utf-8") as file:
-        env = file.read()
-
-    # Check to see if initial u-boot env already contains fuse variables
-    if any(fuse_var in env for fuse_var in FUSE_VARIABLES):
-        raise InvalidStateError(
-            "Input image already contains fuse related u-boot variables")
-
-    board = find_board(env)
-    hwid = board + "-fuses"
-    if hwid not in FUSE_HARDWAREIDS:
-        raise InvalidStateError(
-            f"Hardware type \"{board}\" is not supported by this command.")
+    hwid, _ = _detect_fuse_hwid(input_dir)
 
     # Validate and check fuse file before proceeding
     fuse_file_data = validate_fuse_file(fuse_file, [hwid])
@@ -63,10 +50,11 @@ def env_fuses(input_dir, output_dir, fuse_file, force=False):
     var_list = get_fuse_vars(fuse_file_data)
 
     inplace = False
+    initial_env_filename = get_env_filename(input_dir)
     if os.path.normpath(output_dir) == os.path.normpath(input_dir):
         log.debug("Updating Torizon OS image in place.")
         output_dir = input_dir
-        output_env = initial_env
+        output_env = os.path.join(input_dir, initial_env_filename)
         inplace = True
     else:
         if os.path.exists(output_dir) and force:
@@ -80,6 +68,9 @@ def env_fuses(input_dir, output_dir, fuse_file, force=False):
         write_uboot_vars(output_env, var_list)
         set_output_ownership(output_dir)
         log.info("Fuse U-Boot variables successfully added to image.")
+        log.info("WARNING: Any device flashed with this image will perform "
+                 "automatic fusing for secure-boot. This is an irreversible "
+                 "operation. Take care to check before flashing this image.")
     except:
         if not inplace:
             log.debug("Removing output directory due to error.")
@@ -173,3 +164,81 @@ def write_uboot_vars(env_file, var_list):
 
     with open(env_file, "a", encoding="utf-8") as file:
         file.writelines(var + '\n' for var in var_list)
+
+
+def _detect_fuse_hwid(image_dir):
+    """Determine the hardware-id based on the input image
+
+    :param image_dir: Path to directory containing input image
+    :returns: A tuple containing the detected hardware-id and board
+    """
+
+    initial_env_filename = get_env_filename(image_dir)
+    initial_env = os.path.join(image_dir, initial_env_filename)
+
+    with open(initial_env, "r", encoding="utf-8") as file:
+        env = file.read()
+
+    # Check to see if initial u-boot env already contains fuse variables
+    if any(fuse_var in env for fuse_var in FUSE_VARIABLES):
+        raise InvalidStateError(
+            "Input image already contains fuse related u-boot variables")
+
+    board = find_board(env)
+    hwid = board + "-fuses"
+    if hwid not in FUSE_HARDWAREIDS:
+        raise InvalidStateError(
+            f"Hardware type \"{board}\" is not supported by this command.")
+
+    return hwid, board
+
+
+# pylint: disable-next=too-many-locals
+def generate_fuse_file(close, image_dir):
+    """Generate valid fuse.yaml file based on re-signing information
+
+    :params close: Boolean on whether closing should be set in the yaml
+    :params image_dir: Path to image directory containing the signed image
+    :returns: Path to generated yaml file
+    """
+
+    fuse_instructions = os.path.join(image_dir, FUSE_CMD_TXT_NAME)
+    if not os.path.isfile(fuse_instructions):
+        raise PathNotExistError("Unable to find fusing instructions file: "
+                                f"{FUSE_CMD_TXT_NAME}. Is the image signed?")
+
+    # Figure out what machine this is for
+    hwid, board = _detect_fuse_hwid(image_dir)
+
+    _tech = SECBOOT_TECH_PER_MACHINE.get(board)
+    fuse_num = fuse_count_for_tech(_tech)
+
+    # Parse fusing values from fusing instruction file created by re-signing
+    hex_regex = re.compile(r"\b(?:0[xX])[0-9a-fA-F]+\b")
+
+    fuse_values = []
+    with open(fuse_instructions, 'r', encoding="utf-8") as file:
+        for line in file:
+            fuse_value = hex_regex.findall(line)
+            if fuse_value:
+                fuse_values.append(fuse_value[0])
+
+            if len(fuse_values) == fuse_num:
+                break
+
+    # Create temporary fuse yaml file to be used later
+    with tempfile.NamedTemporaryFile(mode='w+', delete=False) as tmp_fuse_file:
+        tmp_fuse_file.write("fuses:\n")
+        _index = 1
+        for value in fuse_values:
+            tmp_fuse_file.write(f"  fuse-val{_index}: {value}\n")
+            _index += 1
+
+        tmp_fuse_file.write(f"  fuse-close: {close}\n")
+
+    tmp_fuse_path = tmp_fuse_file.name
+
+    # Quick sanity check on generated file
+    validate_fuse_file(tmp_fuse_path, [hwid])
+
+    return tmp_fuse_path

--- a/tcbuilder/backend/ubootenv.py
+++ b/tcbuilder/backend/ubootenv.py
@@ -135,13 +135,16 @@ def get_fuse_vars(fuse_data):
     restore_hex(fuse_data)
 
     val_list = ""
-    for key in sorted(fuse_data['fuses'].keys()):
-        if "fuse-val" in key:
-            num = fuse_data["fuses"].get(key)
-            if not val_list:
-                val_list = num
-            else:
-                val_list = val_list + " " + num
+    # Subtract one to account for 'fuse-close'
+    fuse_num = len(fuse_data['fuses']) - 1
+    # Parse fuse values in order
+    for index in range(fuse_num):
+        # Add 1 cause range starts at 0
+        num = fuse_data["fuses"].get(f"fuse-val{index + 1}")
+        if not val_list:
+            val_list = num
+        else:
+            val_list = val_list + " " + num
 
     fuse_close = fuse_data["fuses"].get("fuse-close")
     if fuse_close:

--- a/tcbuilder/cli/build.py
+++ b/tcbuilder/cli/build.py
@@ -26,6 +26,7 @@ from tcbuilder.backend import images as images_be
 from tcbuilder.backend import kernel as kernel_be
 from tcbuilder.backend import ostree as ostree_be
 from tcbuilder.backend import secboot as secboot_be
+from tcbuilder.backend import ubootenv as ubootenv_be
 from tcbuilder.cli import deploy as deploy_cli
 from tcbuilder.cli import dt as dt_cli
 from tcbuilder.cli import dto as dto_cli
@@ -554,7 +555,8 @@ def _union_parse_ostree_key(ostree_key_dir, ostree_key_props, *,
     return ostree_key_obj
 
 
-def handle_output_section(props, changes_dirs=None, default_base_raw_image=None):
+def handle_output_section(props, changes_dirs=None, default_base_raw_image=None,
+                          sign_type=None):
     """Handle the output section of the configuration file
 
     :param props: Dictionary holding the data of the section.
@@ -562,6 +564,7 @@ def handle_output_section(props, changes_dirs=None, default_base_raw_image=None)
     :param default_base_raw_image: Default base raw image. Should always be the
                                    input raw image. If dealing with tezi images,
                                    this value is equal to 'None'.
+    :param sign_type: Secure-boot signing technology being used.
     """
 
     if props:
@@ -616,7 +619,7 @@ def handle_output_section(props, changes_dirs=None, default_base_raw_image=None)
 
     if common.unpacked_image_type() == "tezi":
         tezi_props = props.get("easy-installer", {})
-        handle_easy_installer_output(tezi_props, union_params)
+        handle_easy_installer_output(tezi_props, union_params, sign_type)
     else:
         raw_props = props.get("raw-image", {})
         handle_raw_image_output(raw_props, union_params, default_base_raw_image)
@@ -667,11 +670,12 @@ def handle_raw_image_output(props, union_params, default_base_raw_image):
                              base_sector_size)
 
 
-def handle_easy_installer_output(props, union_params):
+def handle_easy_installer_output(props, union_params, sign_type=None):
     """Handle the output/easy-installer section of the configuration file
 
     :param props: Dictionary holding the data of the section.
     :param union_params: Parameters related to union(). This is a required arg.
+    :param sign_type: Secure-boot technology being used.
     """
 
     # Note that the following test should never fail (due to schema validation).
@@ -696,6 +700,9 @@ def handle_easy_installer_output(props, union_params):
 
     if "provisioning" in props:
         handle_provisioning(output_dir, props.get("provisioning"))
+
+    if "fusing" in props:
+        handle_fusing(output_dir, props.get("fusing"), sign_type)
 
 
 def handle_bundle_common(bundle_props, compress_tar=True):
@@ -878,6 +885,51 @@ def handle_provisioning(output_dir, prov_props, rootfs_label=None, sector_size=N
     images_be.provision(**prov_params)
 
 
+def handle_fusing(output_dir, fuse_props, sign_type=None):
+    """Handle the fusing step of the output generation."""
+
+    # Check to make sure re-signing of bootloader was done earlier
+    if sign_type is None:
+        raise InvalidStateError("To do 'fusing', 'sign-bootloader-hab' must be defined "
+                                "at the same time.")
+
+    _do_fuse = fuse_props.get("auto-programming", False)
+    _do_file = fuse_props.get("fuse-file")
+
+    if not _do_fuse and not _do_file:
+        log.info(l2_pref("Neither 'auto-programming' or 'fuse-file' specified "
+                         "skipping 'fusing' section"))
+        return
+
+    fuse_file = None
+    try:
+        fuse_file = ubootenv_be.generate_fuse_file(fuse_props.get("close-device"), output_dir)
+
+        if _do_fuse:
+            log.info(l2_pref("Adding automatic secure fuse programming to image."))
+            ubootenv_params = {
+                "input_dir": output_dir,
+                "output_dir": output_dir,
+                "fuse_file": fuse_file,
+                "force": True,
+            }
+            ubootenv_be.env_fuses(**ubootenv_params)
+
+        if _do_file:
+            log.info(l2_pref(f"Creating fuse-file '{fuse_props['fuse-file']}'."))
+            output_root = os.path.realpath(output_dir)
+            fuse_output = os.path.realpath(os.path.join(output_root, _do_file))
+            if (fuse_output == output_root or
+                    os.path.commonpath((output_root, fuse_output)) != output_root):
+                raise InvalidDataError("'fuse-file' must be inside the output directory.")
+            shutil.copy(fuse_file, fuse_output)
+            os.chmod(fuse_output, 0o644)
+            common.set_output_ownership(fuse_output)
+    finally:
+        if fuse_file and os.path.exists(fuse_file):
+            os.remove(fuse_file)
+
+
 def _build_setup(config, force):
     """Do some sanity checks and prepare for handling the build operations."""
 
@@ -955,6 +1007,17 @@ def build(config_fname, *, substs=None, enable_subst=True, force=False):
     except KeyError as _exc:
         pass
 
+    # Track whether bootloader re-signing is being done for auto-fusing
+    _sign_type = None
+    try:
+        if "sign-bootloader-hab" in config["customization"]["secboot"]:
+            _sign_type = "hab"
+        # TODO: Once ahab devices are supported with re-signing
+        #elif "sign-bootloader-ahab" in config["customization"]["secboot"]:
+        #    _sign_type = "ahab"
+    except KeyError as _exc:
+        pass
+
     # ---
     # Handle each section.
     # ---
@@ -970,7 +1033,8 @@ def build(config_fname, *, substs=None, enable_subst=True, force=False):
         handle_output_section(
             config["output"],
             changes_dirs=fs_changes,
-            default_base_raw_image=base_raw_image)
+            default_base_raw_image=base_raw_image,
+            sign_type=_sign_type)
 
     except Exception as exc:
         # Avoid leaving a damaged output around:

--- a/tcbuilder/cli/tcbuild.template.yaml
+++ b/tcbuilder/cli/tcbuild.template.yaml
@@ -263,3 +263,17 @@ output:
       # >> Replace example UUID with your actual fleet UUID.
       # fleets:
         # - 0dfab76b-5b71-4435-ab6f-c6cdc62690c6
+    # >> Fusing configuration:
+    # >> Only valid for easy-installer based images
+    # fusing:
+      # >> Enable/disable automatic fusing (REQUIRED)
+      # >> WARNING: Setting the below to true will cause the resulting image to perform
+      # >> automatic fusing. This fusing is an irreversible operation.
+      # auto-programming: true
+      # >> Automatically close device during fusing (REQUIRED)
+      # >> WARNING: Setting the below to true along with auto-programming will cause the
+      # >> resulting image to close the device for secure-boot. This is an irreversible operation.
+      # close-device: false
+      # >> Output a file containing the fusing information that can be used
+      # >> with Torizon Cloud (OPTIONAL)
+      # fuse-file: fuse.yaml

--- a/tests/integration/samples/config/tcbuild-hab-re-signing-components.yaml
+++ b/tests/integration/samples/config/tcbuild-hab-re-signing-components.yaml
@@ -39,3 +39,7 @@ output:
     local: "${OUTPUT_DIR:?Please specify output directory}"
     name: "image with re-signed kernel FIT and bootloader"
     description: "HAB image with both the kernel FIT and the bootloader re-signed"
+    fusing:
+      auto-programming: true
+      close-device: false
+      fuse-file: "${FUSE_FILE:?Please specify fuse filename}"

--- a/tests/integration/samples/config/tcbuild-no-re-sign-fuse.yaml
+++ b/tests/integration/samples/config/tcbuild-no-re-sign-fuse.yaml
@@ -1,0 +1,15 @@
+
+input:
+  easy-installer:
+    local: "${INPUT_IMAGE:?Please specify input image}"
+
+output:
+  ostree:
+    branch: failed-fuse
+  easy-installer:
+    local: "${OUTPUT_DIR:?Please specify output directory}"
+    name: "image with re-signed kernel FIT and bootloader"
+    description: "HAB image with both the kernel FIT and the bootloader re-signed"
+    fusing:
+      auto-programming: true
+      close-device: false

--- a/tests/integration/testcases/build.bats
+++ b/tests/integration/testcases/build.bats
@@ -142,6 +142,9 @@ teardown_file() {
     local CST_SRK_FUSE_NAME="SRK_1_2_3_4_fuse.bin"
     local CST_SRK_NO_CA_FLAG="1"
 
+    # fusing related variables
+    local FUSE_FILE="fuse.yaml"
+
     # Prepare tcbuild file:
     cp "${SAMPLES_DIR}/config/tcbuild-hab-re-signing-components.yaml" \
        "tcbuild-hab-re-signing-components.yaml"
@@ -188,6 +191,7 @@ teardown_file() {
         --set CST_SRK_TABLE_NAME="$CST_SRK_TABLE_NAME" \
         --set CST_SRK_FUSE_NAME="$CST_SRK_FUSE_NAME" \
         --set INPUT_IMAGE="$DEFAULT_SIGNED_TEZI_IMAGE" \
+        --set FUSE_FILE="$FUSE_FILE" \
         --set OUTPUT_DIR="$OUTDIR" --force
 
     assert_success
@@ -272,6 +276,21 @@ teardown_file() {
 
     run test "${FOUND_KEY_NAME}" == "${KERNEL_KEY_NAME}"
     assert_success
+
+    # Check fusing output
+    # Check fusing u-boot variables
+    run grep -r "fuse_status" "$OUTDIR"
+    assert_success
+    assert_output --partial 'fuse_status=pending'
+
+    run grep -r "fuse_prog_list" "$OUTDIR"
+    assert_success
+    assert_output --partial 'fuse_prog_list=0x3dca7649 0xb65e96b 0x2d813c2f 0x63d99878 0x29562ca4 0xc1f8b14a 0xfa337048 0xc8e7d657'
+
+    # Check fusing file output
+    run grep "fuse-close" "$OUTDIR/$FUSE_FILE"
+    assert_success
+    assert_output --partial 'fuse-close: False'
 
     # delete copied CST binaries as they're no longer needed
     rm -rf "${CST_DIR}/linux32"
@@ -705,4 +724,102 @@ teardown_file() {
     run [ -e "${OUTDIR}/docker-storage.tar.xz" -a -e "${OUTDIR}/docker-compose.yml" ]
     assert_success
     rm -fr "$OUTDIR"
+}
+
+@test "build: fusing without re-signing failure case" {
+    cp "${SAMPLES_DIR}/config/tcbuild-no-re-sign-fuse.yaml" \
+       "tcbuild-no-re-sign-fuse.yaml"
+    local TCBUILD_YAML="tcbuild-no-re-sign-fuse.yaml"
+
+    local OUTDIR='failed_image'
+
+    run torizoncore-builder build \
+	--file "${TCBUILD_YAML}" \
+	--set INPUT_IMAGE="$DEFAULT_TEZI_IMAGE" \
+        --set OUTPUT_DIR="$OUTDIR" --force
+
+    assert_failure
+    assert_output --partial "Error: To do 'fusing', 'sign-bootloader-hab' must be defined at the same time."
+}
+
+@test "build: fusing file outside of output directory failure case" {
+    requires-supported-kernel-signing-machine
+    requires-supported-hab-signing-machine
+    requires-signed-image
+
+    # sign-kernel related variables
+    local SIGNING_KEYS_DIR="${SAMPLES_DIR}/signing_keys"
+    local KERNEL_KEY_DIR="${SIGNING_KEYS_DIR}/kernel_fitimage"
+    local KERNEL_KEY_NAME="test"
+    local KERNEL_KEY_ALGO="sha256,rsa2048"
+
+    # sign-bootloader-hab related variables
+    local CST_DIRS="cst_dirs"
+    local CST_TARBALL="${SIGNING_KEYS_DIR}/${CST_DIRS}.tar.gz"
+    local CST_BINARIES_DIR="${CST_DIRS}/cst-3.4.1"
+    local CST_DIR="${CST_DIRS}/hab/cst-3.4.1_tcb_test_rsa_1024_no_ca"
+
+    local CST_CRYPTO="rsa"
+    local CST_KEY_SIZE="1024"
+    local CST_KEY_EXP="65537"
+    local CST_DIGEST_ALGO="sha256"
+    local CST_SRK_INDEX="3"
+    local CST_SRK_TABLE_NAME="SRK_1_2_3_4_table.bin"
+    local CST_SRK_FUSE_NAME="SRK_1_2_3_4_fuse.bin"
+    local CST_SRK_NO_CA_FLAG="1"
+
+    # fusing related variables
+    local FUSE_FILE="../fuse.yaml"
+
+    # Prepare tcbuild file:
+    cp "${SAMPLES_DIR}/config/tcbuild-hab-re-signing-components.yaml" \
+       "fuse-file-escape-failure.yaml"
+    local TCBUILD_YAML="fuse-file-escape-failure.yaml"
+
+    if [ "$CST_SRK_NO_CA_FLAG" == "1" ]; then
+        # Enable `srk-no-ca-flag`
+        cat "${TCBUILD_YAML}" | \
+                sed -Ee 's/## srk-no-ca-flag/srk-no-ca-flag/' > \
+                "${TCBUILD_YAML}-no-ca.yaml"
+        TCBUILD_YAML="${TCBUILD_YAML}-no-ca.yaml"
+
+        CST_SRK_NO_CA_FLAG="YES"
+    else
+        CST_SRK_NO_CA_FLAG="NO"
+    fi
+
+    if [ "${DEFAULT_TEZI_IMAGE_HAS_CFS_SUPPORT}" = "1" ]; then
+        set-ostree-key-in-tcbuild \
+            "${TCBUILD_YAML}" \
+            "name=cfs-dev;algo=ed25519" \
+            "${SAMPLES_DIR}/signing_keys/ostree-good1/"
+    fi
+
+    unpack-image "${CST_TARBALL}"
+
+    # copy CST binaries to CST_DIR before running tests
+    cp -r "${CST_BINARIES_DIR}/linux32" "${CST_DIR}"
+    cp -r "${CST_BINARIES_DIR}/linux64" "${CST_DIR}"
+
+    local OUTDIR='failed_image'
+
+    run torizoncore-builder build \
+        --file "${TCBUILD_YAML}" \
+        --set KERNEL_KEY_DIR="$KERNEL_KEY_DIR" \
+        --set KERNEL_KEY_NAME="$KERNEL_KEY_NAME" \
+        --set KERNEL_KEY_ALGO="$KERNEL_KEY_ALGO" \
+        --set CST_DIR="$CST_DIR" \
+        --set CST_CRYPTO="$CST_CRYPTO" \
+        --set CST_KEY_SIZE="$CST_KEY_SIZE" \
+        --set CST_KEY_EXP="$CST_KEY_EXP" \
+        --set CST_DIGEST_ALGO="$CST_DIGEST_ALGO" \
+        --set CST_SRK_INDEX="$CST_SRK_INDEX" \
+        --set CST_SRK_TABLE_NAME="$CST_SRK_TABLE_NAME" \
+        --set CST_SRK_FUSE_NAME="$CST_SRK_FUSE_NAME" \
+        --set INPUT_IMAGE="$DEFAULT_SIGNED_TEZI_IMAGE" \
+        --set FUSE_FILE="$FUSE_FILE" \
+        --set OUTPUT_DIR="$OUTDIR" --force
+
+    assert_failure
+    assert_output --partial "Error: 'fuse-file' must be inside the output directory."
 }

--- a/tests/integration/testcases/ubootenv.bats
+++ b/tests/integration/testcases/ubootenv.bats
@@ -18,9 +18,11 @@ bats_load_library 'bats/bats-file/load.bash'
     case "$INPUT_IMAGE_DIR" in
         *apalis-imx8*|*colibri-imx8x*)
             FUSE_FILE="$FUSE_DIR/fuse-non-canon-16.yaml"
+	    EXPECTED_FUSE_LIST="0x1a 0x2b 0x3c 0x4d 0x5e 0x6f 0x7a 0x8b 0x9 0x10 0x11 0x12 0x13 0x14 0x15 0x16"
             ;;
         *imx6*|*imx7*|*imx6ull*|*imx8mm*|*imx8mp*)
             FUSE_FILE="$FUSE_DIR/fuse-non-canon-8.yaml"
+	    EXPECTED_FUSE_LIST="0x1a 0x2b 0x3c 0x4d 0x5e 0x6f 0x7a 0x8b"
             ;;
         *)
             # Just use whatever fuse file here 
@@ -62,9 +64,9 @@ bats_load_library 'bats/bats-file/load.bash'
         assert_success
         assert_output --partial 'variables successfully added to image'
 
-        run grep -r "fuse_status" "$OUTPUT_IMAGE_DIR"
+        run grep -r "fuse_prog_list" "$OUTPUT_IMAGE_DIR"
         assert_success
-        assert_output --partial 'fuse_status=pending'
+        assert_output --partial "fuse_prog_list=$EXPECTED_FUSE_LIST"
 
         # image already containing fuse data
         run torizoncore-builder ubootenv fuses "$OUTPUT_IMAGE_DIR" "temp" \


### PR DESCRIPTION
This adds functionality similar to the 'ubootenv fuses' command. However instead of ingesting a yaml file with the fuse information, this requires re-signing to be done in the same 'build' invocation. The output from the re-signing is then used to determine the fuse information.

There is also an option to output the equivalent yaml file.

This also adds related checks in the testing.

This also fixes a bug where `ubootenv fuses` was resulting in the wrong fuse order for ahab devices.

Related-to: TCB-897
Related-to: TCB-903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added Easy Installer support for automatic device fusing.
  - Fusing can program fuses, close the device, and/or generate a fuse configuration file.
  - Added validation for required settings, supported hardware, secure-boot prerequisites, fuse values, and output file locations.
  - Generated images include fuse programming information and device-close status when applicable.

- **Tests**
  - Added integration coverage for fuse generation, programming values, device-close settings, missing prerequisites, and invalid fuse file locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->