### PR TITLE
images, build: Warn that hibernation mode is deprecated

### DIFF
--- a/tcbuilder/backend/images.py
+++ b/tcbuilder/backend/images.py
@@ -55,6 +55,12 @@ LAST_DEPRECATED_IMAGE_NAME = "TorizonCore"
 LAST_DEPRECATED_IMAGE_VERSION = "5.7.2"
 LAST_TCB_VERSION_SUPPORTING_DEPRECATED = "3.10.0"
 
+HIBERNATION_MODE_URL = (
+    "https://developer.toradex.com/"
+    "torizon/torizon-platform/devices-fleet-management"
+    "#hibernation-mode"
+)
+
 def serve(images_directory):
     """
     Serve TorizonCore TEZI images via HTTP so they can be installed directly
@@ -639,6 +645,11 @@ def provision(input_path, output_path, rootfs_label, prov_data, *,
     :param force: Boolean indicating whether to remove output directory if it
                   already exists.
     """
+
+    if hibernated:
+        log.warning("Warning: Hibernation Mode is deprecated and may be removed in a "
+                    "future release; please do not use it in new projects.\n"
+                    f"See: {HIBERNATION_MODE_URL}")
 
     # Basic validations:
     img_version, is_tezi_img, rootfs_label = prov_check_input(

--- a/tcbuilder/backend/tcbuild.schema.yaml
+++ b/tcbuilder/backend/tcbuild.schema.yaml
@@ -500,7 +500,7 @@ properties:
             description: "string containing provisioning data specific to the online mode"
           hibernated:
             type: boolean
-            description: "provision in hibernated mode"
+            description: "[DEPRECATED] provision in hibernated mode"
           fleets:
             type: array
             description: "list of UUID(s) to provision to"

--- a/tcbuilder/cli/images.py
+++ b/tcbuilder/cli/images.py
@@ -231,9 +231,10 @@ def init_parser(subparsers):
     subparser.add_argument(
         "--hibernated", dest="hibernated",
         default=False, action="store_true",
-        help=("(Torizon OS 6.8+) Add flag to auto-provision in hibernated mode. Hibernated "
-              "devices are registered, but cannot receive updates from Torizon Cloud nor "
-              "send data to it."))
+        help=("[DEPRECATED] Add flag to auto-provision in hibernated mode. Hibernated "
+              "devices are registered, but cannot receive updates from Torizon Cloud "
+              "nor send data to it. Hibernation Mode is deprecated; do not use it in "
+              "new projects."))
     subparser.add_argument(
         "--fleet", dest="fleets", action="append",
         help=("(Torizon OS 7.7+) Add fleet UUID to the provisioning. Devices that provision "

--- a/tcbuilder/cli/tcbuild.template.yaml
+++ b/tcbuilder/cli/tcbuild.template.yaml
@@ -206,9 +206,10 @@ output:
       # mode: "online"
       # shared-data: "shared-data.tar.gz"
       # online-data: "${ONLINE_PROVISIONING_DATA:?online provisioning data not supplied}"
-      # >> Provision in hibernated mode. In this state devices are registered, but
-      # >> cannot send/receive data to/from Torizon Cloud, and they're not counted
-      # >> towards a subscription.
+      # >> [DEPRECATED] Provision in hibernated mode. Hibernation Mode is deprecated
+      # >> and may be removed in a future release; do not use it in new projects.
+      # >> In this state devices are registered, but cannot send/receive data to/from
+      # >> Torizon Cloud, and they're not counted towards a subscription.
       # hibernated: false
       # >> List of fleet UUIDs to provision to.
       # >> Replace example UUID with your actual fleet UUID.
@@ -255,9 +256,10 @@ output:
       # mode: "online"
       # shared-data: "shared-data.tar.gz"
       # online-data: "${ONLINE_PROVISIONING_DATA:?online provisioning data not supplied}"
-      # >> Provision in hibernated mode. In this state devices are registered, but
-      # >> cannot send/receive data to/from Torizon Cloud, and they're not counted
-      # >> towards a subscription.
+      # >> [DEPRECATED] Provision in hibernated mode. Hibernation Mode is deprecated
+      # >> and may be removed in a future release; do not use it in new projects.
+      # >> In this state devices are registered, but cannot send/receive data to/from
+      # >> Torizon Cloud, and they're not counted towards a subscription.
       # hibernated: false
       # >> List of fleet UUIDs to provision to.
       # >> Replace example UUID with your actual fleet UUID.

--- a/tests/integration/testcases/images.bats
+++ b/tests/integration/testcases/images.bats
@@ -8,6 +8,12 @@ bats_load_library 'bats/bats-file/load.bash'
     assert_output --partial ' {download,provision,serve,unpack}'
 }
 
+@test "images provision: --hibernated is flagged as deprecated" {
+    run torizoncore-builder images provision --help
+    assert_success
+    assert_output --partial '[DEPRECATED]'
+}
+
 @test "images provision: basic offline-provisioning (standalone)" {
     unpack-image "$DEFAULT_TEZI_IMAGE"
     local INPUT_IMAGE_DIR=$(echo $DEFAULT_TEZI_IMAGE | sed 's/\.tar$//g')
@@ -62,6 +68,7 @@ bats_load_library 'bats/bats-file/load.bash'
         --mode=offline "$INPUT_IMAGE_DIR" "$OUTPUT_IMAGE_DIR"
     assert_success
     assert_output --partial "--hibernated is specific to online provisioning. Ignoring."
+    assert_output --partial 'Hibernation Mode is deprecated'
     assert_output --partial 'Image successfully provisioned'
 
     # case: success, with --fleet option ignored
@@ -211,6 +218,7 @@ bats_load_library 'bats/bats-file/load.bash'
         --hibernated \
         --mode=online "$INPUT_IMAGE_DIR" "$OUTPUT_IMAGE_DIR"
     assert_success
+    assert_output --partial 'Hibernation Mode is deprecated'
     assert_output --partial 'Adding hibernated mode flag'
     assert_output --partial 'Image successfully provisioned'
 

--- a/tests/integration/testcases/wic/images.bats
+++ b/tests/integration/testcases/wic/images.bats
@@ -67,6 +67,7 @@ bats_load_library 'bats/bats-file/load.bash'
         --mode=offline "$INPUT_IMAGE" "$OUTPUT_IMAGE"
     assert_success
     assert_output --partial "--hibernated is specific to online provisioning. Ignoring."
+    assert_output --partial 'Hibernation Mode is deprecated'
     assert_output --partial 'Image successfully provisioned'
 
     # case: success, with --fleet option ignored
@@ -187,6 +188,7 @@ bats_load_library 'bats/bats-file/load.bash'
         --hibernated \
         --mode=online "$INPUT_IMAGE" "$OUTPUT_IMAGE"
     assert_success
+    assert_output --partial 'Hibernation Mode is deprecated'
     assert_output --partial 'Adding hibernated mode flag'
     assert_output --partial 'Image successfully provisioned'
 


### PR DESCRIPTION
Torizon Cloud Hibernation Mode is being phased out, but TCB gave no
indication of that at runtime: `images provision --hibernated` and
`provisioning.hibernated: true` in `tcbuild.yaml` both worked silently.

This prints a warning whenever provisioning is asked to enable hibernated
mode. Both entry points converge on `images.provision()`, so the check
lives there and a single `if hibernated:` covers them. The switch, the
`tcbuild.yaml` schema property and the generated template comments are
also marked `[DEPRECATED]`, so `images provision --help` and
`build --create-template` tell the same story.

Nothing is removed and no behavior changes — the feature keeps working,
it only warns now. Wording deliberately says "may be removed in a future
release" rather than the stronger phrasing used by the deprecated `push`
command, to match the docs and not promise a removal that hasn't been
scheduled.

Companion documentation change (Developer Website): https://gitlab.com/toradex/ma/websites/developer-website/developer-website/-/merge_requests/2978

Two notes for reviewers:

- With `--mode offline`, the offline path now prints both the
  pre-existing `--hibernated is specific to online provisioning.
  Ignoring.` and the deprecation notice. That is intended — the user did
  ask for a deprecated feature. It also gives the `tcbuild.yaml` offline
  case its first diagnostic at all; previously `mode: offline` combined
  with `hibernated: true` was accepted and silently dropped.
- `torizoncore-builder-completion.bash` has no `--hibernated` entry to
  begin with (`_TCBCOMP_ARGS_IMAGES_PROVISION` lists `--fleet` but not
  `--hibernated`). Left alone here — it looks like a separate,
  pre-existing omission.

## Testing

Verified against a locally built `torizoncore-builder:local`:

- `images provision --help` renders `[DEPRECATED]` on the `--hibernated`
  entry.
- `build --create-template --file -` shows the new deprecation comments
  in both the `raw-image` and `easy-installer` provisioning blocks.
- `--mode online --hibernated` prints the notice, and it is emitted
  before any input validation.
- `--mode offline --hibernated` prints the `Ignoring` warning followed by
  the notice.
- The notice goes to stderr like every other TCB message (stdout is empty
  when it is printed) — note that bats merges the two streams, so the
  assertions below cannot detect a regression on that point.
- `pylint` on the two changed Python files reports nothing new.
- `bats --filter 'flagged as deprecated' testcases/images.bats` passes.

The image-dependent cases in `testcases/images.bats` and
`testcases/wic/images.bats` were **not** run locally — they need Torizon
OS images from Artifactory, which were not available in this environment.
Relying on the CI pipeline for those.

Related-to: UXPB-39


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecation Notices**
  * Marked hibernation mode as deprecated across provisioning options, configuration guidance, and command-line help.
  * Added warnings when hibernated provisioning is requested, including a link to migration guidance.
  * New projects are advised not to use hibernation mode.

* **Tests**
  * Added coverage verifying deprecation messages in help output and during offline and online provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->