### PR TITLE
bundle: wait for DinD API readiness before creating the docker client

### DIFF
--- a/tcbuilder/backend/bundle.py
+++ b/tcbuilder/backend/bundle.py
@@ -10,6 +10,7 @@ import socket
 import subprocess
 import sys
 import time
+import urllib.parse
 
 from contextlib import closing
 from datetime import datetime
@@ -394,11 +395,46 @@ class DindManager(DockerManager):
             if self.network is not None:
                 self.network.remove()
 
+    def _wait_api_ready(self, retries=10, delay=1):
+        # Certificate presence (_wait_certs) doesn't mean the daemon is
+        # accepting connections yet; a bare TCP probe can't misread a TLS failure as that.
+        assert retries >= 1, "_wait_api_ready: retries must be a positive integer"
+        parsed = urllib.parse.urlparse(self.docker_host)
+        try:
+            if parsed.scheme != "tcp" or not parsed.hostname or parsed.port is None:
+                raise ValueError("expected a tcp://host:port address")
+            host, port = parsed.hostname, parsed.port
+        except (TypeError, ValueError) as exc:
+            raise OperationFailureError(
+                f"Docker Daemon host \"{self.docker_host}\" is not a valid "
+                f"host:port address: {exc}") from exc
+        for attempt in range(retries):
+            try:
+                with socket.create_connection((host, port), timeout=delay):
+                    return
+            except (ConnectionRefusedError, TimeoutError) as exc:
+                if attempt == retries - 1:
+                    raise OperationFailureError(
+                        f"Docker Daemon at \"{self.docker_host}\" did not "
+                        f"start accepting connections: {exc}") from exc
+                log.debug(
+                    "Docker Daemon not accepting connections yet "
+                    f"(attempt {attempt + 1}/{retries}): {exc}")
+                time.sleep(delay)
+            except OSError as exc:
+                raise OperationFailureError(
+                    f"Docker Daemon at \"{self.docker_host}\" is not "
+                    f"reachable: {exc}") from exc
+
     def get_client(self):
         """Create a client object associated to the DinD instance"""
 
         # Wait until certificates are generated.
         self._wait_certs()
+
+        # Wait until the daemon's API is actually accepting connections —
+        # certificate presence does not imply this (see _wait_api_ready).
+        self._wait_api_ready()
 
         # Use TLS to authenticate
         tls_config = docker.tls.TLSConfig(


### PR DESCRIPTION
`DindManager.get_client()` calls `docker.DockerClient()` immediately after `_wait_certs()` returned, with no check that the daemon's TCP listener was actually bound yet - certificate presence on disk does not imply that. A fresh DinD instance could still refuse the first connection attempt, producing an intermittent `Error trying to bundle Docker containers` failure with no useful detail (the caller's bare `except:` discards the real exception).

Add a bounded wait loop for the raw TCP port to accept a connection before calling `docker.DockerClient`, similar to the wait loop already implemented in `_wait_certs()`. It only checks whether anything is listening, so it should not misclassify a TLS failure (e.g. a malformed certificate) as the daemon still starting; that keeps surfacing on the unmodified `DockerClient()` call, on the first attempt, exactly as before.

This looks like a similar issue reported on the Toradex community forum in ["TorizonCore Builder on Azure VM results in ConnectionRefusedError"](https://community.toradex.com/t/torizoncore-builder-on-azure-vm-results-in-connectionrefusederror/25468) - same `ConnectionRefusedError` connecting to the daemon's `/version` endpoint during `bundle`, on unrelated infrastructure.

## Testing

Used a small script that drives `DindManager` directly (start a DinD instance, call `get_client()`) instead of going through the full `torizoncore-builder build` path, to get a real `ConnectionRefusedError` traceback out of the race instead of the generic wrapped error. 

Ran the upstream `bats` wic test group (0 failures) and a full `torizoncore-builder build` against a config with a `bundle:` block after the fix, which went through cleanly on the first try.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker connection reliability by validating the configured host address and waiting for the Docker API to become available.
  * Added retries during startup to ensure generated certificates and daemon readiness are complete before connecting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->