### PR TITLE
tests: Fix 'build' test for OS images with composefs support

### DIFF
--- a/tests/integration/samples/config/tcbuild-no-re-sign-fuse.yaml
+++ b/tests/integration/samples/config/tcbuild-no-re-sign-fuse.yaml
@@ -3,6 +3,14 @@ input:
   easy-installer:
     local: "${INPUT_IMAGE:?Please specify input image}"
 
+## customization:
+  ## secboot:
+    ## sign-ostree:
+      ## ostree-key-dir: {{ ostree_key_dir }}
+      ## ostree-key:
+         ## - name: {{ ostree_key_name }}
+         ##   algo: {{ ostree_key_algo }}
+
 output:
   ostree:
     branch: failed-fuse

--- a/tests/integration/testcases/build.bats
+++ b/tests/integration/testcases/build.bats
@@ -733,6 +733,13 @@ teardown_file() {
 
     local OUTDIR='failed_image'
 
+    if [ "${DEFAULT_TEZI_IMAGE_HAS_CFS_SUPPORT}" = "1" ]; then
+        set-ostree-key-in-tcbuild \
+            "${TCBUILD_YAML}" \
+            "name=cfs-dev;algo=ed25519" \
+            "${SAMPLES_DIR}/signing_keys/ostree-good1/"
+    fi
+
     run torizoncore-builder build \
 	--file "${TCBUILD_YAML}" \
 	--set INPUT_IMAGE="$DEFAULT_TEZI_IMAGE" \


### PR DESCRIPTION
Fix a particular 'build' test that fails for `torizon-signed` images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved integration coverage for image builds that use ComposeFS and OSTree signing configurations.
  - Added validation for builds that intentionally omit re-signing while providing an OSTree signing key.
- **Documentation**
  - Expanded the sample configuration with commented guidance for optional OSTree signing settings.
- **Bug Fixes**
  - No end-user functionality changes; these updates improve test reliability and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->