### PR TITLE
torizoncore-builder: Take the libfdt bindings from Debian

### DIFF
--- a/requirements_debian.txt
+++ b/requirements_debian.txt
@@ -10,6 +10,3 @@ python-dateutil==2.9.0.post0
 pyyaml==6.0.3
 debugpy==1.8.19
 fabric==3.2.2
-
-# pylibfdt requires GCC and python3-dev.
-pylibfdt==1.7.2.post1

--- a/torizoncore-builder.Dockerfile
+++ b/torizoncore-builder.Dockerfile
@@ -280,6 +280,7 @@ RUN apt-get -q -y update && \
             python3-git \
             python3-guestfs \
             python3-ifaddr \
+            python3-libfdt \
             python3-paramiko \
             python3-pip \
             python3-setuptools \
@@ -340,32 +341,15 @@ RUN --mount=type=bind,from=skopeo-builder,source=/root,target=/build/skopeo \
 RUN --mount=type=bind,from=uboot-builder,source=/root,target=/build/uboot \
     tar xvf /build/uboot/u-boot-tools.tar.bz2 -C /
 
-# Install Python requirements via pip.
-#
-# For this to succeed we need to install build-essential and some dev packages,
-# but those can be uninstalled after the installation is done.
+# Install Python requirements via pip; all of them are available as wheels, so no
+# compiler or Python development files are needed here.
 #
 # TODO: Consider using a virtual environment to avoid system-wide installations.
 #
 COPY requirements_debian.txt /tmp
-RUN echo "Installing build requirements..." && \
-    apt-get -q -y update && \
-    apt-get -q -y --no-install-recommends install \
-            build-essential \
-            python3-dev \
-    && \
-    \
-    echo "Installing Debian requirements (Python code dependencies)..." && \
+RUN echo "Installing Debian requirements (Python code dependencies)..." && \
     pip3 install --no-cache-dir --break-system-packages -r /tmp/requirements_debian.txt && \
-    rm -rf /tmp/requirements_debian.txt && \
-    \
-    echo "Uninstalling build requirements..." && \
-    apt-get -q -y --no-install-recommends remove \
-            build-essential \
-            python3-dev \
-    && \
-    apt-get -q -y --no-install-recommends autoremove && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /tmp/requirements_debian.txt
 
 # Install extra development dependencies related to "kernel build_module"; notice
 # that these are not dependencies of TorizonCore Builder itself but are needed


### PR DESCRIPTION
This is expected to solve the build failure happening in CI lately.

pylibfdt has no wheels, so pip built it from source and the image needed GCC and the Python development headers just for that. Debian trixie packages the same 1.7.2 bindings as python3-libfdt, so we use it now.

Since pylibfdt was the only Python requirement that needed to be built from source, the use of the Debian package also allows us to avoid temporarily installing build-essential and python3-dev in the image; this is also done here.

Related-to: TCB-914


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Debian runtime environment to include the required device-tree tooling.
  * Simplified dependency installation by removing unnecessary compiler and Python development packages.
  * Removed a redundant dependency declaration from the Debian requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->