### PR TITLE
Fix circular import and grow_last_partition() cleanup

### DIFF
--- a/tcbuilder/backend/combine.py
+++ b/tcbuilder/backend/combine.py
@@ -16,6 +16,7 @@ from tcbuilder.backend.common import \
     (set_output_ownership, check_licence_acceptance, run_with_loading_animation, open_disk_image,
      get_tar_compress_program_options, DOCKER_BUNDLE_TARNAME, TAR_EXT_TO_PROGRAM,
      OSTREE_SOTA_DIR_PATH, DEFAULT_RAW_SECTOR_SIZE)
+from tcbuilder.backend.deploy import grow_last_partition
 from tcbuilder.errors import InvalidStateError, InvalidDataError, TorizonCoreBuilderError
 
 log = logging.getLogger("torizon." + __name__)
@@ -382,10 +383,6 @@ def combine_raw_image(image_path, bundle_dir, output_path, rootfs_label, force,
                 os.remove(tmp_image)
     else:
         # virt-resize can't open 4Kn disks; grow directly via libguestfs instead.
-        # Local import: a module-level one re-enters kernel.py's import cycle
-        # before cli/build.py's own import order finishes resolving it.
-        # pylint: disable-next=import-outside-toplevel
-        from tcbuilder.backend.deploy import grow_last_partition
         grow_last_partition(output_path, extra_disk_size_kb, sector_size, root_partition)
 
     with open_disk_image(output_path, delete_on_error=delete_on_error,

--- a/tcbuilder/backend/combine.py
+++ b/tcbuilder/backend/combine.py
@@ -383,7 +383,8 @@ def combine_raw_image(image_path, bundle_dir, output_path, rootfs_label, force,
                 os.remove(tmp_image)
     else:
         # virt-resize can't open 4Kn disks; grow directly via libguestfs instead.
-        grow_last_partition(output_path, extra_disk_size_kb, sector_size, root_partition)
+        grow_last_partition(output_path, extra_disk_size_kb, sector_size, root_partition,
+                            delete_on_error=delete_on_error)
 
     with open_disk_image(output_path, delete_on_error=delete_on_error,
                          sector_size=sector_size) as gfs:

--- a/tcbuilder/backend/common.py
+++ b/tcbuilder/backend/common.py
@@ -172,6 +172,48 @@ def get_int_ostree_dir():
     return os.path.join(storage_dir, "ostree-archive")
 
 
+DT_CHANGES_SUBDIR = "dt"
+KERNEL_CHANGES_SUBDIR = "kernel"
+
+
+def get_changes_dir(subdir):
+    """Get the path to a named customization changes directory."""
+    storage_dir = get_storage_dir()
+    return os.path.join(storage_dir, subdir)
+
+
+def get_image_bootloader(sysroot_dir):
+    """
+    Get bootloader being used in a given unpacked sysroot
+
+    :param sysroot_dir: sysroot path
+
+    Based on:
+    - https://github.com/ostreedev/ostree/blob/v2024.4/src/libostree/ostree-bootloader-uboot.c#L47
+    - https://github.com/ostreedev/ostree/blob/v2024.4/src/libostree/ostree-bootloader-grub2.c#L73
+    """
+    tentative_uenv_path = os.path.join(sysroot_dir, "boot/loader/uEnv.txt")
+
+    if os.path.exists(tentative_uenv_path):
+        return "U-Boot"
+
+    tentative_grubcfg_path1 = os.path.join(sysroot_dir, "boot/grub/grub.cfg")
+    tentative_grubcfg_path2 = os.path.join(sysroot_dir, "boot/grub2/grub.cfg")
+
+    if (os.path.exists(tentative_grubcfg_path1) or
+            os.path.exists(tentative_grubcfg_path2)):
+        return "GRUB2"
+
+    tentative_efi_dir_path = os.path.join(sysroot_dir, "boot/efi/EFI")
+    if (os.path.exists(tentative_efi_dir_path) and
+            os.path.isdir(tentative_efi_dir_path)):
+        for _, _, files in os.walk(tentative_efi_dir_path):
+            if "grub.cfg" in files:
+                return "GRUB2"
+
+    return "unknown"
+
+
 # Based on this solution: https://stackoverflow.com/a/50690347
 # Usage of Event object to stop thread was based on:
 # https://www.pythontutorial.net/python-concurrency/python-stop-thread/

--- a/tcbuilder/backend/deploy.py
+++ b/tcbuilder/backend/deploy.py
@@ -6,7 +6,9 @@ import json
 import logging
 import os
 import shutil
+import struct
 import subprocess
+import tempfile
 import threading
 import shlex
 
@@ -293,46 +295,102 @@ def deploy_tezi_image(tezi_dir, src_sysroot_dir, src_ostree_archive_dir,
         copy_signed_artifacts(commit_dir, output_dir)
 
 
-def grow_last_partition(raw_img, added_size_kb, sector_size, rootfs_partition):
+# pylint: disable-next=too-many-locals
+def grow_last_partition(raw_img, added_size_kb, sector_size, rootfs_partition, *,
+                        delete_on_error=False):
     """Enlarge a raw image and extend its last partition to fill the new space.
 
-    For 4Kn images, where virt-resize cannot operate. Preserves the partition's
-    GPT identity (name, type, GUID, attributes) so it still boots; the rootfs
-    must be the last partition, which is checked. The partition's filesystem
-    is grown to match.
+    For 4Kn images, where virt-resize cannot operate. delete_on_error=True
+    mutates raw_img directly and deletes it on failure; otherwise raw_img is
+    the caller's only copy, so every mutation runs against a temporary
+    sibling copy instead, swapped into place only on full success.
     """
-    # Round up to a whole sector; a non-sector-multiple size can be rejected at 4Kn.
-    new_size = os.path.getsize(raw_img) + int(added_size_kb) * 1024
-    new_size = (new_size + sector_size - 1) // sector_size * sector_size
-    subprocess.check_output(["truncate", "-s", str(new_size), raw_img])
+    work_img = raw_img
+    tmp_img = None
 
-    with open_disk_image(raw_img, sector_size=sector_size) as gfs:
-        dev = "/dev/sda"
-        gfs.part_expand_gpt(dev)  # relocate the GPT backup header to the new end
-        partnum = len(gfs.list_partitions())
-        if gfs.part_to_partnum(rootfs_partition) != partnum:
-            raise TorizonCoreBuilderError(
-                "the rootfs must be the last partition to grow a 4Kn raw image.")
-        start_sector = gfs.part_list(dev)[-1]["part_start"] // sector_size
+    try:
+        if not delete_on_error:
+            tmp_fd, tmp_img = tempfile.mkstemp(
+                prefix=f"{os.path.basename(raw_img)}.",
+                suffix=".grow.tmp",
+                dir=os.path.dirname(os.path.abspath(raw_img)))
+            os.close(tmp_fd)
+            shutil.copy2(raw_img, tmp_img)
+            work_img = tmp_img
 
-        name = gfs.part_get_name(dev, partnum)
-        gpt_type = gfs.part_get_gpt_type(dev, partnum)
-        gpt_guid = gfs.part_get_gpt_guid(dev, partnum)
-        gpt_attributes = gfs.part_get_gpt_attributes(dev, partnum)
+        orig_size = os.path.getsize(work_img)
+        # Round up to a whole sector; a non-sector-multiple size can be rejected at 4Kn.
+        new_size = orig_size + int(added_size_kb) * 1024
+        new_size = (new_size + sector_size - 1) // sector_size * sector_size
+        subprocess.check_output(["truncate", "-s", str(new_size), work_img])
 
-        # Stop short of the disk end to clear the GPT backup (33 LBAs of 512 B).
-        gpt_tail = (33 * 512 + sector_size - 1) // sector_size
-        end_sector = os.path.getsize(raw_img) // sector_size - 1 - gpt_tail
-        gfs.part_del(dev, partnum)
-        gfs.part_add(dev, "primary", start_sector, end_sector)
+        with open_disk_image(work_img, delete_on_error=True,
+                             sector_size=sector_size) as gfs:
+            dev = "/dev/sda"
+            last_partition = max(
+                gfs.part_list(dev), key=lambda partition: partition["part_start"])
+            partnum = last_partition["part_num"]
+            if gfs.part_to_partnum(rootfs_partition) != partnum:
+                raise TorizonCoreBuilderError(
+                    "the rootfs must be the last partition to grow a 4Kn raw image.")
+            start_sector = last_partition["part_start"] // sector_size
 
-        gfs.part_set_name(dev, partnum, name)
-        gfs.part_set_gpt_type(dev, partnum, gpt_type)
-        gfs.part_set_gpt_guid(dev, partnum, gpt_guid)
-        gfs.part_set_gpt_attributes(dev, partnum, gpt_attributes)
+            gfs.part_expand_gpt(dev)  # relocate the GPT backup header to the new end
 
-        # Growing only the partition would leave the fs at its old size.
-        gfs.resize2fs(rootfs_partition)
+            # LastUsableLBA (offset 48, 8-byte LE) already reflects the real
+            # backup reservation post-expand; read it instead of re-deriving it.
+            header = gfs.pread_device(dev, 56, sector_size)
+            if len(header) != 56 or header[:8] != b"EFI PART":
+                raise TorizonCoreBuilderError(
+                    f"could not read the GPT header at LBA 1 for a "
+                    f"{sector_size}-byte sector size after expanding the "
+                    "partition table.")
+            end_sector = struct.unpack("<Q", header[48:56])[0]
+            if end_sector <= start_sector:
+                raise TorizonCoreBuilderError(
+                    "not enough room to grow the last partition of a 4Kn raw image.")
+
+            name = gfs.part_get_name(dev, partnum)
+            gpt_type = gfs.part_get_gpt_type(dev, partnum)
+            gpt_guid = gfs.part_get_gpt_guid(dev, partnum)
+            gpt_attributes = gfs.part_get_gpt_attributes(dev, partnum)
+
+            gfs.part_del(dev, partnum)
+            gfs.part_add(dev, "primary", start_sector, end_sector)
+
+            # part_add() may reuse a different free slot than the one just deleted
+            # if a lower gap exists; re-derive the number from the start sector.
+            try:
+                new_partnum = next(p["part_num"] for p in gfs.part_list(dev)
+                                   if p["part_start"] // sector_size == start_sector)
+            except StopIteration:
+                raise TorizonCoreBuilderError(
+                    "could not locate the regrown partition after part_add().") from None
+            new_rootfs_partition = f"{dev}{new_partnum}"
+            gfs.part_set_name(dev, new_partnum, name)
+            gfs.part_set_gpt_type(dev, new_partnum, gpt_type)
+            gfs.part_set_gpt_guid(dev, new_partnum, gpt_guid)
+            gfs.part_set_gpt_attributes(dev, new_partnum, gpt_attributes)
+
+            # Growing only the partition would leave the fs at its old size; the
+            # original rootfs_partition may no longer exist if renumbered above.
+            gfs.resize2fs(new_rootfs_partition)
+
+        if tmp_img:
+            os.replace(tmp_img, raw_img)
+    except BaseException:  # always re-raises; must also clean up on KeyboardInterrupt/SystemExit
+        # Clean up the disposable file only: tmp_img if it exists (even a
+        # failed copy or swap can leave one), else raw_img when
+        # delete_on_error.
+        cleanup_target = tmp_img if tmp_img else (raw_img if delete_on_error else None)
+        try:
+            # open_disk_image may have removed it already.
+            if cleanup_target and os.path.isfile(cleanup_target):
+                os.remove(cleanup_target)
+        except OSError as cleanup_exc:
+            log.error("Failed to clean up '%s' after a grow failure: %s",
+                     cleanup_target, cleanup_exc)
+        raise
 
 
 # pylint: disable-next=too-many-positional-arguments
@@ -360,7 +418,7 @@ def create_output_raw_image(base_raw_img, output_raw_img, base_rootfs_partition,
             log.info(f"Adding {added_size_kb/1024:.2f} MiB to output image.")
             log.info(f"Size of output image will be: {out_size_kb/1024/1024:.2f} GiB")
             grow_last_partition(output_raw_img, added_size_kb, sector_size,
-                                base_rootfs_partition)
+                                base_rootfs_partition, delete_on_error=True)
         else:
             log.info("Output image will have the same size as the base one.")
         return

--- a/tcbuilder/backend/deploy.py
+++ b/tcbuilder/backend/deploy.py
@@ -21,7 +21,8 @@ from tcbuilder.backend import ostree
 from tcbuilder.backend.common import (get_rootfs_tarball, resolve_remote_host,
                                       run_with_loading_animation, open_disk_image,
                                       REMOTE_CMD_TIMEOUT, SECBOOT_ARTIFACTS_DIR,
-                                      DEFAULT_RAW_SECTOR_SIZE, FUSE_CMD_TXT_NAME)
+                                      DEFAULT_RAW_SECTOR_SIZE, FUSE_CMD_TXT_NAME,
+                                      get_image_bootloader)
 from tcbuilder.backend.rforward import reverse_forward_tunnel, request_port_forward
 from tcbuilder.errors import TorizonCoreBuilderError, InvalidDataError
 from tezi.utils import find_rootfs_content
@@ -50,38 +51,6 @@ def create_sysroot(deploy_sysroot_dir):
         raise TorizonCoreBuilderError("Error loading OSTree sysroot.")
 
     return sysroot
-
-
-def get_image_bootloader(sysroot_dir):
-    """
-    Get bootloader being used in a given unpacked sysroot
-
-    :param sysroot_dir: sysroot path
-
-    Based on:
-    - https://github.com/ostreedev/ostree/blob/v2024.4/src/libostree/ostree-bootloader-uboot.c#L47
-    - https://github.com/ostreedev/ostree/blob/v2024.4/src/libostree/ostree-bootloader-grub2.c#L73
-    """
-    tentative_uenv_path = os.path.join(sysroot_dir, "boot/loader/uEnv.txt")
-
-    if os.path.exists(tentative_uenv_path):
-        return "U-Boot"
-
-    tentative_grubcfg_path1 = os.path.join(sysroot_dir, "boot/grub/grub.cfg")
-    tentative_grubcfg_path2 = os.path.join(sysroot_dir, "boot/grub2/grub.cfg")
-
-    if (os.path.exists(tentative_grubcfg_path1) or
-            os.path.exists(tentative_grubcfg_path2)):
-        return "GRUB2"
-
-    tentative_efi_dir_path = os.path.join(sysroot_dir, "boot/efi/EFI")
-    if (os.path.exists(tentative_efi_dir_path) and
-            os.path.isdir(tentative_efi_dir_path)):
-        for _, _, files in os.walk(tentative_efi_dir_path):
-            if "grub.cfg" in files:
-                return "GRUB2"
-
-    return "unknown"
 
 
 def deploy_rootfs(sysroot, src_sysroot_dir, ref, refspec, kargs):

--- a/tcbuilder/backend/dt.py
+++ b/tcbuilder/backend/dt.py
@@ -10,168 +10,22 @@ import subprocess
 import sys
 import re
 
-from tcbuilder.errors import (InvalidDataError, InvalidStateError)
-from tcbuilder.backend.kernel import get_kernel_changes_dir
+from tcbuilder.errors import InvalidDataError
 from tcbuilder.backend.common import (get_storage_dir, is_file_type_dtb, unpacked_image_type,
-                                      get_src_sysroot_dir)
-from tcbuilder.backend.deploy import get_image_bootloader
+                                      get_src_sysroot_dir, get_image_bootloader,
+                                      get_changes_dir, DT_CHANGES_SUBDIR)
+from tcbuilder.backend import uenv
 
 log = logging.getLogger("torizon." + __name__)
 
 DTB_PREFIX_RE = re.compile(r'bootm[^#]*#conf-([^$]*)\$')
-
-BACKSLASH_SPC_RE = re.compile(r"\\\s*$")
 
 DT_SUPPORTED_BOOTLOADERS = ["U-Boot"]
 
 
 def get_dt_changes_dir():
     """Returns the directory that contains external device tree related changes."""
-    storage_dir = get_storage_dir()
-    return os.path.join(storage_dir, "dt")
-
-
-# TODO: Consider moving the various "uenv" functions to a separate module (other than common).
-def get_current_uenv_txt_path():
-    """Get the path to the currently applied uEnv.txt, the bootloader environment file."""
-
-    # Look for the file in two changes directories; the former is used with
-    # non-FIT whereas the latter with FIT images.
-    storage_dir = get_storage_dir()
-    dchangesdir = get_dt_changes_dir()
-    dpath = os.path.join(dchangesdir, "usr", "lib", "ostree-boot", "uEnv.txt")
-    kchangesdir = get_kernel_changes_dir()
-    kpath = os.path.join(kchangesdir, "usr", "lib", "ostree-boot", "uEnv.txt")
-
-    if os.path.exists(dpath) and os.path.exists(kpath):
-        raise InvalidStateError(
-            f"Bad storage state: uEnv.txt was found both in '{dpath}' and '{kpath}'")
-
-    for _path in (dpath, kpath):
-        if os.path.exists(_path):
-            log.debug(f"Found uEnv.txt in changes dir: '{_path}'")
-            return _path
-
-    # Check for the ostree-managed version of the file in the deployment; this
-    # finds the committed version of the file rather the modified copy produced
-    # by libostree in the boot directory when a deployment is created.
-    dpath = subprocess.check_output(
-        ["find", f"{storage_dir}/sysroot/ostree/deploy",
-         "-wholename", "*/usr/lib/ostree-boot/uEnv.txt",
-         "-print", "-quit"],
-        text=True).strip()
-    assert dpath and os.path.exists(dpath), "panic: missing uEnv.txt in base image!"
-    log.debug(f"Found uEnv.txt in deployment: '{dpath}'")
-
-    return dpath
-
-
-def set_uenv_txt_variable(var_name, var_value, *, changes_dir, append=False):
-    """Set/clear a variable in uEnv.txt storing the modified file in the changes directory.
-
-    :param var_name: Name of the variable.
-    :param var_value: Value of the variable; if None is passed, the variable
-        will be cleared (removed from the file).
-    :param changes_dir: Path to changes directory.
-    :param append: If False (default), the new variable assignment is added at
-        the beginning of the uEnv.txt file; otherwise, it's added at its end.
-    :returns: True if the variable existed in uEnv.txt; False, otherwise."""
-
-    # Load original file:
-    uenv_src_path = get_current_uenv_txt_path()
-    with open(uenv_src_path, "r", encoding="utf-8") as fhandle:
-        lines = fhandle.readlines()
-
-    # Status indicates that the variable was set before.
-    status = False
-
-    # Drop lines assigning to the desired variable (lines may be continued by
-    # a backslash at the end):
-    ign_cont = False
-    new_lines = []
-    for line in lines:
-        if ign_cont:
-            if not BACKSLASH_SPC_RE.search(line):
-                ign_cont = False
-        elif line.startswith(f"{var_name}="):
-            status = True
-            if BACKSLASH_SPC_RE.search(line):
-                ign_cont = True
-        else:
-            new_lines.append(line)
-
-    if var_value is None:
-        # Variable is being deleted.
-        pass
-    elif append:
-        # Add assignment as the last line.
-        assgn_str = f"{var_name}={var_value}\n"
-        new_lines.append(assgn_str)
-    else:
-        # Add assignment as the first line.
-        assgn_str = f"{var_name}={var_value}\n"
-        new_lines.insert(0, assgn_str)
-
-    # Save modified version of the file:
-    uenv_target_dir = os.path.join(changes_dir, "usr", "lib", "ostree-boot")
-    uenv_target_path = os.path.join(uenv_target_dir, "uEnv.txt")
-    os.makedirs(uenv_target_dir, exist_ok=True)
-    with open(uenv_target_path, "w", encoding="utf-8") as fhandle:
-        fhandle.writelines(new_lines)
-
-    return status
-
-
-def get_uenv_txt_variable(var_name, *, drop_cont=False):
-    """Get a variable from the current uEnv.txt.
-
-    By default, if the variable setting in uEnv.txt was split into multiple-lines
-    in the source file, the returned value will be a string with embedded new-line
-    characters including the backslash at end of each line indicating the line
-    continuation. This behavior can be changed by 'drop_cont'.
-
-    :param var_name: Name of the variable.
-    :param drop_cont: Drop the continuaton string at the end of the lines
-        effectively joining all lines together.
-    """
-
-    # Load original file:
-    uenv_src_path = get_current_uenv_txt_path()
-    with open(uenv_src_path, "r", encoding="utf-8") as fhandle:
-        lines = fhandle.readlines()
-
-    assgn_str = f"{var_name}="
-    var_value = None
-
-    # Find the assignment (handling the multi-line case); in case of multiple
-    # assignments get the value of the last one:
-    cont = False
-    for line in lines:
-        if cont:
-            var_value.append(line)
-            if not BACKSLASH_SPC_RE.search(line):
-                cont = False
-        elif line.startswith(assgn_str):
-            var_value = []
-            var_value.append(line[len(assgn_str):])
-            if BACKSLASH_SPC_RE.search(line):
-                cont = True
-
-    # Drop the continuation string from all intermediate lines:
-    if var_value and drop_cont:
-        for _idx, _val in enumerate(var_value[:-1]):
-            var_value[_idx] = _val[:_val.rindex("\\")]
-
-    # Drop the newline character of the last line:
-    if var_value:
-        if "\n" in var_value[-1]:
-            _val = var_value[-1]
-            var_value[-1] = _val[:_val.rindex("\n")]
-
-    if var_value is not None:
-        var_value = "".join(var_value)
-
-    return var_value
+    return get_changes_dir(DT_CHANGES_SUBDIR)
 
 
 def get_uboot_initial_env_tezi_path():
@@ -215,7 +69,7 @@ def get_current_dtb_basename():
         return None
 
     # Find the value of fdtfile in uEnv.txt
-    dtb_basename = query_variable_in_config_file("fdtfile", get_current_uenv_txt_path())
+    dtb_basename = query_variable_in_config_file("fdtfile", uenv.get_current_uenv_txt_path())
     if dtb_basename:
         return dtb_basename
 
@@ -351,7 +205,7 @@ def get_kernelfit_dtb_prefix(defval=None):
     invocation.
     """
 
-    uenv_path = get_current_uenv_txt_path()
+    uenv_path = uenv.get_current_uenv_txt_path()
     with open(uenv_path, "r", encoding="utf-8") as fhandle:
         lines = fhandle.readlines()
     res = None

--- a/tcbuilder/backend/kernel.py
+++ b/tcbuilder/backend/kernel.py
@@ -9,10 +9,11 @@ import shutil
 import subprocess
 import urllib.request
 
-from tcbuilder.backend import ostree, dt
+from tcbuilder.backend import ostree, uenv
 from tcbuilder.backend.common import \
     (download_progress, get_tar_compress_program_options, get_storage_dir,
-     set_output_ownership, OSTREE_ROOT_DEPLOY_PATH)
+     set_output_ownership, OSTREE_ROOT_DEPLOY_PATH,
+     get_changes_dir, KERNEL_CHANGES_SUBDIR)
 from tcbuilder.errors import \
     (TorizonCoreBuilderError, PathNotExistError)
 
@@ -46,8 +47,7 @@ MOD_DIR_COPY_EXCLUDE_SET = {"dtb"}
 
 def get_kernel_changes_dir():
     """Return directory containing kernel related changes."""
-    storage_dir = get_storage_dir()
-    return os.path.join(storage_dir, "kernel")
+    return get_changes_dir(KERNEL_CHANGES_SUBDIR)
 
 
 def _kernel_version_from_source(linux_src):
@@ -366,7 +366,7 @@ def copy_kernel_to_changes_dir(changes_dir, *, basename=None):
 def get_supported_bootargs_methods():
     """Determine the set of bootargs passing methods supported by the current image."""
 
-    uenv_txt_path = dt.get_current_uenv_txt_path()
+    uenv_txt_path = uenv.get_current_uenv_txt_path()
     method_re = {
         "overlay": re.compile(SET_BOOTARGS_CUSTOM_RE),
         "uenv": re.compile(SET_BOOTARGS_CUSTOM2_RE)

--- a/tcbuilder/backend/uenv.py
+++ b/tcbuilder/backend/uenv.py
@@ -1,0 +1,158 @@
+"""
+Backend for the uEnv.txt (bootloader environment file) related operations.
+"""
+
+import logging
+import os
+import re
+import subprocess
+
+from tcbuilder.errors import InvalidStateError
+from tcbuilder.backend.common import \
+    (get_storage_dir, get_changes_dir, DT_CHANGES_SUBDIR, KERNEL_CHANGES_SUBDIR)
+
+log = logging.getLogger("torizon." + __name__)
+
+BACKSLASH_SPC_RE = re.compile(r"\\\s*$")
+
+
+def get_current_uenv_txt_path():
+    """Get the path to the currently applied uEnv.txt, the bootloader environment file."""
+
+    # Look for the file in two changes directories; the former is used with
+    # non-FIT whereas the latter with FIT images.
+    storage_dir = get_storage_dir()
+    dchangesdir = get_changes_dir(DT_CHANGES_SUBDIR)
+    dpath = os.path.join(dchangesdir, "usr", "lib", "ostree-boot", "uEnv.txt")
+    kchangesdir = get_changes_dir(KERNEL_CHANGES_SUBDIR)
+    kpath = os.path.join(kchangesdir, "usr", "lib", "ostree-boot", "uEnv.txt")
+
+    if os.path.exists(dpath) and os.path.exists(kpath):
+        raise InvalidStateError(
+            f"Bad storage state: uEnv.txt was found both in '{dpath}' and '{kpath}'")
+
+    for _path in (dpath, kpath):
+        if os.path.exists(_path):
+            log.debug(f"Found uEnv.txt in changes dir: '{_path}'")
+            return _path
+
+    # Check for the ostree-managed version of the file in the deployment; this
+    # finds the committed version of the file rather the modified copy produced
+    # by libostree in the boot directory when a deployment is created.
+    dpath = subprocess.check_output(
+        ["find", f"{storage_dir}/sysroot/ostree/deploy",
+         "-wholename", "*/usr/lib/ostree-boot/uEnv.txt",
+         "-print", "-quit"],
+        text=True).strip()
+    assert dpath and os.path.exists(dpath), "panic: missing uEnv.txt in base image!"
+    log.debug(f"Found uEnv.txt in deployment: '{dpath}'")
+
+    return dpath
+
+
+def set_uenv_txt_variable(var_name, var_value, *, changes_dir, append=False):
+    """Set/clear a variable in uEnv.txt storing the modified file in the changes directory.
+
+    :param var_name: Name of the variable.
+    :param var_value: Value of the variable; if None is passed, the variable
+        will be cleared (removed from the file).
+    :param changes_dir: Path to changes directory.
+    :param append: If False (default), the new variable assignment is added at
+        the beginning of the uEnv.txt file; otherwise, it's added at its end.
+    :returns: True if the variable existed in uEnv.txt; False, otherwise."""
+
+    # Load original file:
+    uenv_src_path = get_current_uenv_txt_path()
+    with open(uenv_src_path, "r", encoding="utf-8") as fhandle:
+        lines = fhandle.readlines()
+
+    # Status indicates that the variable was set before.
+    status = False
+
+    # Drop lines assigning to the desired variable (lines may be continued by
+    # a backslash at the end):
+    ign_cont = False
+    new_lines = []
+    for line in lines:
+        if ign_cont:
+            if not BACKSLASH_SPC_RE.search(line):
+                ign_cont = False
+        elif line.startswith(f"{var_name}="):
+            status = True
+            if BACKSLASH_SPC_RE.search(line):
+                ign_cont = True
+        else:
+            new_lines.append(line)
+
+    if var_value is None:
+        # Variable is being deleted.
+        pass
+    elif append:
+        # Add assignment as the last line.
+        assgn_str = f"{var_name}={var_value}\n"
+        new_lines.append(assgn_str)
+    else:
+        # Add assignment as the first line.
+        assgn_str = f"{var_name}={var_value}\n"
+        new_lines.insert(0, assgn_str)
+
+    # Save modified version of the file:
+    uenv_target_dir = os.path.join(changes_dir, "usr", "lib", "ostree-boot")
+    uenv_target_path = os.path.join(uenv_target_dir, "uEnv.txt")
+    os.makedirs(uenv_target_dir, exist_ok=True)
+    with open(uenv_target_path, "w", encoding="utf-8") as fhandle:
+        fhandle.writelines(new_lines)
+
+    return status
+
+
+def get_uenv_txt_variable(var_name, *, drop_cont=False):
+    """Get a variable from the current uEnv.txt.
+
+    By default, if the variable setting in uEnv.txt was split into multiple-lines
+    in the source file, the returned value will be a string with embedded new-line
+    characters including the backslash at end of each line indicating the line
+    continuation. This behavior can be changed by 'drop_cont'.
+
+    :param var_name: Name of the variable.
+    :param drop_cont: Drop the continuaton string at the end of the lines
+        effectively joining all lines together.
+    """
+
+    # Load original file:
+    uenv_src_path = get_current_uenv_txt_path()
+    with open(uenv_src_path, "r", encoding="utf-8") as fhandle:
+        lines = fhandle.readlines()
+
+    assgn_str = f"{var_name}="
+    var_value = None
+
+    # Find the assignment (handling the multi-line case); in case of multiple
+    # assignments get the value of the last one:
+    cont = False
+    for line in lines:
+        if cont:
+            var_value.append(line)
+            if not BACKSLASH_SPC_RE.search(line):
+                cont = False
+        elif line.startswith(assgn_str):
+            var_value = []
+            var_value.append(line[len(assgn_str):])
+            if BACKSLASH_SPC_RE.search(line):
+                cont = True
+
+    # Drop the continuation string from all intermediate lines:
+    if var_value and drop_cont:
+        for _idx, _val in enumerate(var_value[:-1]):
+            var_value[_idx] = _val[:_val.rindex("\\")]
+
+    # Drop the newline character of the last line:
+    if var_value:
+        if "\n" in var_value[-1]:
+            _val = var_value[-1]
+            var_value[-1] = _val[:_val.rindex("\n")]
+
+    if var_value is not None:
+        var_value = "".join(var_value)
+
+    return var_value

--- a/tcbuilder/cli/dt.py
+++ b/tcbuilder/cli/dt.py
@@ -13,6 +13,7 @@ import traceback
 from tcbuilder.backend import dt as dt_be
 from tcbuilder.backend import dto as dto_be
 from tcbuilder.backend import kernel as kernel_be
+from tcbuilder.backend import uenv as uenv_be
 from tcbuilder.backend.common import \
     (checkout_dt_git_repo, images_unpack_executed, is_file_type_fit, set_output_ownership,
      update_dt_git_repo, get_src_sysroot_dir)
@@ -129,7 +130,7 @@ def _deploy_dtb_fit(*, dtb_src_path, dtb_name, changes_dir):
 
 
 def _deploy_updated_uenv_txt(*, fdtfile, changes_dir):
-    dt_be.set_uenv_txt_variable("fdtfile", fdtfile, changes_dir=changes_dir)
+    uenv_be.set_uenv_txt_variable("fdtfile", fdtfile, changes_dir=changes_dir)
 
 
 def _deploy_empty_overlays_txt(*, changes_dir):

--- a/tcbuilder/cli/kernel.py
+++ b/tcbuilder/cli/kernel.py
@@ -18,7 +18,7 @@ from tcbuilder.backend.common import \
      get_arch_from_ostree, get_src_sysroot_dir)
 from tcbuilder.backend.deploy import get_image_bootloader
 
-from tcbuilder.backend import kernel, dt, dto
+from tcbuilder.backend import kernel, dt, dto, uenv
 from tcbuilder.backend.kernelfit import KernelFit
 from tcbuilder.cli import dto as dto_cli
 
@@ -214,15 +214,15 @@ def _set_custom_kargs_uenv(kargs, changes_dir, *, prepend=False):
     log.debug("Setting bootargs (uenv method).")
     if prepend:
         log.debug("Passed string will be prepended to the original bootargs.")
-        dt.set_uenv_txt_variable(
+        uenv.set_uenv_txt_variable(
             UENV_CUSTOM_BOOTARGS_L_VAR, kargs, changes_dir=changes_dir)
-        dt.set_uenv_txt_variable(
+        uenv.set_uenv_txt_variable(
             UENV_CUSTOM_BOOTARGS_R_VAR, None, changes_dir=changes_dir)
     else:
         log.debug("Passed string will be appended to the original bootargs.")
-        dt.set_uenv_txt_variable(
+        uenv.set_uenv_txt_variable(
             UENV_CUSTOM_BOOTARGS_L_VAR, None, changes_dir=changes_dir)
-        dt.set_uenv_txt_variable(
+        uenv.set_uenv_txt_variable(
             UENV_CUSTOM_BOOTARGS_R_VAR, kargs, changes_dir=changes_dir)
 
 
@@ -461,8 +461,8 @@ def _get_custom_kargs_uenv():
     """Get the custom bootargs using the (new) uenv method."""
 
     log.debug("Getting bootargs (uenv method).")
-    kargs_l = dt.get_uenv_txt_variable(UENV_CUSTOM_BOOTARGS_L_VAR)
-    kargs_r = dt.get_uenv_txt_variable(UENV_CUSTOM_BOOTARGS_R_VAR)
+    kargs_l = uenv.get_uenv_txt_variable(UENV_CUSTOM_BOOTARGS_L_VAR)
+    kargs_r = uenv.get_uenv_txt_variable(UENV_CUSTOM_BOOTARGS_R_VAR)
     if kargs_l and kargs_r:
         raise InvalidDataError(
             "Error: the Torizon OS image you are customizing has both "
@@ -572,9 +572,9 @@ def _clr_custom_kargs_uenv(changes_dir):
     """Clear the custom bootargs set using the new method (variables in uEnv.txt)."""
 
     log.debug("Clearing bootargs (uenv method).")
-    status_l = dt.set_uenv_txt_variable(
+    status_l = uenv.set_uenv_txt_variable(
         UENV_CUSTOM_BOOTARGS_L_VAR, None, changes_dir=changes_dir)
-    status_r = dt.set_uenv_txt_variable(
+    status_r = uenv.set_uenv_txt_variable(
         UENV_CUSTOM_BOOTARGS_R_VAR, None, changes_dir=changes_dir)
     return status_l or status_r
 

--- a/tests/integration/testcases/lib/grow-lba-mock.py
+++ b/tests/integration/testcases/lib/grow-lba-mock.py
@@ -1,0 +1,28 @@
+import struct, os, unittest.mock
+import guestfs
+from tcbuilder.backend.deploy import grow_last_partition
+
+SECTOR = 4096
+img = "grow_lba_mock.img"
+added_kb = 4 * 1024
+orig_size = os.path.getsize(img)
+expected_new_size = orig_size + added_kb * 1024
+expected_new_size = (expected_new_size + SECTOR - 1) // SECTOR * SECTOR
+# Deliberately not what the default-table reservation would give
+# (5 sectors at this SECTOR size).
+mock_end_sector = expected_new_size // SECTOR - 1 - 9
+mock_header = b"EFI PART" + b"\0" * 40 + struct.pack("<Q", mock_end_sector)
+
+with unittest.mock.patch("guestfs.GuestFS.pread_device", return_value=mock_header):
+    grow_last_partition(img, added_kb, SECTOR, "/dev/sda1", delete_on_error=True)
+
+g = guestfs.GuestFS(python_return_dict=True)
+g.add_drive_opts(img, format="raw", blocksize=SECTOR)
+g.launch()
+grown = max(g.part_list("/dev/sda"), key=lambda p: p["part_start"])
+actual_end = grown["part_end"] // SECTOR
+g.shutdown()
+g.close()
+
+assert actual_end == mock_end_sector, f"expected {mock_end_sector}, got {actual_end}"
+print("OK: grew to mocked LastUsableLBA sector", actual_end)

--- a/tests/integration/testcases/lib/raw-sector-size.bash
+++ b/tests/integration/testcases/lib/raw-sector-size.bash
@@ -27,8 +27,8 @@ build-synth-raw-image() {
     local total_bytes=$(( size_kb * 1024 ))
     total_bytes=$(( (total_bytes + sector - 1) / sector * sector ))
     local total_sectors=$(( total_bytes / sector ))
-    # 33 LBAs reserved for the GPT backup header, converted to this disk's
-    # sector size - grow_last_partition's own calculation.
+    # 33 512-byte LBAs reserved for the GPT backup header (default 128-entry
+    # table), converted to this disk's sector size.
     local gpt_tail=$(( (33 * 512 + sector - 1) / sector ))
     local end_sector=$(( total_sectors - 1 - gpt_tail ))
     local blocksize_opt=""

--- a/tests/integration/testcases/wic/deploy.bats
+++ b/tests/integration/testcases/wic/deploy.bats
@@ -13,7 +13,7 @@ teardown_file() {
 }
 
 teardown() {
-    rm -f rss_deploy_out.img
+    rm -f rss_deploy_out.img grow_lba_mock.img grow-lba-mock.py
 }
 
 @test "deploy: deploy changes to a 4Kn raw image" {
@@ -122,4 +122,17 @@ teardown() {
 
     run device-shell-root /usr/sbin/secret_of_life
     assert_failure 42
+}
+
+# A real non-default GPT table can't be synthesized here (sgdisk/gdisk
+# can't be told a plain file's 4Kn sector size), so mock the header read.
+@test "deploy: grow_last_partition() takes end_sector verbatim from LastUsableLBA" {
+    # grow_last_partition() with delete_on_error=True mutates in place, and
+    # $RSS_SYNTH_4K is shared with every other test in this file - copy it.
+    cp "$RSS_SYNTH_4K" grow_lba_mock.img
+    cp "$BATS_TEST_DIRNAME/../lib/grow-lba-mock.py" .
+
+    run torizoncore-builder-shell "PYTHONPATH=/builder python3 /workdir/grow-lba-mock.py"
+    assert_success
+    assert_output --partial "OK: grew to mocked"
 }


### PR DESCRIPTION
Two follow-up fixes for #156.

## common: break the dt/deploy/secboot/kernel circular import

A pre-existing bug encountered while working on #156.

`dt.py` importing `get_kernel_changes_dir` from `kernel.py` and
`get_image_bootloader` from `deploy.py` closes a cycle:
`dt -> deploy -> secboot -> kernel -> dt`. Move them to
`common.py`, which has no dependency back into the ring; 
and make `kernel.py` and `deploy.py` re-export the relocated 
functions so existing call sites are unaffected.

## deploy: clean up `grow_last_partition()` on a mid-way failure

`grow_last_partition()` left a corrupt image on disk on a mid-way failure:

- the rootfs-must-be-last-partition and growth-size preconditions ran
  *after* the partition table had already been mutated;
- `delete_on_error` was accepted but never forwarded to the function's
  own `open_disk_image()` call;
- the failure path relied on `TorizonCoreBuilderError` being a
  `RuntimeError` subclass to trigger `open_disk_image()`'s own rollback -
  it isn't, so that rollback never ran.

Both preconditions now run before any partition-table mutation, and the
whole operation is wrapped so a failure removes the fresh output
(`delete_on_error=True`) or restores the original file size
(`delete_on_error=False`, the in-place case), catching
`TorizonCoreBuilderError` directly. A cleanup failure is logged and the
original error is still raised, not omitted.

## Testing

Verified with `pylint` (clean, 10/10), the upstream `bats` wic test
group (`torizoncore-builder.bats` + `wic/*.bats`, 99 tests / 0 failures),
and a hardware run on a real LEC-MTK-i1200 board covering unpack,
deploy, combine, provisioning, and the `grow_last_partition()`
mid-failure cleanup path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved raw image resizing reliability and cleanup after failures.
  * Added safeguards against unsafe partition-table changes.
  * Improved detection of U-Boot and GRUB2 bootloaders, including EFI configurations.
  * Added handling for images without a recognized bootloader.
  * Improved support for 4 KiB-sector images while preserving GPT metadata.

* **New Features**
  * Added centralized management of `uEnv.txt` settings.
  * Improved device-tree and kernel customization using configured change locations.
  * Preserved multiline settings when updating `uEnv.txt` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->